### PR TITLE
Add support for building on Haiku.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,8 @@ if enable_glx == 'auto'
     build_glx = false
   elif host_system == 'android'
     build_glx = false
+  elif host_system == 'haiku'
+    build_glx = false
   else
     build_glx = true
   endif


### PR DESCRIPTION
Haiku is a operating system that targets personal computing and is inspired by BeOS. This commit disables building glx on Haiku, allowing it to build libepoxy successfully. I also tested the build on Haiku and it passes all tests.