### PR TITLE
fix error: use of undeclared identifier 'OPENGL_LIB'

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -683,7 +683,11 @@ epoxy_load_gl(void)
 #endif
 
     if (!api.gl_handle) {
+#if defined(OPENGL_LIB)
         fprintf(stderr, "Couldn't open %s or %s\n", GLX_LIB, OPENGL_LIB);
+#else
+        fprintf(stderr, "Couldn't open %s\n", GLX_LIB);
+#endif
         abort();
     }
 


### PR DESCRIPTION
at epoxy/src/dispatch_common.c:690 in LibreOffice android build with
libepoxy-1.5.9