### PR TITLE
src/gen_dispatch.py: Make Generated Code Build Under pre-2013 Visual Studio

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -659,9 +659,10 @@ class Generator(object):
         assert(offset < 65536)
 
         self.outln('static const uint16_t enum_string_offsets[] = {')
+        self.outln('    -1, /* {0}_provider_terminator, unused */'.format(self.target))
         for human_name in sorted_providers:
             enum = self.provider_enum[human_name]
-            self.outln('    [{0}] = {1},'.format(enum, self.enum_string_offset[human_name]))
+            self.outln('    {1}, /* {0} */'.format(enum, self.enum_string_offset[human_name]))
         self.outln('};')
         self.outln('')
 
@@ -789,7 +790,7 @@ class Generator(object):
 
         self.outln('static struct dispatch_table resolver_table = {')
         for func in self.sorted_functions:
-            self.outln('    .{0} = epoxy_{0}_dispatch_table_rewrite_ptr,'.format(func.wrapped_name))
+            self.outln('    epoxy_{0}_dispatch_table_rewrite_ptr, /* {0} */'.format(func.wrapped_name))
         self.outln('};')
         self.outln('')
 


### PR DESCRIPTION
Hi,

I am opening this pull request as we would still like to support building GTK+ entirely with Visual Studio, and there are still many people that are not yet able to go up to Visual Studio 2013.

At this point, the main thing that needs to be done is to avoid named initializers, but
instead initialize the structs in old-school C89 way, so the changes needed here are quite small.

The generated code may not look that robust, but since this is generated
code, I think this is not that much an issue; when the Khronos registry gets
updated, all that is needed is that the code gets re-generated, and we have the
items in the right order.

With blessings, thank you!
