### PR TITLE
Ensure Autotools enables EGL-X11 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,8 @@ if test x$enable_x11 = xno; then
         AC_MSG_ERROR([GLX support is explicitly enabled, but X11 was disabled])
     fi
     build_glx=no
+else
+    AC_DEFINE([ENABLE_X11], [1], [Whether X11 support is enabled])
 fi
 
 AM_CONDITIONAL(BUILD_EGL, test x$build_egl = xyes)


### PR DESCRIPTION
The X11 support in the Autotools build is missing the definition of the
ENABLE_X11 pre-processor symbol. Without it, we're missing the X11
platform definitions for EGL.

Fixes #188