### PR TITLE
nVidia glx.h uses __glx_h__; check it too.

### DIFF
--- a/include/epoxy/glx.h
+++ b/include/epoxy/glx.h
@@ -39,10 +39,11 @@ extern "C" {
 #include <X11/Xutil.h>
 #include <stdbool.h>
 
-#if defined(GLX_H) || defined(__glxext_h_)
+#if defined(GLX_H) || defined(__glx_h__) || defined(__glxext_h_)
 #error epoxy/glx.h must be included before (or in place of) GL/glx.h
 #else
 #define GLX_H
+#define __glx_h__
 #define __glxext_h_
 #endif
 


### PR DESCRIPTION
The code used to check this symbol, but commit 689abf4 replaced it with
GLX_H, presumably to work better with either Mesa or Khronos headers.
But nVidia's header use the older include guard.  Add it as another
option.

Fixes the headerguards.c compile test when the system glx.h is from
nVidia's binary drivers.