### PR TITLE
Add call convention to mock function

### DIFF
--- a/test/gl_version.c
+++ b/test/gl_version.c
@@ -29,7 +29,7 @@ GLenum mock_enum;
 const char *mock_gl_version;
 const char *mock_glsl_version;
 
-static const GLubyte *override_glGetString(GLenum name)
+static const GLubyte * EPOXY_CALLSPEC override_glGetString(GLenum name)
 {
     switch (name) {
     case GL_VERSION:


### PR DESCRIPTION
A call convention is required to be able to compile tests on Windows MSVC, otherwise the compiler complain about different function signature.