### PR TITLE
support newer/larger gl.xml

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -578,7 +578,7 @@ class Generator(object):
             self.outln('        {0}_provider_terminator'.format(self.target))
             self.outln('    };')
 
-            self.outln('    static const uint16_t entrypoints[] = {')
+            self.outln('    static const uint32_t entrypoints[] = {')
             if len(providers) > 1:
                 for provider in providers:
                     self.outln('        {0} /* "{1}" */,'.format(self.entrypoint_string_offset[provider.name], provider.name))
@@ -668,22 +668,24 @@ class Generator(object):
     def write_entrypoint_strings(self):
         self.entrypoint_string_offset = {}
 
-        self.outln('static const char entrypoint_strings[] = ')
+        self.outln('static const char entrypoint_strings[] = {')
         offset = 0
         for func in self.sorted_functions:
             if func.name not in self.entrypoint_string_offset:
                 self.entrypoint_string_offset[func.name] = offset
                 offset += len(func.name) + 1
-                self.outln('   "{0}\\0"'.format(func.name))
-        self.outln('    ;')
+                for c in func.name:
+                    self.outln("   '{0}',".format(c))
+                self.outln('   0, // {0}'.format(func.name))
+        self.outln('    0 };')
         # We're using uint16_t for the offsets.
-        assert(offset < 65536)
+        #assert(offset < 65536)
         self.outln('')
 
     def write_provider_resolver(self):
         self.outln('static void *{0}_provider_resolver(const char *name,'.format(self.target))
         self.outln('                                   const enum {0}_provider *providers,'.format(self.target))
-        self.outln('                                   const uint16_t *entrypoints)')
+        self.outln('                                   const uint32_t *entrypoints)')
         self.outln('{')
         self.outln('    int i;')
 
@@ -720,7 +722,7 @@ class Generator(object):
         self.outln('}')
         self.outln('')
 
-        single_resolver_proto = '{0}_single_resolver(enum {0}_provider provider, uint16_t entrypoint_offset)'.format(self.target)
+        single_resolver_proto = '{0}_single_resolver(enum {0}_provider provider, uint32_t entrypoint_offset)'.format(self.target)
         self.outln('EPOXY_NOINLINE static void *')
         self.outln('{0};'.format(single_resolver_proto))
         self.outln('')


### PR DESCRIPTION
The newest gl.xml from the Khronos registry is too large to fit in the array size. Changed indices from 16-bit to 32-bit and had to change ridiculously enormous string into ridiculously enormous array of single characters as it was over the string size limit.