### PR TITLE
Make __declspec(dllimport) optional (and off by default)

### DIFF
--- a/include/epoxy/gl.h
+++ b/include/epoxy/gl.h
@@ -71,7 +71,17 @@ extern "C" {
 #endif
 
 #ifndef EPOXY_IMPORTEXPORT
+// On any reasonably modern compiler and linker, decorating functions with
+// __declspec(dllimport) is completely optional, and only provides a very minor
+// optimization, bypassing a tiny (~2 instructions) and readily pipelinable
+// "thunk", which is likely to be optimized out anyway if LTO is enabled.
+// The problems it creates with static linking and portability make it arguably
+// not worth the bother. But for those that need it, or think they need it...
+#ifdef EPOXY_USE_DLLIMPORT
 #define EPOXY_IMPORTEXPORT __declspec(dllimport)
+#else
+#define EPOXY_IMPORTEXPORT
+#endif
 #endif
 
 #ifndef GLAPI
@@ -79,7 +89,7 @@ extern "C" {
 #endif
 
 #define KHRONOS_APIENTRY __stdcall
-#define KHRONOS_APICALL __declspec(dllimport) __stdcall
+#define KHRONOS_APICALL EPOXY_IMPORTEXPORT __stdcall
 
 #endif /* _WIN32 */
 

--- a/include/epoxy/gl.h
+++ b/include/epoxy/gl.h
@@ -89,7 +89,11 @@ extern "C" {
 #endif
 
 #define KHRONOS_APIENTRY __stdcall
-#define KHRONOS_APICALL EPOXY_IMPORTEXPORT __stdcall
+#ifdef EPOXY_USE_DLLIMPORT
+#define KHRONOS_APICALL __declspec(dllimport) __stdcall
+#else
+#define KHRONOS_APICALL __stdcall
+#endif
 
 #endif /* _WIN32 */
 


### PR DESCRIPTION
The added comment sums up the rationale, but to elaborate... the two big problems avoided by omitting it:
- dllimport is not supported by GCC on non-Windows hosts, regardless of the target platform. In other words, when cross-compiling to Windows, dllimport is unavailable and will generate a compile-time error.
- The compiler takes this prefix as a hint that it can assume the method will be provided by a DLL, and therefore generates a direct call into the DLL. This doesn't fly if the library is actually being statically linked -- something the compiler can't know ahead of time.

Of course, there may be edge cases where not prefixing with dllimport will cause undesired behavior, or generate a more substantial relocation thunk with a significant performance impact. Those that find themselves dealing with such cases can simply define EPOXY_USE_DLLIMPORT where necessary.

This is a pretty good explanation of what __declspec(dllimport) actually does: http://blogs.msdn.com/b/russellk/archive/2005/03/20/399465.aspx?wa=wsignin1.0
