### PR TITLE
fixes 'cd error' in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,7 @@ ORIGDIR=`pwd`
 cd $srcdir
 
 autoreconf -v --install || exit 1
-cd $ORIGDIR || exit $?
+cd "$ORIGDIR" || exit $?
 
 if test -z "$NOCONFIGURE"; then
     $srcdir/configure "$@"


### PR DESCRIPTION
If a parent directory of the libepoxy source directory contains a space, 'cd' in line 10 fails.

Note: 'make install' fails, too. I did not fix that
