### PR TITLE
Fix dlwrap for FreeBSD

### DIFF
--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -242,7 +242,8 @@ dlwrap_real_dlsym(void *handle, const char *name)
             "GLIBC_2.3",
             "GLIBC_2.2.5",
             "GLIBC_2.2",
-            "GLIBC_2.0"
+            "GLIBC_2.0",
+            "FBSD_1.0"
         };
         int num_versions = sizeof(version) / sizeof(version[0]);
         int i;

--- a/test/meson.build
+++ b/test/meson.build
@@ -5,10 +5,13 @@ has_gles1 = gles1_dep.found()
 has_gles2 = gles2_dep.found()
 build_x11_tests = enable_x11 and x11_dep.found()
 
-test_cflags = common_cflags + [
+test_cflags = common_cflags
+if not has_dlvsym
+test_cflags += [
   '-D_XOPEN_SOURCE',
   '-D_POSIX_C_SOURCE=200809L',
 ]
+endif
 
 # Unconditionally built tests
 test('header_guards',


### PR DESCRIPTION
This pull request fixes the compilation error and add a symbol version for dlwrap on FreeBSD. It doesn't fix the test because of the lack of libglvnd.