### PR TITLE
RFC: Add epoxy_set_resolver_failure_handler()

### DIFF
--- a/include/epoxy/gl.h
+++ b/include/epoxy/gl.h
@@ -92,6 +92,20 @@ EPOXY_PUBLIC bool epoxy_has_gl_extension(const char *extension);
 EPOXY_PUBLIC bool epoxy_is_desktop_gl(void);
 EPOXY_PUBLIC int epoxy_gl_version(void);
 
+/*
+ * the type of the stub function that the failure handler must return;
+ * this function will be called on subsequent calls to the same bogus
+ * function name
+ */
+typedef void (*epoxy_resolver_stub_t)(void);
+
+/* the type of the failure handler itself */
+typedef epoxy_resolver_stub_t
+(*epoxy_resolver_failure_handler_t)(const char *name);
+
+EPOXY_PUBLIC epoxy_resolver_failure_handler_t
+epoxy_set_resolver_failure_handler(epoxy_resolver_failure_handler_t handler);
+
 EPOXY_END_DECLS
 
 #endif /* EPOXY_GL_H */

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -845,3 +845,21 @@ WRAPPER(epoxy_glEnd)(void)
 
 PFNGLBEGINPROC epoxy_glBegin = epoxy_glBegin_wrapped;
 PFNGLENDPROC epoxy_glEnd = epoxy_glEnd_wrapped;
+
+epoxy_resolver_failure_handler_t epoxy_resolver_failure_handler;
+
+epoxy_resolver_failure_handler_t
+epoxy_set_resolver_failure_handler(epoxy_resolver_failure_handler_t handler)
+{
+#ifdef _WIN32
+    return InterlockedExchangePointer(&epoxy_resolver_failure_handler,
+				      handler);
+#else
+    epoxy_resolver_failure_handler_t old;
+    pthread_mutex_lock(&api.mutex);
+    old = epoxy_resolver_failure_handler;
+    epoxy_resolver_failure_handler = handler;
+    pthread_mutex_unlock(&api.mutex);
+    return old;
+#endif
+}

--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -172,6 +172,8 @@ bool epoxy_extension_in_string(const char *extension_list, const char *ext);
 extern void UNWRAPPED_PROTO(glBegin_unwrapped)(GLenum primtype);
 extern void UNWRAPPED_PROTO(glEnd_unwrapped)(void);
 
+extern epoxy_resolver_failure_handler_t epoxy_resolver_failure_handler;
+
 #if USING_DISPATCH_TABLE
 void gl_init_dispatch_table(void);
 void gl_switch_to_dispatch_table(void);

--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -709,6 +709,10 @@ class Generator(object):
         self.outln('    }')
         self.outln('')
 
+        self.outln('    if (epoxy_resolver_failure_handler)')
+        self.outln('        return epoxy_resolver_failure_handler(name);')
+        self.outln('')
+
         # If the function isn't provided by any known extension, print
         # something useful for the poor application developer before
         # aborting.  (In non-epoxy GL usage, the app developer would


### PR DESCRIPTION
I'd like to use epoxy in xserver's libglx, but the fatal error on resolve
failure makes this a little awkward. My generated glx protocol code is
going to be wired up regardless of the gl extensions the renderer actually
supports, and while a well-behaved client isn't going to send a request
the connection doesn't support, I don't want a mischevious client to be
able to shoot down the entire X server. I could prevent this by mirroring
the same provider iteration walk in the generated code, but needing to do
that in two places instead of one kind of defeats the point of having
epoxy involved at all.

This change adds a failure handler that, if registered, is called instead
of abort. There's not much it can usefully do of course - I expect the
xserver handler will just chirp in the log and kill the client connection
- so there's no closure pointer in the signature. I'm not totally sure the
signal()-like "return the old handler" idiom is useful.