### PR TITLE
test: #define __EXTENSIONS__ on Solaris for strdup()

### DIFF
--- a/test/egl_epoxy_api.c
+++ b/test/egl_epoxy_api.c
@@ -27,7 +27,11 @@
  * Tests the Epoxy API using EGL.
  */
 
+#ifdef __sun
+#define __EXTENSIONS__
+#else
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/test/egl_has_extension_nocontext.c
+++ b/test/egl_has_extension_nocontext.c
@@ -28,7 +28,11 @@
  * no context bound would fail out in dispatch.
  */
 
+#ifdef __sun
+#define __EXTENSIONS__
+#else
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
Needed to allow functions outside the original XPG3 standard to be
visible in the Solaris headers when _XOPEN_SOURCE is defined and
not set to a particular value.

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>