### PR TITLE
Fix build if EGL/X11 headers are in a custom prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -165,9 +165,11 @@ endif
 dl_dep = cc.find_library('dl', required: false)
 gl_dep = dependency('gl', required: false)
 egl_dep = dependency('egl', required: false)
+elg_headers_dep = egl_dep.partial_dependency(compile_args: true, includes: true)
 
 # Optional dependencies for tests
 x11_dep = dependency('x11', required: false)
+x11_headers_dep = x11_dep.partial_dependency(compile_args: true, includes: true)
 
 # GLES v2 and v1 may have pkg-config files, courtesy of downstream
 # packagers; let's check those first, and fall back to find_library()

--- a/src/meson.build
+++ b/src/meson.build
@@ -59,6 +59,12 @@ epoxy_deps = [ dl_dep, ]
 if host_system == 'windows'
   epoxy_deps += [ opengl32_dep, gdi32_dep ]
 endif
+if enable_x11
+  epoxy_deps += [ x11_headers_dep, ]
+endif
+if build_egl
+  epoxy_deps += [ elg_headers_dep, ]
+endif
 
 libepoxy = library(
   'epoxy',


### PR DESCRIPTION
Currently the build works on most systems since these headers are
usually installed in the same directory as other dependencies or in
the default include directory. However, on some platforms the X11/GL
headers are installed to a different prefix, and then the build fails
due to missing includes.