### PR TITLE
Check for EGL support at runtime before calling into EGL functions

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -783,6 +783,9 @@ epoxy_egl_get_current_gl_context_api(void)
 {
     EGLint curapi;
 
+    if (!api.egl_handle)
+        return EGL_NONE;
+
     if (eglQueryContext(eglGetCurrentDisplay(), eglGetCurrentContext(),
 			EGL_CONTEXT_CLIENT_TYPE, &curapi) == EGL_FALSE) {
 	(void)eglGetError();


### PR DESCRIPTION
Libepoxy may be built with support for EGL, but may run on trimmed-down systems which do not expose EGL. Or it may run in a sandbox which doesn't expose the EGL library. Check for EGL support at runtime before calling into EGL functions

Fixes https://gitlab.com/inkscape/inkscape/-/issues/4031