### PR TITLE
Remove Python 2 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,7 @@ m4_ifndef([XORG_MACROS_VERSION],
 XORG_MACROS_VERSION(1.8)
 XORG_DEFAULT_OPTIONS
 
-AC_CHECK_PROGS([PYTHON], [python3 python2 python])
+AC_CHECK_PROGS([PYTHON], [python3])
 
 # Initialize libtool
 AC_DISABLE_STATIC

--- a/include/epoxy/meson.build
+++ b/include/epoxy/meson.build
@@ -25,7 +25,6 @@ foreach g: generated_headers
                             input: registry,
                             output: [ gen_header ],
                             command: [
-                              python,
                               gen_dispatch_py,
                               '--header',
                               '--no-source',

--- a/meson.build
+++ b/meson.build
@@ -196,12 +196,6 @@ if host_system == 'windows'
   gdi32_dep = cc.find_library('gdi32', required: true)
 endif
 
-# Python
-python = import('python3').find_python()
-if not python.found()
-  python = find_program('python', required: true)
-endif
-
 # Generates the dispatch tables
 gen_dispatch_py = files('src/gen_dispatch.py')
 

--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # Copyright © 2013 Intel Corporation

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,7 +33,6 @@ foreach g: generated_sources
                             input: registry,
                             output: [ gen_source ],
                             command: [
-                              python,
                               gen_dispatch_py,
                               '--source',
                               '--no-header',


### PR DESCRIPTION
Python 2 is going to reach EOL in January 2020, and most platforms have
already moved to Python 3.