### PR TITLE
Fix meson c_std error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libepoxy', 'c', version: '1.5.5',
         default_options: [
           'buildtype=debugoptimized',
-          'c_std=gnu99',
+          'c_std=c99',
           'warning_level=1',
         ],
         license: 'MIT',


### PR DESCRIPTION
Fixes the following error, when building with meson 0.56.0:
```console
meson.build:1:0: ERROR: Value "gnu99" (of type "string") for combo
option "C language standard to use" is not one of the choices.
Possible choices are (as string): "none", "c89", "c99", "c11".