### PR TITLE
dispatch: assert, not errx, when we have no context

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -859,7 +859,7 @@ epoxy_get_proc_address(const char *name)
 #elif PLATFORM_HAS_GLX
     if (epoxy_current_context_is_glx())
         return glXGetProcAddressARB((const GLubyte *)name);
-    errx(1, "Couldn't find current GLX or EGL context.\n");
+    assert(0 && "Couldn't find current GLX or EGL context.\n");
 #endif
 
     return NULL;


### PR DESCRIPTION
errx() calls exit(), you'd rather get a backtrace.

Signed-off-by: Adam Jackson <ajax@redhat.com>