### PR TITLE
meson: Don't build glx tests if x11 is disabled

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -74,7 +74,7 @@ if build_egl and build_x11_tests
   endforeach
 endif
 
-if build_glx
+if build_glx and build_x11_tests
   glx_common_sources = [ 'glx_common.h', 'glx_common.c', ]
   glx_common_lib = static_library('glx_common',
                                   sources: glx_common_sources,


### PR DESCRIPTION
Fixes build failure when x11 is not found or disabled and glx is also not found. To reproduce, build with:

`PKG_CONFIG_LIBDIR='' meson _build`

The proper fix involves reorganising the dependency checking logic to use Feature Options instead of a combo with auto/yes/no, but that's a larger patch that I'll add later.