### PR TITLE
Fix build error when aclocal must copy m4 files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,8 @@ SUBDIRS = include/epoxy src
 
 SUBDIRS += test
 
+ACLOCAL_AMFLAGS = -I .
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = epoxy.pc
 

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,7 @@ AC_INIT([libepoxy],
         [libepoxy])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_MACRO_DIR([.])
 
 # Initialize Automake
 AM_INIT_AUTOMAKE([foreign dist-bzip2 subdir-objects])


### PR DESCRIPTION
When ACLOCAL_PATH is set to find m4 files in non standard locations,
aclocal must copy those files in the build tree otherwise automake
won't find them.

Usually AC_CONFIG_MACRO_DIR() is set to m4/ directory but since we
don't ship any m4 file that directory doesn't exist.
