### PR TITLE
meson.build: Fallback from libGL to libOpenGL when GLX is disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -164,6 +164,9 @@ endif
 # Dependencies
 dl_dep = cc.find_library('dl', required: false)
 gl_dep = dependency('gl', required: false)
+if not gl_dep.found() and not build_glx
+	gl_dep = dependency('opengl', required: false)
+endif
 egl_dep = dependency('egl', required: false)
 
 # Optional dependencies for tests

--- a/meson.build
+++ b/meson.build
@@ -165,7 +165,7 @@ endif
 dl_dep = cc.find_library('dl', required: false)
 gl_dep = dependency('gl', required: false)
 if not gl_dep.found() and not build_glx
-	gl_dep = dependency('opengl', required: false)
+  gl_dep = dependency('opengl', required: false)
 endif
 egl_dep = dependency('egl', required: false)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -93,7 +93,7 @@ libepoxy_dep = declare_dependency(
 # pkg-config file, for consumers of Epoxy
 gl_reqs = []
 if gl_dep.found() and gl_dep.type_name() == 'pkgconfig'
-  gl_reqs += 'gl'
+  gl_reqs += gl_dep.name()
 endif
 if build_egl and egl_dep.found() and egl_dep.type_name() == 'pkgconfig'
   gl_reqs += 'egl'


### PR DESCRIPTION
This change allows to build & use libepoxy in a wayland environment without libX11 (as libGL.so depends on it for glx).

There is also a separated "glx" library but that would require more changes to the meson code and I'm not sure if it would be useful to libepoxy.