### PR TITLE
Add glBindRenderbufferEXT to half_aliases

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -561,6 +561,8 @@ class Generator(object):
             'glBindVertexArrayAPPLE' : 'glBindVertexArray',
             'glBindFramebuffer' : 'glBindFramebufferEXT',
             'glBindFramebufferEXT' : 'glBindFramebuffer',
+            'glBindRenderbuffer' : 'glBindRenderbufferEXT',
+            'glBindRenderbufferEXT' : 'glBindRenderbuffer',
         }
         if func.name in half_aliases:
             alias_func = self.functions[half_aliases[func.name]]

--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -659,9 +659,10 @@ class Generator(object):
         assert(offset < 65536)
 
         self.outln('static const uint16_t enum_string_offsets[] = {')
+        self.outln('    -1, /* {0}_provider_terminator, unused */'.format(self.target))
         for human_name in sorted_providers:
             enum = self.provider_enum[human_name]
-            self.outln('    [{0}] = {1},'.format(enum, self.enum_string_offset[human_name]))
+            self.outln('    {1}, /* {0} */'.format(enum, self.enum_string_offset[human_name]))
         self.outln('};')
         self.outln('')
 
@@ -789,7 +790,7 @@ class Generator(object):
 
         self.outln('static struct dispatch_table resolver_table = {')
         for func in self.sorted_functions:
-            self.outln('    .{0} = epoxy_{0}_dispatch_table_rewrite_ptr,'.format(func.wrapped_name))
+            self.outln('    epoxy_{0}_dispatch_table_rewrite_ptr, /* {0} */'.format(func.wrapped_name))
         self.outln('};')
         self.outln('')
 


### PR DESCRIPTION
While working on a game I discovered that epoxy won't resolve glBindRenderbuffer in OpenGL 2.1 contexts even though glBindRenderbufferEXT is available.
Seeing that there already is a similar fix for glBindFramebufferEXT, I added it to the half_aliases array in gen_dispatch.py. Without this fix, you won't be able to make use of FBOs if only GL_EXT_framebuffer_object is available.