### PR TITLE
Add EGL include directories

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -60,6 +60,10 @@ if host_system == 'windows'
   epoxy_deps += [ opengl32_dep, gdi32_dep ]
 endif
 
+if build_egl
+  epoxy_deps += [ egl_dep.partial_dependency(compile_args: true), ]
+endif
+
 libepoxy = library(
   'epoxy',
   sources: epoxy_sources + epoxy_headers,


### PR DESCRIPTION
Although libepoxy includes EGL as its (optional) dependency, it does not
respect the include directory flags required by that dependency.  On
some platforms like Broadcom, this path is non-standard and libepoxy
needs to take that into account.

This patch ensures that libepoxy includes any flags for the platform
EGL.