### PR TITLE
Define _GNU_SOURCE for strdup()

### DIFF
--- a/test/egl_epoxy_api.c
+++ b/test/egl_epoxy_api.c
@@ -27,6 +27,7 @@
  * Tests the Epoxy API using EGL.
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/test/egl_has_extension_nocontext.c
+++ b/test/egl_has_extension_nocontext.c
@@ -28,6 +28,7 @@
  * no context bound would fail out in dispatch.
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
The strdup() function is available on uClibc if _XOPEN_SOURCE_EXTENDED
is defined; since we're using _GNU_SOURCE elsewhere to enable extended
libc features, and uClibc will set _XOPEN_SOURCE_EXTENDED if _GNU_SOURCE
is set, let's use that.

Closes #181