### PR TITLE
Update required version to 0.39.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('libepoxy', 'c', version: '1.4.2',
           'warning_level=1',
         ],
         license: 'MIT',
-        meson_version: '>= 0.38.1')
+        meson_version: '>= 0.39.1')
 
 epoxy_version = meson.project_version().split('.')
 epoxy_major_version = epoxy_version[0].to_int()


### PR DESCRIPTION
It seems bumping to 0.38.1 was too relaxed, and evidently I didn't thoroughly test the change.

Let's bump to 0.39.1, as it's the same version we use for CI.