### PR TITLE
dispatch: fix loading of GL without GLX library

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -675,8 +675,10 @@ epoxy_load_gl(void)
 	get_dlopen_handle(&api.gl_handle, OPENGL_LIB, false, true);
 #endif
 
-    get_dlopen_handle(&api.glx_handle, GLX_LIB, true, true);
-    api.gl_handle = api.glx_handle;
+    if (!api.gl_handle) {
+        get_dlopen_handle(&api.glx_handle, GLX_LIB, true, true);
+        api.gl_handle = api.glx_handle;
+    }
 #endif
 }
 


### PR DESCRIPTION
When loading the GL library in `epoxy_load_gl`, we in turn try to load
OPENGL_LIB and GLX_LIB. But notably, we'll also try to load GLX_LIB even
if loading OPENGL_LIB succeeded. As this load will abort in case the
library wasn't found, the end result is that systems without GLX_LIB
will always fail `epoxy_load_gl`.

Fix the issue by only trying to load GLX_LIB in case OPENGL_LIB wasn't
found.