### PR TITLE
EGL: add _DARWIN_C_SOURCE defines

### DIFF
--- a/test/egl_epoxy_api.c
+++ b/test/egl_epoxy_api.c
@@ -29,6 +29,8 @@
 
 #ifdef __sun
 #define __EXTENSIONS__
+#elif defined(__APPLE__)
+#define _DARWIN_C_SOURCE
 #else
 #define _GNU_SOURCE
 #endif

--- a/test/egl_has_extension_nocontext.c
+++ b/test/egl_has_extension_nocontext.c
@@ -30,6 +30,8 @@
 
 #ifdef __sun
 #define __EXTENSIONS__
+#elif defined(__APPLE__)
+#define _DARWIN_C_SOURCE
 #else
 #define _GNU_SOURCE
 #endif

--- a/test/egl_without_glx.c
+++ b/test/egl_without_glx.c
@@ -30,7 +30,11 @@
  * test either a GLES1-only or a GLES2-only system.
  */
 
+#if defined(__APPLE__)
+#define _DARWIN_C_SOURCE
+#else
 #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
EGL module is lacking `_DARWIN_C_SOURCE` defines for Apple case, which leads to compilation errors. Those defines should be added.