### PR TITLE
Expose epoxy_extension_in_string() in public headers

### DIFF
--- a/include/epoxy/common.h
+++ b/include/epoxy/common.h
@@ -53,4 +53,11 @@ typedef unsigned char bool;
 # include <stdbool.h>
 #endif
 
+EPOXY_BEGIN_DECLS
+
+EPOXY_PUBLIC bool epoxy_extension_in_string(const char *extension_list,
+                                            const char *ext);
+
+EPOXY_END_DECLS
+
 #endif /* EPOXY_COMMON_H */

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -446,6 +446,24 @@ epoxy_conservative_gl_version(void)
     return epoxy_internal_gl_version(100);
 }
 
+/**
+ * @brief Checks for the presence of an extension in an OpenGL extension string
+ *
+ * @param extension_list The string containing the list of extensions to check
+ * @param ext The name of the GL extension
+ * @return `true` if the extension is available'
+ *
+ * @note If you are looking to check whether a normal GL, EGL or GLX extension
+ * is supported by the client, this probably isn't the function you want.
+ *
+ * Some parts of the spec for OpenGL and friends will return an OpenGL formatted
+ * extension string that is seperate from the usual extension strings for the
+ * spec. This function provides easy parsing of those strings.
+ *
+ * @see epoxy_has_gl_extension()
+ * @see epoxy_has_egl_extension()
+ * @see epoxy_has_glx_extension()
+ */
 bool
 epoxy_extension_in_string(const char *extension_list, const char *ext)
 {

--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -165,8 +165,6 @@ bool epoxy_conservative_has_wgl_extension(const char *name);
 void *epoxy_conservative_egl_dlsym(const char *name, bool exit_if_fails);
 void *epoxy_conservative_glx_dlsym(const char *name, bool exit_if_fails);
 
-bool epoxy_extension_in_string(const char *extension_list, const char *ext);
-
 #define glBegin_unwrapped epoxy_glBegin_unwrapped
 #define glEnd_unwrapped epoxy_glEnd_unwrapped
 extern void UNWRAPPED_PROTO(glBegin_unwrapped)(GLenum primtype);


### PR DESCRIPTION
The EGL_EXT_device_query extension introduces the
eglQueryDeviceStringEXT() function, which can be used with an
EGLDeviceEXT enumeration to receive an OpenGL extension string
containing all of the device extensions supported by it. From the
EGL_EXT_device_query spec's amendments to section "3.2 Devices" after
"3.1 Errors":

    const char *eglQueryDeviceStringEXT(EGLDeviceEXT device,
    				    EGLint name);

    returns a pointer to a static, zero-terminated string describing
    some aspect of the specified EGLDeviceEXT.  <name> must be
    EGL_EXTENSIONS.

Since OpenGL extension parsing is rather simple, and we could always run
into additional cases similar to this one in the future, we expose the
shared epoxy_extension_in_string() function in libepoxy's public headers
so that users can save themselves the hassle of having to write their
own extension parser.

Signed-off-by: Lyude Paul <thatslyude@gmail.com>