### PR TITLE
Try even harder to not load GLX

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -597,9 +597,11 @@ epoxy_egl_dlsym(const char *name)
 void *
 epoxy_conservative_glx_dlsym(const char *name, bool exit_if_fails)
 {
+#ifdef GLVND_GLX_LIB
     /* prefer the glvnd library if it exists */
     if (!api.glx_handle)
 	get_dlopen_handle(&api.glx_handle, GLVND_GLX_LIB, false);
+#endif
 
     return do_dlsym(&api.glx_handle, GLX_LIB, name, exit_if_fails);
 }

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -522,6 +522,16 @@ epoxy_current_context_is_glx(void)
 #if !PLATFORM_HAS_GLX
     return false;
 #else
+    void *sym;
+
+    /* If we've been called already, don't load more */
+    if (!api.egl_handle != !api.glx_handle) {
+	if (api.glx_handle)
+	    return true;
+	else if (api.egl_handle)
+	    return false;
+    }
+
     /* If the application hasn't explicitly called some of our GLX
      * or EGL code but has presumably set up a context on its own,
      * then we need to figure out how to getprocaddress anyway.
@@ -529,7 +539,6 @@ epoxy_current_context_is_glx(void)
      * If there's a public GetProcAddress loaded in the
      * application's namespace, then use that.
      */
-    void *sym;
 
     sym = dlsym(NULL, "glXGetCurrentContext");
     if (sym) {


### PR DESCRIPTION
This doesn't _quite_ eliminate X11 libraries from EGL applications, since
Mesa's libEGL has an X11 backend. But it does eliminate libGL and libGLX.