### PR TITLE
build: Force replacing autotools generated files

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,7 +6,7 @@ test -z "$srcdir" && srcdir=.
 ORIGDIR=`pwd`
 cd $srcdir
 
-autoreconf -v --install || exit 1
+autoreconf -v -f --install || exit 1
 cd $ORIGDIR || exit $?
 
 if test -z "$NOCONFIGURE"; then


### PR DESCRIPTION
If the '--force' switch is not passed to autoreconf, the autotools will
try to reuse the generated files committed in the Git repo, which hard
code the names and versions of the tools originally used to generate
them.