### PR TITLE
build: Use find_program()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update
+      brew unlink python@2
       brew install python@3 meson
       # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
       mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja

--- a/meson.build
+++ b/meson.build
@@ -197,7 +197,7 @@ if host_system == 'windows'
 endif
 
 # Generates the dispatch tables
-gen_dispatch_py = files('src/gen_dispatch.py')
+gen_dispatch_py = find_program('src/gen_dispatch.py')
 
 gl_registry = files('registry/gl.xml')
 egl_registry = files('registry/egl.xml')


### PR DESCRIPTION
Do not rely on the shebang line and the executable bit; we should use
find_program(), instead, which lets Meson run a script in the
appropriate environment, portably.