### PR TITLE
gitignore: Don't ignore .patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ core
 *.l[oa]
 *.[oa]
 *.obj
-*.patch
 *.so
 *.pcf.gz
 *.pdb


### PR DESCRIPTION
This was a bit annoying when working on the Debian packaging. I can workaround it in Debian but I figure the slight benefit of not accidentally committing a .patch file to the repo isn't worth the annoyance.