### PR TITLE
Fix Win32 multithread dispatching bugs.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,6 +151,8 @@ if libtype == 'shared'
     conf.set('EPOXY_PUBLIC', '__attribute__((visibility("default"))) extern')
     visibility_cflags += [ '-fvisibility=hidden' ]
   endif
+else
+  conf.set('EPOXY_STATIC_BUILD', true)
 endif
 
 # The inline keyword is available only for C++ in MSVC.

--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -22,7 +22,11 @@
  */
 
 #include "config.h"
-
+#ifdef __GNUC__
+#define EPOXY_THREADLOCAL __thread
+#elif defined (_MSC_VER)
+#define EPOXY_THREADLOCAL __declspec(thread)
+#endif
 #ifdef _WIN32
 #define PLATFORM_HAS_EGL ENABLE_EGL
 #define PLATFORM_HAS_GLX ENABLE_GLX

--- a/src/dispatch_wgl.c
+++ b/src/dispatch_wgl.c
@@ -89,6 +89,8 @@ epoxy_handle_external_wglMakeCurrent(void)
     }
 }
 
+#ifndef EPOXY_STATIC_BUILD
+
 /**
  * This global symbol is apparently looked up by Windows when loading
  * a DLL, but it doesn't declare the prototype.
@@ -140,6 +142,7 @@ DllMain(HINSTANCE dll, DWORD reason, LPVOID reserved)
 
     return TRUE;
 }
+#endif
 
 WRAPPER_VISIBILITY (BOOL)
 WRAPPER(epoxy_wglMakeCurrent)(HDC hdc, HGLRC hglrc)

--- a/src/gen_dispatch.py
+++ b/src/gen_dispatch.py
@@ -784,8 +784,10 @@ class Generator(object):
         self.outln('')
         self.outln('#ifdef __GNUC__')
         self.outln('#define EPOXY_NOINLINE __attribute__((noinline))')
+        self.outln('#define EPOXY_THREADLOCAL __thread')
         self.outln('#elif defined (_MSC_VER)')
         self.outln('#define EPOXY_NOINLINE __declspec(noinline)')
+        self.outln('#define EPOXY_THREADLOCAL __declspec(thread)')
         self.outln('#endif')
 
         self.outln('struct dispatch_table {')
@@ -824,6 +826,14 @@ class Generator(object):
         self.outln('};')
         self.outln('')
 
+        self.outln('#ifdef EPOXY_STATIC_BUILD')
+        self.outln('EPOXY_THREADLOCAL struct dispatch_table {0}_tls_data;'.format(self.target))
+        self.outln('static inline struct dispatch_table *')
+        self.outln('get_dispatch_table(void)')
+        self.outln('{')
+        self.outln('	return &{0}_tls_data;'.format(self.target))
+        self.outln('}')
+        self.outln('#else')
         self.outln('uint32_t {0}_tls_index;'.format(self.target))
         self.outln('uint32_t {0}_tls_size = sizeof(struct dispatch_table);'.format(self.target))
         self.outln('')
@@ -833,6 +843,7 @@ class Generator(object):
         self.outln('{')
         self.outln('	return TlsGetValue({0}_tls_index);'.format(self.target))
         self.outln('}')
+        self.outln('#endif')
         self.outln('')
 
         self.outln('void')


### PR DESCRIPTION
Using `__thread` (and `__declspec(thread)` on MSVC) to replace dirty DllMain hack and thus allowing static build (`-Ddefault_library=static`). (Possibly solving #200 issue.)
Also fixed race condition in dispatch table logic. Now on Win32 it will always use dispatch table. (#199 minimal reproducing example passed.)
