### PR TITLE
Add C++ guards around generated headers

### DIFF
--- a/include/epoxy/egl.h
+++ b/include/epoxy/egl.h
@@ -41,9 +41,9 @@
 #define __eglext_h_
 #endif
 
-#include "epoxy/egl_generated.h"
-
 EPOXY_BEGIN_DECLS
+
+#include "epoxy/egl_generated.h"
 
 EPOXY_PUBLIC bool epoxy_has_egl_extension(EGLDisplay dpy, const char *extension);
 EPOXY_PUBLIC int epoxy_egl_version(EGLDisplay dpy);

--- a/include/epoxy/gl.h
+++ b/include/epoxy/gl.h
@@ -84,9 +84,9 @@
 #define GLAPIENTRYP GLAPIENTRY *
 #endif
 
-#include "epoxy/gl_generated.h"
-
 EPOXY_BEGIN_DECLS
+
+#include "epoxy/gl_generated.h"
 
 EPOXY_PUBLIC bool epoxy_has_gl_extension(const char *extension);
 EPOXY_PUBLIC bool epoxy_is_desktop_gl(void);

--- a/include/epoxy/glx.h
+++ b/include/epoxy/glx.h
@@ -44,9 +44,9 @@
 #define __glxext_h_
 #endif
 
-#include "epoxy/glx_generated.h"
-
 EPOXY_BEGIN_DECLS
+
+#include "epoxy/glx_generated.h"
 
 EPOXY_PUBLIC bool epoxy_has_glx_extension(Display *dpy, int screen, const char *extension);
 EPOXY_PUBLIC int epoxy_glx_version(Display *dpy, int screen);

--- a/include/epoxy/wgl.h
+++ b/include/epoxy/wgl.h
@@ -49,9 +49,9 @@
 #define wglUseFontBitmaps wglUseFontBitmapsA
 #endif
 
-#include "epoxy/wgl_generated.h"
-
 EPOXY_BEGIN_DECLS
+
+#include "epoxy/wgl_generated.h"
 
 EPOXY_PUBLIC bool epoxy_has_wgl_extension(HDC hdc, const char *extension);
 EPOXY_PUBLIC void epoxy_handle_external_wglMakeCurrent(void);


### PR DESCRIPTION
Commit 0625a74d69f762df8d411bc0451927424aee1f2c moved the C++ guards
after the inclusion of the generated headers, which was an unintended
behavioural change and now requires header guards around the inclusion
of Epoxy headers.

Fixes: #106