### PR TITLE
gen_dispatch: Define KHR platform types only if header not present

### DIFF
--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -501,11 +501,12 @@ class Generator(object):
                 self.outln('#endif')
                 self.outln('#endif')
         else:
+            self.outln('#ifdef HAVE_KHRPLATFORM_H')
+            self.outln('#include <KHR/khrplatform.h>')
+            self.outln('#else')
             # Add some ridiculous inttypes.h redefinitions that are
-            # from khrplatform.h and not included in the XML.  We
-            # don't directly include khrplatform.h because it's not
-            # present on many systems, and coming up with #ifdefs to
-            # decide when it's not present would be hard.
+            # from khrplatform.h and not included in the XML when
+            # it's not present on the platform.
             self.outln('#define __khrplatform_h_ 1')
             self.outln('typedef int8_t khronos_int8_t;')
             self.outln('typedef int16_t khronos_int16_t;')
@@ -535,6 +536,7 @@ class Generator(object):
             self.outln('    KHRONOS_TRUE  = 1,')
             self.outln('    KHRONOS_BOOLEAN_ENUM_FORCE_SIZE = KHRONOS_MAX_ENUM')
             self.outln('} khronos_boolean_enum_t;')
+            self.outln('#endif')
 
         if self.target == "glx":
             self.outln('#include <X11/Xlib.h>')


### PR DESCRIPTION
On some platforms, `khrplatform.h` is present and provides information
(basic types, pre-processor definitions) that make it subtly different
than what's auto-generated by the libepoxy generator script
(`gen_dispatch.py`).  This later results in compilation failures for
such platforms.

Since it's possible to determine whether the header is present, use the
logic to include it preferably, and fall back to the original behaviour
otherwise.