### PR TITLE
Fix printf family usage

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -296,8 +296,7 @@ get_dlopen_handle(void **handle, const char *lib_name, bool exit_on_fail)
         return true;
 
     if (!library_initialized) {
-        fprintf(stderr,
-                "Attempting to dlopen() while in the dynamic linker.\n");
+        fputs("Attempting to dlopen() while in the dynamic linker.\n", stderr);
         abort();
     }
 

--- a/src/dispatch_wgl.c
+++ b/src/dispatch_wgl.c
@@ -53,9 +53,9 @@ epoxy_has_wgl_extension(HDC hdc, const char *ext)
 
      getext = (void *)wglGetProcAddress("wglGetExtensionsStringARB");
      if (!getext) {
-         fprintf(stderr,
-                 "Implementation unexpectedly missing "
-                 "WGL_ARB_extensions_string.  Probably a libepoxy bug.\n");
+         fputs("Implementation unexpectedly missing "
+               "WGL_ARB_extensions_string.  Probably a libepoxy bug.\n",
+               stderr);
          return false;
      }
 

--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -144,7 +144,7 @@ dlwrap_real_dlopen(const char *filename, int flag)
     if (!real_dlopen) {
         real_dlopen = (fips_dlopen_t) dlwrap_real_dlsym(RTLD_NEXT, "dlopen");
         if (!real_dlopen) {
-            fprintf(stderr, "Error: Failed to find symbol for dlopen.\n");
+            fputs("Error: Failed to find symbol for dlopen.\n", stderr);
             exit(1);
         }
     }
@@ -251,22 +251,22 @@ dlwrap_real_dlsym(void *handle, const char *name)
                 break;
         }
         if (i == num_versions) {
-            fprintf(stderr, "Internal error: Failed to find real dlsym\n");
-            fprintf(stderr,
-                    "This may be a simple matter of fips not knowing about the version of GLIBC that\n"
-                    "your program is using. Current known versions are:\n\n\t");
+            fputs("Internal error: Failed to find real dlsym\n", stderr);
+            fputs("This may be a simple matter of fips not knowing about the version of GLIBC that\n"
+                  "your program is using. Current known versions are:\n\n\t",
+                  stderr);
             for (i = 0; i < num_versions; i++)
                 fprintf(stderr, "%s ", version[i]);
-            fprintf(stderr,
-                    "\n\nYou can inspect your version by first finding libdl.so.2:\n"
-                    "\n"
-                    "\tldd <your-program> | grep libdl.so\n"
-                    "\n"
-                    "And then inspecting the version attached to the dlsym symbol:\n"
-                    "\n"
-                    "\treadelf -s /path/to/libdl.so.2 | grep dlsym\n"
-                    "\n"
-                    "And finally, adding the version to dlwrap.c:dlwrap_real_dlsym.\n");
+            fputs("\n\nYou can inspect your version by first finding libdl.so.2:\n"
+                  "\n"
+                  "\tldd <your-program> | grep libdl.so\n"
+                  "\n"
+                  "And then inspecting the version attached to the dlsym symbol:\n"
+                  "\n"
+                  "\treadelf -s /path/to/libdl.so.2 | grep dlsym\n"
+                  "\n"
+                  "And finally, adding the version to dlwrap.c:dlwrap_real_dlsym.\n",
+                  stderr);
 
             exit(1);
         }

--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -162,7 +162,11 @@ wrapped_dlsym(const char *prefix, const char *name)
     char *wrap_name;
     void *symbol;
 
-    asprintf(&wrap_name, "override_%s_%s", prefix, name);
+    if (asprintf(&wrap_name, "override_%s_%s", prefix, name) < 0) {
+        fputs("Error: Failed to allocate memory.\n", stderr);
+        abort();
+    }
+
     symbol = dlwrap_real_dlsym(RTLD_DEFAULT, wrap_name);
     free(wrap_name);
     return symbol;

--- a/test/egl_and_glx_different_pointers.c
+++ b/test/egl_and_glx_different_pointers.c
@@ -103,7 +103,7 @@ make_glx_current_and_test(Display *dpy, GLXContext ctx, Drawable draw)
     glXMakeCurrent(dpy, draw, ctx);
 
     if (!epoxy_is_desktop_gl()) {
-        fprintf(stderr, "Claimed to be ES\n");
+        fputs("Claimed to be ES\n", stderr);
         pass = false;
     }
 
@@ -145,7 +145,7 @@ make_egl_current_and_test(EGLDisplay *dpy, EGLContext ctx)
     eglMakeCurrent(dpy, NULL, NULL, ctx);
 
     if (epoxy_is_desktop_gl()) {
-        fprintf(stderr, "Claimed to be desktop\n");
+        fputs("Claimed to be desktop\n", stderr);
         pass = false;
     }
 

--- a/test/egl_gl.c
+++ b/test/egl_gl.c
@@ -53,7 +53,7 @@ make_egl_current_and_test(EGLDisplay *dpy, EGLContext ctx)
     eglMakeCurrent(dpy, NULL, NULL, ctx);
 
     if (!epoxy_is_desktop_gl()) {
-        fprintf(stderr, "Claimed to be desktop\n");
+        fputs("Claimed to be desktop\n", stderr);
         pass = false;
     }
 

--- a/test/glx_common.c
+++ b/test/glx_common.c
@@ -32,7 +32,7 @@ get_display_or_skip(void)
 	Display *dpy = XOpenDisplay(NULL);
 
 	if (!dpy) {
-		fprintf(stderr, "couldn't open display\n");
+		fputs("couldn't open display\n", stderr);
 		exit(77);
 	}
 
@@ -55,8 +55,7 @@ get_glx_visual(Display *dpy)
 
 	visinfo = glXChooseVisual(dpy, screen, attrib);
 	if (visinfo == NULL) {
-		fprintf(stderr,
-			"Couldn't get an RGBA, double-buffered visual\n");
+		fputs("Couldn't get an RGBA, double-buffered visual\n", stderr);
 		exit(1);
 	}
 
@@ -96,7 +95,7 @@ make_glx_context_current_or_skip(Display *dpy)
 
 	ctx = glXCreateContext(dpy, visinfo, False, True);
 	if (ctx == None) {
-		fprintf(stderr, "glXCreateContext failed\n");
+		fputs("glXCreateContext failed\n", stderr);
 		exit(1);
 	}
 

--- a/test/glx_public_api.c
+++ b/test/glx_public_api.c
@@ -92,15 +92,15 @@ static bool
 test_glx_extension_supported(void)
 {
     if (!epoxy_has_glx_extension(dpy, 0, "GLX_ARB_get_proc_address")) {
-        fprintf(stderr,
-                "Incorrectly reported no support for GLX_ARB_get_proc_address "
-                "(should always be present in Linux ABI)\n");
+        fputs("Incorrectly reported no support for GLX_ARB_get_proc_address "
+              "(should always be present in Linux ABI)\n",
+              stderr);
         return false;
     }
 
     if (epoxy_has_glx_extension(dpy, 0, "GLX_EXT_ham_sandwich")) {
-        fprintf(stderr,
-                "Incorrectly reported support for GLX_EXT_ham_sandwich\n");
+        fputs("Incorrectly reported support for GLX_EXT_ham_sandwich\n",
+              stderr);
         return false;
     }
 

--- a/test/glx_public_api_core.c
+++ b/test/glx_public_api_core.c
@@ -51,8 +51,9 @@ test_has_extensions(void)
     }
 
     if (epoxy_has_gl_extension("GL_ARB_ham_sandwich")) {
-        fprintf(stderr, "epoxy implementation reported support for "
-                "GL_ARB_ham_sandwich, but it shouldn't\n");
+        fputs("epoxy implementation reported support for "
+              "GL_ARB_ham_sandwich, but it shouldn't\n",
+              stderr);
         return false;
     }
 

--- a/test/glx_static.c
+++ b/test/glx_static.c
@@ -50,7 +50,7 @@ main(int argc, char **argv)
 
 #if NEEDS_TO_BE_STATIC
     if (dlsym(NULL, "epoxy_glCompileShader")) {
-        fprintf(stderr, "glx_static requires epoxy built with --enable-static\n");
+        fputs("glx_static requires epoxy built with --enable-static\n", stderr);
         return 77;
     }
 #endif
@@ -62,7 +62,7 @@ main(int argc, char **argv)
     val = 0;
     glGetIntegerv(GL_LIGHTING, &val);
     if (!val) {
-        fprintf(stderr, "Enabling GL_LIGHTING didn't stick.\n");
+        fputs("Enabling GL_LIGHTING didn't stick.\n", stderr);
         pass = false;
     }
 

--- a/test/khronos_typedefs_nonepoxy.c
+++ b/test/khronos_typedefs_nonepoxy.c
@@ -62,7 +62,7 @@ get_system_typedef_sizes(uint32_t *sizes)
 void
 get_system_typedef_sizes(uint32_t *sizes)
 {
-    fprintf(stderr, "./configure failed to find khrplatform.h\n");
+    fputs("./configure failed to find khrplatform.h\n", stderr);
     exit(77);
 }
 

--- a/test/wgl_common.c
+++ b/test/wgl_common.c
@@ -54,12 +54,12 @@ setup_pixel_format(HDC hdc)
 
     pixel_format = ChoosePixelFormat(hdc, &pfd);
     if (!pixel_format) {
-        fprintf(stderr, "ChoosePixelFormat failed.\n");
+        fputs("ChoosePixelFormat failed.\n", stderr);
         exit(1);
     }
 
     if (SetPixelFormat(hdc, pixel_format, &pfd) != TRUE) {
-        fprintf(stderr, "SetPixelFormat() failed.\n");
+        fputs("SetPixelFormat() failed.\n", stderr);
         exit(1);
     }
 }
@@ -108,7 +108,7 @@ make_window_and_test(int (*callback)(HDC hdc))
     window_class.lpszMenuName = NULL;
     window_class.lpszClassName = class_name;
     if (!RegisterClass(&window_class)) {
-        fprintf(stderr, "Failed to register window class\n");
+        fputs("Failed to register window class\n", stderr);
         exit(1);
     }
 

--- a/test/wgl_core_and_exts.c
+++ b/test/wgl_core_and_exts.c
@@ -35,11 +35,11 @@ test_function(HDC hdc)
 
     ctx = wglCreateContext(hdc);
     if (!ctx) {
-        fprintf(stderr, "Failed to create wgl context\n");
+        fputs("Failed to create wgl context\n", stderr);
         return 1;
     }
     if (!wglMakeCurrent(hdc, ctx)) {
-        fprintf(stderr, "Failed to make context current\n");
+        fputs("Failed to make context current\n", stderr);
         return 1;
     }
 
@@ -48,7 +48,7 @@ test_function(HDC hdc)
     val = 0;
     glGetIntegerv(GL_LIGHTING, &val);
     if (!val) {
-        fprintf(stderr, "Enabling GL_LIGHTING didn't stick.\n");
+        fputs("Enabling GL_LIGHTING didn't stick.\n", stderr);
         pass = false;
     }
 

--- a/test/wgl_per_context_funcptrs.c
+++ b/test/wgl_per_context_funcptrs.c
@@ -57,7 +57,7 @@ OVERRIDE_API (GLuint)
 override_glCreateShader_ctx1(GLenum target)
 {
     if (current_context != ctx1) {
-        fprintf(stderr, "ctx1 called while other context current\n");
+        fputs("ctx1 called while other context current\n", stderr);
         pass = false;
     }
     return CREATESHADER_CTX1_VAL;
@@ -67,7 +67,7 @@ OVERRIDE_API (GLuint)
 override_glCreateShader_ctx2(GLenum target)
 {
     if (current_context != ctx2) {
-        fprintf(stderr, "ctx2 called while other context current\n");
+        fputs("ctx2 called while other context current\n", stderr);
         pass = false;
     }
     return CREATESHADER_CTX2_VAL;
@@ -123,18 +123,18 @@ test_function(HDC hdc)
     ctx1 = wglCreateContext(hdc);
     ctx2 = wglCreateContext(hdc);
     if (!ctx1 || !ctx2) {
-        fprintf(stderr, "Failed to create wgl contexts\n");
+        fputs("Failed to create wgl contexts\n", stderr);
         return 1;
     }
 
     if (!wglMakeCurrent(hdc, ctx1)) {
-        fprintf(stderr, "Failed to make context current\n");
+        fputs("Failed to make context current\n", stderr);
         return 1;
     }
 
     if (epoxy_gl_version() < 20) {
         /* We could possibly do a 1.3 entrypoint or something instead. */
-        fprintf(stderr, "Test relies on overriding a GL 2.0 entrypoint\n");
+        fputs("Test relies on overriding a GL 2.0 entrypoint\n", stderr);
         return 77;
     }
 

--- a/test/wgl_usefontbitmaps.c
+++ b/test/wgl_usefontbitmaps.c
@@ -36,11 +36,11 @@ test_function(HDC hdc)
 
     ctx = wglCreateContext(hdc);
     if (!ctx) {
-        fprintf(stderr, "Failed to create wgl context\n");
+        fputs("Failed to create wgl context\n", stderr);
         return 1;
     }
     if (!wglMakeCurrent(hdc, ctx)) {
-        fprintf(stderr, "Failed to make context current\n");
+        fputs("Failed to make context current\n", stderr);
         return 1;
     }
 


### PR DESCRIPTION
 - Fix use of `asprintf` to be correct and silence compiler warnings
 - Only use `fprintf` when actually needed, otherwise use `fputs` (avoid unnecessary allocations)