### PR TITLE
Fix pointer mismatch bug on Windows 10.

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -852,7 +852,7 @@ epoxy_resolver_failure_handler_t
 epoxy_set_resolver_failure_handler(epoxy_resolver_failure_handler_t handler)
 {
 #ifdef _WIN32
-    return InterlockedExchangePointer(&epoxy_resolver_failure_handler,
+    return InterlockedExchangePointer((void**)&epoxy_resolver_failure_handler,
 				      handler);
 #else
     epoxy_resolver_failure_handler_t old;


### PR DESCRIPTION
We must explicitly cast to void**. See http://c-faq.com/ptrs/genericpp.html. This change fixed build errors I was experiencing on Windows.