### PR TITLE
test: Fix dlwrap on aarch64

### DIFF
--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -232,6 +232,7 @@ dlwrap_real_dlsym(void *handle, const char *name)
          * In the meantime, I'll just keep augmenting this
          * hard-coded version list as people report bugs. */
         const char *version[] = {
+            "GLIBC_2.17",
             "GLIBC_2.4",
             "GLIBC_2.3",
             "GLIBC_2.2.5",


### PR DESCRIPTION
dlsym on aarch64 has version GLIBC_2.17.