### PR TITLE
meson: Define visibility flags for static builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -160,8 +160,8 @@ endforeach
 libtype = get_option('default_library')
 
 # Visibility compiler flags; we only use this for shared libraries
+visibility_cflags = []
 if libtype == 'shared'
-  visibility_cflags = []
   if host_system == 'windows'
     conf.set('DLL_EXPORT', true)
     conf.set('EPOXY_PUBLIC', '__declspec(dllexport) extern')


### PR DESCRIPTION
It's used unconditionally, but defined only for shared builds. For
static builds define it but don't populate it.