### PR TITLE
Fix some bugs in loading OpenGL/GLX/EGL libraries

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -189,7 +189,7 @@
 #define GLES2_LIB "libGLESv2.dll"
 #define OPENGL_LIB "OPENGL32"
 #else
-#define GLVND_GLX_LIB "libGLX.so.1"
+#define GLVND_GLX_LIB "libGLX.so.0"
 #define GLX_LIB "libGL.so.1"
 #define EGL_LIB "libEGL.so.1"
 #define GLES1_LIB "libGLESv1_CM.so.1"

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -684,7 +684,8 @@ epoxy_load_gl(void)
     if (!api.gl_handle) {
 	get_dlopen_handle(&api.gl_handle, GLX_LIB, true, true);
 #if PLATFORM_HAS_GLX
-	api.glx_handle = api.gl_handle;
+        if (!api.glx_handle)
+	    api.glx_handle = api.gl_handle;
 #endif
     }
 #endif

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -580,21 +580,28 @@ epoxy_current_context_is_glx(void)
 #else
     void *sym;
 
-    sym = epoxy_conservative_glx_dlsym("glXGetCurrentContext", false);
-    if (sym) {
-        if (glXGetCurrentContext())
-            return true;
-    } else {
-        (void)dlerror();
+    // There is no point of getting symbols from library, which is not loaded,
+    // as handle will always be NULL, when exit_on_fail is false
+    if (api.glx_handle) {
+        sym = epoxy_conservative_glx_dlsym("glXGetCurrentContext", false);
+        if (sym) {
+            if (glXGetCurrentContext())
+                return true;
+        } else {
+            (void)dlerror();
+        }
     }
 
 #if PLATFORM_HAS_EGL
-    sym = epoxy_conservative_egl_dlsym("eglGetCurrentContext", false);
-    if (sym) {
-        if (epoxy_egl_get_current_gl_context_api() != EGL_NONE)
-            return false;
-    } else {
-        (void)dlerror();
+    // Same as for GLX
+    if (api.egl_handle) {
+        sym = epoxy_conservative_egl_dlsym("eglGetCurrentContext", false);
+        if (sym) {
+            if (epoxy_egl_get_current_gl_context_api() != EGL_NONE)
+                return false;
+        } else {
+            (void)dlerror();
+        }
     }
 #endif /* PLATFORM_HAS_EGL */
 

--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -674,9 +674,12 @@ epoxy_load_gl(void)
     if (!api.gl_handle)
 	get_dlopen_handle(&api.gl_handle, OPENGL_LIB, false, true);
 #endif
-
-    get_dlopen_handle(&api.glx_handle, GLX_LIB, true, true);
-    api.gl_handle = api.glx_handle;
+    if (!api.gl_handle) {
+	get_dlopen_handle(&api.gl_handle, GLX_LIB, true, true);
+#if PLATFORM_HAS_GLX
+	api.glx_handle = api.gl_handle;
+#endif
+    }
 #endif
 }
 


### PR DESCRIPTION
Without additional check, even if libOpenGL was loaded, libGL.so will be loaded as well, and used both in gl_handle and glx_handle, so libglvnd libraries will not be used.

The problem is that on Wayland-only system, there will be no libGL, so epoxy_load_gl will fail even if libOpenGL was loaded.