### PR TITLE
Adds support for OS X without X11.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ case $host_os in
         ;;
     darwin*)
         build_egl=no
-        build_glx=yes
+        build_glx=no
         build_wgl=no
         build_apple=yes
         has_znow=no

--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -30,7 +30,7 @@
 #define EPOXY_IMPORTEXPORT __declspec(dllexport)
 #elif defined(__APPLE__)
 #define PLATFORM_HAS_EGL 0
-#define PLATFORM_HAS_GLX 1
+#define PLATFORM_HAS_GLX 0
 #define PLATFORM_HAS_WGL 0
 #define EPOXY_IMPORTEXPORT
 #else


### PR DESCRIPTION
OS X support shouldn't depend on X11 being installed on the host.
Removes the X11 dependency.