### PR TITLE
dispatch: Try harder to avoid calling the resolver

### DIFF
--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -85,10 +85,11 @@
 #define WRAPPER(x) x ## _wrapped
 
 #define GEN_GLOBAL_REWRITE_PTR(name, args, passthrough)          \
-    static void EPOXY_CALLSPEC                                        \
+    static void EPOXY_CALLSPEC                                   \
     name##_global_rewrite_ptr args                               \
     {                                                            \
-        name = (void *)name##_resolver();                        \
+        if (name == (void *)name##_global_rewrite_ptr)           \
+            name = (void *)name##_resolver();                    \
         name passthrough;                                        \
     }
 
@@ -96,7 +97,8 @@
     static ret EPOXY_CALLSPEC                                    \
     name##_global_rewrite_ptr args                               \
     {                                                            \
-        name = (void *)name##_resolver();                        \
+        if (name == (void *)name##_global_rewrite_ptr)           \
+            name = (void *)name##_resolver();                    \
         return name passthrough;                                 \
     }
 


### PR DESCRIPTION
Our caller may load (eg) epoxy_glAlphaFunc, which is a function pointer,
and then call through that value multiple times. Until the caller
re-examines the value of that function pointer, which is a copy
relocation in the executable, repeated calls mean repeated work
resolving the GL function.

We can't make the caller reinspect the variable, but the resolver
function can avoid doing redundant work.

Fixes: anholt/libepoxy#171
Signed-off-by: Adam Jackson <ajax@redhat.com>