### PR TITLE
dispatch: Fix GLES3 symbol lookup

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -732,7 +732,7 @@ epoxy_gles3_dlsym(const char *name)
         return epoxy_get_proc_address(name);
     } else {
         if (get_dlopen_handle(&api.gles2_handle, GLES2_LIB, false, true)) {
-            void *func = do_dlsym(&api.gles2_handle, GLES2_LIB, false);
+            void *func = do_dlsym(&api.gles2_handle, name, false);
 
             if (func)
                 return func;


### PR DESCRIPTION
Looking for a symbol named "libGLESv2.so.2" is probably not going to
work very well.