### PR TITLE
Update WGL Core Test

### DIFF
--- a/test/wgl_core_and_exts.c
+++ b/test/wgl_core_and_exts.c
@@ -43,6 +43,21 @@ test_function(HDC hdc)
         return 1;
     }
 
+    // Attempt to create core context if supported
+    if (epoxy_has_gl_extension("WGL_ARB_create_context")) {
+        // -- Define an array of Context Attributes
+        int attribs[] = {
+            WGL_CONTEXT_PROFILE_MASK_ARB,WGL_CONTEXT_CORE_PROFILE_BIT_ARB,
+            0
+        };
+    
+        HGLRC corectx = wglCreateContextAttribsARB(hdc, 0, attribs);
+        wglMakeCurrent(NULL, NULL);
+        wglDeleteContext(ctx);
+        ctx = corectx;
+        wglMakeCurrent(hdc, ctx);
+    }
+    
     /* GL 1.0 APIs are available as symbols in opengl32.dll. */
     glEnable(GL_LIGHTING);
     val = 0;


### PR DESCRIPTION
I've updated the test to try creating a real actual core context using the appropriate WGL extension. I am unsure and forget if epoxy_has_gl_extension can check for WGL extensions, so I could use some help with what to replace that with if needed.