### PR TITLE
Add fallback definition for EGL_CAST

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -491,6 +491,15 @@ class Generator(object):
             self.outln('#include "epoxy/gl.h"')
             if self.target == "egl":
                 self.outln('#include "EGL/eglplatform.h"')
+                # Account for older eglplatform.h, which doesn't define
+                # the EGL_CAST macro.
+                self.outln('#ifndef EGL_CAST')
+                self.outln('#if defined(__cplusplus)')
+                self.outln('#define EGL_CAST(type, value) (static_cast<type>(value))')
+                self.outln('#else')
+                self.outln('#define EGL_CAST(type, value) ((type) (value))')
+                self.outln('#endif')
+                self.outln('#endif')
         else:
             # Add some ridiculous inttypes.h redefinitions that are
             # from khrplatform.h and not included in the XML.  We


### PR DESCRIPTION
The EGL API update from d11104f2b5 introduced a dependency on the
EGL_CAST() macro, provided by an updated eglplatform.h. Given that we
don't provide eglplatform.h, add a fallback definition for if we're
building against Mesa 17.0.x or similar.

https://bugs.gentoo.org/show_bug.cgi?id=623926