### PR TITLE
sort the providers by their enum not by their function name

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -566,8 +566,8 @@ class Generator(object):
                 providers.append(provider)
 
         def provider_sort(provider):
-            return (provider.name != func.name, provider.name)
-        providers.sort(key=provider_sort);
+            return (provider.name != func.name, provider.enum)
+        providers.sort(key=provider_sort)
 
         if len(providers) != 1:
             self.outln('    static const enum {0}_provider providers[] = {{'.format(self.target))


### PR DESCRIPTION
This avoids generated code that changes from rebuild to rebuild within openSUSE:

[  131s] --- old//usr/src/debug/libepoxy-1.2/src/egl_generated_dispatch.c	2015-02-11 04:56:55.000000000 +0000
[  131s] +++ new//usr/src/debug/libepoxy-1.2/src/egl_generated_dispatch.c	2015-11-04 09:50:48.000000000 +0000
[  131s] @@ -833,8 +833,8 @@
[  131s]  epoxy_eglLockSurfaceKHR_resolver(void)
[  131s]  {
[  131s]      static const enum egl_provider providers[] = {
[  131s] -        EGL_extension_EGL_KHR_lock_surface,
[  131s]          EGL_extension_EGL_KHR_lock_surface3,
[  131s] +        EGL_extension_EGL_KHR_lock_surface,
[  131s]          egl_provider_terminator