### PR TITLE
Add explicit version flags for macOS builds

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -51,10 +51,14 @@ foreach h: headers
   epoxy_headers += join_paths(meson.source_root(), 'include/epoxy/@0@'.format(h))
 endforeach
 
+common_ldflags = []
 if cc.get_id() == 'gcc'
   common_ldflags = [ '-Wl,-Bsymbolic', '-Wl,-z,relro', '-Wl,-z,now', ]
-else
-  common_ldflags = []
+endif
+
+# Maintain compatibility with autotools; see: https://github.com/anholt/libepoxy/issues/108
+if host_system == 'darwin'
+  common_ldflags += [ '-compatibility_version=1', '-current_version=1.0', ]
 endif
 
 epoxy_deps = [ dl_dep, ]

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,7 +52,8 @@ foreach h: headers
 endforeach
 
 common_ldflags = []
-if cc.get_id() == 'gcc'
+
+if host_system == 'linux'
   common_ldflags = [ '-Wl,-Bsymbolic', '-Wl,-z,relro', '-Wl,-z,now', ]
 endif
 


### PR DESCRIPTION
Autotools automatically adds version related linker flags on macOS that
are not related to the version information. Since we want to maintain
binary compatibility, we should do the same when building on macOS.

Fixes: #108