### PR TITLE
egl: Fix the query for the current context's API

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -569,31 +569,15 @@ epoxy_get_core_proc_address(const char *name, int core_version)
 static EGLenum
 epoxy_egl_get_current_gl_context_api(void)
 {
-    EGLenum save_api = eglQueryAPI();
-    EGLContext ctx;
+    EGLint curapi;
 
-    if (eglBindAPI(EGL_OPENGL_API)) {
-        ctx = eglGetCurrentContext();
-        if (ctx) {
-            eglBindAPI(save_api);
-            return EGL_OPENGL_API;
-        }
-    } else {
-        (void)eglGetError();
+    if (eglQueryContext(eglGetCurrentDisplay(), eglGetCurrentContext(),
+			EGL_CONTEXT_CLIENT_TYPE, &curapi) == EGL_FALSE) {
+	(void)eglGetError();
+	return EGL_NONE;
     }
 
-    if (eglBindAPI(EGL_OPENGL_ES_API)) {
-        ctx = eglGetCurrentContext();
-        eglBindAPI(save_api);
-        if (ctx) {
-            eglBindAPI(save_api);
-            return EGL_OPENGL_ES_API;
-        }
-    } else {
-        (void)eglGetError();
-    }
-
-    return EGL_NONE;
+    return (EGLenum) curapi;
 }
 #endif /* PLATFORM_HAS_EGL */
 


### PR DESCRIPTION
Binding an API does not change the type of the current context. Even if
it did, EGL 1.5 treats EGL_OPENGL_API and EGL_OPENGLES_API as identical
for this purpose.  If you want to know properties of the current
context, query it.

Signed-off-by: Adam Jackson ajax@redhat.com
