### PR TITLE
test: Fix dlwrap on riscv64

### DIFF
--- a/test/dlwrap.c
+++ b/test/dlwrap.c
@@ -237,6 +237,7 @@ dlwrap_real_dlsym(void *handle, const char *name)
          * In the meantime, I'll just keep augmenting this
          * hard-coded version list as people report bugs. */
         const char *version[] = {
+            "GLIBC_2.27",
             "GLIBC_2.17",
             "GLIBC_2.4",
             "GLIBC_2.3",


### PR DESCRIPTION
See [sysdeps/unix/sysv/linux/riscv/rv64/libdl.abilist](https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/riscv/rv64/libdl.abilist;h=33ff573df8748197102314b6ca7579e060c7b8ad) in glibc's source.