### PR TITLE
Remove redeclaration of khronos_uintptr_t

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -535,7 +535,6 @@ class Generator(object):
             self.outln('    KHRONOS_TRUE  = 1,')
             self.outln('    KHRONOS_BOOLEAN_ENUM_FORCE_SIZE = KHRONOS_MAX_ENUM')
             self.outln('} khronos_boolean_enum_t;')
-            self.outln('typedef uintptr_t khronos_uintptr_t;')
 
         if self.target == "glx":
             self.outln('#include <X11/Xlib.h>')


### PR DESCRIPTION
The type is being redeclared because I didn't see the original
declaration when I wrote 144cbc9325250081f2eb584ca5deb13aaf1c2433.

Fixes: #249