### PR TITLE
epoxy_internal_has_gl_extension, epoxy_egl_version: add some missing …

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -443,7 +443,12 @@ bool
 epoxy_extension_in_string(const char *extension_list, const char *ext)
 {
     const char *ptr = extension_list;
-    int len = strlen(ext);
+    int len;
+
+    if (!ext)
+        return false;
+
+    len = strlen(ext);
 
     if (extension_list == NULL || *extension_list == '\0')
         return false;
@@ -478,6 +483,8 @@ epoxy_internal_has_gl_extension(const char *ext, bool invalid_op_mode)
 
         for (i = 0; i < num_extensions; i++) {
             const char *gl_ext = (const char *)glGetStringi(GL_EXTENSIONS, i);
+            if (!gl_ext)
+                return false;
             if (strcmp(ext, gl_ext) == 0)
                 return true;
         }

--- a/src/dispatch_egl.c
+++ b/src/dispatch_egl.c
@@ -65,6 +65,9 @@ epoxy_egl_version(EGLDisplay dpy)
     int ret;
 
     version_string = eglQueryString(dpy, EGL_VERSION);
+    if (!version_string)
+        return 0;
+
     ret = sscanf(version_string, "%d.%d", &major, &minor);
     assert(ret == 2);
     return major * 10 + minor;


### PR DESCRIPTION
…nullpointer checks from https://bugzilla.redhat.com/show_bug.cgi?id=1395366

Related commit: b3b8bd9af7bf1fcfe544fd131f4d4f0d117ae7bc
 Fix "epoxy_glx_version" to handle the case when GLX is not active on the display.
Patch is tweak from the original version posted by Tom Horsley