### PR TITLE
meson: do not add gl to pkg-config file on macOS

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -93,10 +93,10 @@ epoxy_has_wgl = build_wgl ? '1' : '0'
 # not needed when building Epoxy; we do want to add them to the generated
 # pkg-config file, for consumers of Epoxy
 gl_reqs = []
-if gl_dep.found()
+if gl_dep.found() and gl_dep.type_name() == 'pkgconfig'
   gl_reqs += 'gl'
 endif
-if build_egl and egl_dep.found()
+if build_egl and egl_dep.found() and egl_dep.type_name() == 'pkgconfig'
   gl_reqs += 'egl'
 endif
 


### PR DESCRIPTION
Even though meson will find the dependency gl on macOS, this does not mean that
there is a pkg-config file for it, as meson does not use pkg-config to
establish its presence. It should therefore not be added to
the libepoxy pkg-config file as a (private) requirement.