### PR TITLE
meson: Override dependency to improve usage as a subproject

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -93,6 +93,7 @@ libepoxy_dep = declare_dependency(
     'epoxy_has_wgl': epoxy_has_wgl,
   },
 )
+meson.override_dependency('epoxy', libepoxy_dep)
 
 # We don't want to add these dependencies to the library, as they are
 # not needed when building Epoxy; we do want to add them to the generated


### PR DESCRIPTION
With this change, libepoxy can be consumed as a subproject without making any changes to the build files of a project. All you need to do is provide a wrap file with a `[provide]` section:

https://mesonbuild.com/Wrap-dependency-system-manual.html#provide-section

This is also necessary because otherwise projects need to hard-code the subproject name, which might be `libepoxy` when using `wrap-git` or `libepoxy-1.5.10` when using `wrap-file` (to build from a release tarball). This can cause conflicts between different subprojects that consume libepoxy differently.

Other projects like glib, cairo, pango, etc already do this.