### PR TITLE
meson.build: fix macOS common_ldflags

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -59,7 +59,7 @@ endif
 
 # Maintain compatibility with autotools; see: https://github.com/anholt/libepoxy/issues/108
 if host_system == 'darwin'
-  common_ldflags += [ '-compatibility_version=1', '-current_version=1.0', ]
+  common_ldflags += [ '-compatibility_version 1', '-current_version 1.0', ]
 endif
 
 epoxy_deps = [ dl_dep, ]


### PR DESCRIPTION
Just saw this happening on macOS:

````
[9/13] Linking target src/libepoxy.0.dylib
FAILED: src/libepoxy.0.dylib 
clang  -o src/libepoxy.0.dylib 'src/epoxy@sha/src_gl_generated_dispatch.c.o' 'src/epoxy@sha/dispatch_common.c.o' '-shared' '-install_name' '/private/tmp/libepoxy-20170612-40467-rny9re/libepoxy-1.4.3/build/src/libepoxy.dylib' '-compatibility_version=1' '-current_version=1.0' '-ldl' '-Wl,-rpath,/private/tmp/libepoxy-20170612-40467-rny9re/libepoxy-1.4.3/build/src'  
ld: malformed 32-bit x.y.z version number: =1
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.

````

Fix was simply replacing the equal signs with spaces.