### PR TITLE
Fix return value of shading language for GLES2.

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -392,10 +392,10 @@ epoxy_is_desktop_gl(void)
 }
 
 static int
-epoxy_internal_gl_version(GLenum version_string, int error_version)
+epoxy_internal_gl_version(GLenum version_string, int error_version, int factor)
 {
     const char *version = (const char *)glGetString(version_string);
-    GLint major, minor, factor;
+    GLint major, minor;
     int scanf_count;
 
     if (!version)
@@ -412,11 +412,6 @@ epoxy_internal_gl_version(GLenum version_string, int error_version)
                 version);
         abort();
     }
-
-    if (minor >= 10)
-        factor = 100;
-    else
-        factor = 10;
 
     return factor * major + minor;
 }
@@ -439,7 +434,7 @@ epoxy_internal_gl_version(GLenum version_string, int error_version)
 int
 epoxy_gl_version(void)
 {
-    return epoxy_internal_gl_version(GL_VERSION, 0);
+    return epoxy_internal_gl_version(GL_VERSION, 0, 10);
 }
 
 int
@@ -448,7 +443,7 @@ epoxy_conservative_gl_version(void)
     if (api.begin_count)
         return 100;
 
-    return epoxy_internal_gl_version(GL_VERSION, 100);
+    return epoxy_internal_gl_version(GL_VERSION, 100, 10);
 }
 
 /**
@@ -471,7 +466,7 @@ epoxy_glsl_version(void)
 {
     if (epoxy_gl_version() >= 20 ||
         epoxy_has_gl_extension ("GL_ARB_shading_language_100"))
-        return epoxy_internal_gl_version(GL_SHADING_LANGUAGE_VERSION, 0);
+        return epoxy_internal_gl_version(GL_SHADING_LANGUAGE_VERSION, 0, 100);
 
     return 0;
 }

--- a/test/gl_version.c
+++ b/test/gl_version.c
@@ -80,6 +80,8 @@ main(int argc, char **argv)
 
     pass = pass && test_version("3.0 Mesa 13.0.6", 30,
                                 "1.30", 130);
+    pass = pass && test_version("OpenGL ES 2.0 Mesa 20.1.0-devel (git-4bb19a330e)", 20,
+                                "OpenGL ES GLSL ES 1.0.16", 100);
     pass = pass && test_version("OpenGL ES 3.2 Mesa 18.3.0-devel", 32,
                                 "OpenGL ES GLSL ES 3.20", 320);
     pass = pass && test_version("4.5.0 NVIDIA 384.130", 45,


### PR DESCRIPTION
Throughout the mesa project we've been using 100 for GLES2's shading
language.  It was pretty clearly the intent here, but the clever
inline detection of "am I parsing a GLSL version or a GL version
string" forgot about GLSL 1.0.x, and thus returned 10.