### PR TITLE
meson: Set same variables in declare_dependency() as in pkgconfig

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project('libepoxy', 'c', version: '1.5.6',
           'warning_level=1',
         ],
         license: 'MIT',
-        meson_version: '>= 0.48.0')
+        meson_version: '>= 0.54.0')
 
 epoxy_version = meson.project_version().split('.')
 epoxy_major_version = epoxy_version[0].to_int()

--- a/src/meson.build
+++ b/src/meson.build
@@ -72,16 +72,21 @@ libepoxy = library(
   link_args: common_ldflags,
 )
 
+epoxy_has_glx = build_glx ? '1' : '0'
+epoxy_has_egl = build_egl ? '1' : '0'
+epoxy_has_wgl = build_wgl ? '1' : '0'
+
 libepoxy_dep = declare_dependency(
   link_with: libepoxy,
   include_directories: libepoxy_inc,
   dependencies: epoxy_deps,
   sources: epoxy_headers,
+  variables: {
+    'epoxy_has_glx': epoxy_has_glx,
+    'epoxy_has_egl': epoxy_has_egl,
+    'epoxy_has_wgl': epoxy_has_wgl,
+  },
 )
-
-epoxy_has_glx = build_glx ? '1' : '0'
-epoxy_has_egl = build_egl ? '1' : '0'
-epoxy_has_wgl = build_wgl ? '1' : '0'
 
 # We don't want to add these dependencies to the library, as they are
 # not needed when building Epoxy; we do want to add them to the generated


### PR DESCRIPTION
GTK currently fails to detect if epoxy has been built with EGL on
Windows when epoxy is a subproject. To fix that it needs to get that
information from the dependency variables.