### PR TITLE
meson: Fix meson version assertion

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('libepoxy', 'c', version: '1.5.3',
           'warning_level=1',
         ],
         license: 'MIT',
-        meson_version: '>= 0.44.0')
+        meson_version: '>= 0.46.0')
 
 epoxy_version = meson.project_version().split('.')
 epoxy_major_version = epoxy_version[0].to_int()


### PR DESCRIPTION
Currently meson.build asserts meson >= 0.44.0 however it seems to be
using features introducing in meson 0.46.0, thus spewing the following
warning messages:

```
WARNING: Project targetting '>= 0.44.0' but tried to use feature
introduced in '0.46.0': compiler.get_supported_link_arguments_method
WARNING: Project targetting '>= 0.44.0' but tried to use feature
introduced in '0.46.0': compiler.has_link_argument
WARNING: Project targetting '>= 0.44.0' but tried to use feature
introduced in '0.46.0': compiler.has_multi_link_argument
<stripped>
WARNING: Project specifies a minimum meson_version '>= 0.44.0' but uses
features which were added in newer versions:
* 0.46.0: {'compiler.get_supported_link_arguments_method',
'compiler.has_multi_link_argument', 'compiler.has_link_argument'}
```

This patch fixes the issue by bumping the version assertion to >=
0.46.0.

This patch is based on mere speculation and is NOT TESTED, please
review.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>