### PR TITLE
meson: Don't call find_program objects with python

### DIFF
--- a/include/epoxy/meson.build
+++ b/include/epoxy/meson.build
@@ -4,7 +4,6 @@ gl_generated = custom_target('gl_generated.h',
                                'gl_generated.h',
                              ],
                              command: [
-                               python,
                                gen_dispatch_py,
                                '--header',
                                '--no-source',
@@ -24,7 +23,6 @@ if build_egl
                                   'egl_generated.h',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--header',
                                   '--no-source',
@@ -44,7 +42,6 @@ if build_glx
                                   'glx_generated.h',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--header',
                                   '--no-source',
@@ -64,7 +61,6 @@ if build_wgl
                                   'wgl_generated.h',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--header',
                                   '--no-source',

--- a/meson.build
+++ b/meson.build
@@ -132,11 +132,6 @@ configure_file(input: 'epoxy.pc.in',
                install: true,
                install_dir: join_paths(epoxy_libdir, 'pkgconfig'))
 
-# Find Python for gen_dispatch
-# XXX: With Meson 0.37 we should use
-#   python = import('python3').find_python()
-python = find_program('python3')
-
 # Generates the dispatch tables
 gen_dispatch_py = find_program('src/gen_dispatch.py')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,6 @@ gl_generated = custom_target('gl_generated_dispatch.c',
                                'gl_generated_dispatch.c',
                              ],
                              command: [
-                               python,
                                gen_dispatch_py,
                                '--source',
                                '--no-header',
@@ -30,7 +29,6 @@ if build_egl
                                   'egl_generated_dispatch.c',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--source',
                                   '--no-header',
@@ -48,7 +46,6 @@ if build_glx
                                   'glx_generated_dispatch.c',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--source',
                                   '--no-header',
@@ -66,7 +63,6 @@ if build_wgl
                                   'wgl_generated_dispatch.c',
                                 ],
                                 command: [
-                                  python,
                                   gen_dispatch_py,
                                   '--source',
                                   '--no-header',


### PR DESCRIPTION
On UNIX-like OSes, the OS will read the shebang and use the correct interpreter, and on Windows, Meson will read the shebang and use the correct interpreter.

Adding it manually will cause python to try to interpret python.exe

With this change, libepoxy builds and the tests pass with MSVC on Windows for me.