### PR TITLE
GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Build
+on:
+  push:
+    branches-ignore:
+      - debian
+      - khronos-registry
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: 
+          - ubuntu-18.04
+          - macos-10.15
+        compiler:
+          - gcc
+          - clang
+        build-opts:
+          - ''
+          - '-Dglx=no'
+          - '-Degl=no'
+          - '-Dx11=false'
+        exclude:
+          - os: macos-10.15
+            compiler: gcc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - if: runner.os == 'macOS'
+        run: brew install ninja
+      - if: runner.os == 'Linux'
+        run: >
+          sudo apt-get update &&
+          sudo apt-get install --no-install-recommends
+          libgl1-mesa-dev
+          libegl1-mesa-dev
+          libgles2-mesa-dev
+          libgl1-mesa-dri
+          ninja-build
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: |
+          python -m pip install --upgrade pip
+          pip3 install meson
+      - if: runner.os == 'macOS'
+        run: /bin/sh -c "CC=${{ matrix.compiler }} .travis/epoxy-ci-osx.sh ${{ matrix.build-opts }}"
+      - if: runner.os == 'Linux'
+        run: /bin/sh -c "CC=${{ matrix.compiler }} .travis/epoxy-ci-linux.sh ${{ matrix.build-opts }}"


### PR DESCRIPTION
I created a GitHub CI config for libepoxy in case you are interested in using it. The whole build took just over 2 minutes which is probably much faster than Travis. It is also using the Ubuntu 18.04 that is installed on the runner instead of Debian Stretch inside Docker.