### PR TITLE
change hardcoded library names to less hardcoded names.

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -177,7 +177,7 @@
 #define str(a) #a
 
 #ifndef GLX_LIB_NAME
-#error "GLX_LIB_NAME not defined"
+#define GLX_LIB "libGL.so.1"
 #else
 #define GLX_LIB    xstr(GLX_LIB_NAME)
 #endif
@@ -187,19 +187,19 @@
 #endif
 
 #ifndef EGL_LIB_NAME
-#error "EGL_LIB_NAME not defined"
+#define EGL_LIB "libEGL.so.1"
 #else
 #define EGL_LIB    xstr(EGL_LIB_NAME)
 #endif
 
 #ifndef GLES1_LIB_NAME
-#error "GLES1_LIB_NAME not defined"
+#define GLES1_LIB "libGLESv1_CM.so.1"
 #else
 #define GLES1_LIB  xstr(GLES1_LIB_NAME)
 #endif
 
 #ifndef GLES2_LIB_NAME
-#error "GLES2_LIB_NAME not defined"
+#define GLES2_LIB "libGLESv2.so.2"
 #else
 #define GLES2_LIB  xstr(GLES2_LIB_NAME)
 #endif

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -204,6 +204,12 @@
 #define GLES2_LIB  xstr(GLES2_LIB_NAME)
 #endif
 
+#ifndef OPENGL_LIB_NAME
+#define OPENGL_LIB "libOpenGL.so.0"
+#else
+#define OPENGL_LIB  xstr(GLES2_LIB_NAME)
+#endif
+
 #ifdef __GNUC__
 #define CONSTRUCT(_func) static void _func (void) __attribute__((constructor));
 #define DESTRUCT(_func) static void _func (void) __attribute__((destructor));

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -173,28 +173,35 @@
 
 #include "dispatch_common.h"
 
-#ifdef __APPLE__
-#define GLX_LIB "/opt/X11/lib/libGL.1.dylib"
-#elif defined(ANDROID)
-#define GLX_LIB "libGLESv2.so"
+#define xstr(a) str(a)
+#define str(a) #a
+
+#ifndef GLX_LIB_NAME
+#error "GLX_LIB_NAME not defined"
 #else
-#define GLVND_GLX_LIB "libGLX.so.1"
-#define GLX_LIB "libGL.so.1"
+#define GLX_LIB    xstr(GLX_LIB_NAME)
 #endif
 
-#ifdef ANDROID
-#define EGL_LIB "libEGL.so"
-#define GLES1_LIB "libGLESv1_CM.so"
-#define GLES2_LIB "libGLESv2.so"
-#elif defined _WIN32
-#define EGL_LIB "libEGL.dll"
-#define GLES1_LIB "libGLES_CM.dll"
-#define GLES2_LIB "libGLESv2.dll"
+#ifdef GLVND_GLX_LIB_NAME
+#define GLVND_GLX_LIB xstr(GLVND_GLX_LIB_NAME)
+#endif
+
+#ifndef EGL_LIB_NAME
+#error "EGL_LIB_NAME not defined"
 #else
-#define EGL_LIB "libEGL.so.1"
-#define GLES1_LIB "libGLESv1_CM.so.1"
-#define GLES2_LIB "libGLESv2.so.2"
-#define OPENGL_LIB "libOpenGL.so.0"
+#define EGL_LIB    xstr(EGL_LIB_NAME)
+#endif
+
+#ifndef GLES1_LIB_NAME
+#error "GLES1_LIB_NAME not defined"
+#else
+#define GLES1_LIB  xstr(GLES1_LIB_NAME)
+#endif
+
+#ifndef GLES2_LIB_NAME
+#error "GLES2_LIB_NAME not defined"
+#else
+#define GLES2_LIB  xstr(GLES2_LIB_NAME)
 #endif
 
 #ifdef __GNUC__


### PR DESCRIPTION
Sharing is caring, after an upgrade of WebKit I needed to use libepoxy on several platforms that are not based on Android, which didn't have e.g. libEGL.so.1 and I wasn't allowed to introduce extra symbolic links. So I thought there must be a way to specify the graphics library names from a build system level.  This is maybe not the cleanest way, but this way you can add the names using defines at build time.  e.g. in my buildroot makefile: 

ifeq ($(BR2_PACKAGE_PLATFORM_X),y)
LIBEPOXY_CONF_OPTS += \
	CFLAGS='$(TARGET_CFLAGS) \
			-DGLX_LIB_NAME="libGLESv2.so" \
			-DEGL_LIB_NAME="libEGL.so" \
			-DGLES1_LIB_NAME="libGLESv1_CM.so" \
			-DGLES2_LIB_NAME="libGLESv2.so"'
else
LIBEPOXY_MAKE_OPTS += \
	CFLAGS='$(TARGET_CFLAGS) \
            -DGLX_LIB_NAME="libGL.so.1" \
            -DEGL_LIB_NAME="libEGL.so.1" \
            -DGLES1_LIB_NAME="libGLESv1_CM.so.1" \
            -DGLES2_LIB_NAME="libGLESv2.so.2"'
endif