### PR TITLE
Forward EGL cflags into epoxy.pc

### DIFF
--- a/epoxy.pc.in
+++ b/epoxy.pc.in
@@ -10,6 +10,6 @@ epoxy_has_wgl=@epoxy_has_wgl@
 Name: epoxy
 Description: epoxy GL dispatch Library
 Version: @PACKAGE_VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @EGL_CFLAGS@
 Libs: -L${libdir} -lepoxy
 Libs.private: @DLOPEN_LIBS@


### PR DESCRIPTION
When building mesa egl without x11 and gles2 the headers need a
MESA_EGL_NO_X11_HEADERS define to avoid including X11 headers.
Forward EGL CFLAGS into epoxy.pc to avoid build failures when linking
against libepoxy on this scenario.

Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>