### PR TITLE
test: Fix dlwrap for glvnd

### DIFF
--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -67,6 +67,7 @@ static struct libwrap {
     { "libGL.so", "GL", NULL },
     { "libEGL.so", "EGL", NULL },
     { "libGLESv2.so", "GLES2", NULL },
+    { "libOpenGL.so", "GL", NULL},
 };
 
 /* Match 'filename' against an internal list of libraries for which


### PR DESCRIPTION
Add libOpenGL to the list of libraries we'll intercept. This is harmless
if glvnd is not available as the dlopen(libOpenGL.so) will fail, but
without this we can't intercept glGetString, which the
egl_and_glx_different_pointers_glx test needs to be able to do.

Signed-off-by: Adam Jackson <ajax@redhat.com>