### PR TITLE
Bump `khronos-registry` branch to last commit 

### DIFF
--- a/registry/egl.xml
+++ b/registry/egl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <!--
-    Copyright (c) 2013-2016 The Khronos Group Inc.
+    Copyright (c) 2013-2017 The Khronos Group Inc.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and/or associated documentation files (the
@@ -29,7 +29,7 @@
     together with documentation, schema, and Python generator scripts used
     to generate C header files for EGL, can be found in the Khronos Registry
     at
-        http://www.opengl.org/registry/
+        https://www.github.com/KhronosGroup/EGL-Registry
     -->
 
     <!-- SECTION: EGL type definitions. Does not include GL types. -->
@@ -38,6 +38,7 @@
         <type name="khrplatform">#include &lt;KHR/khrplatform.h&gt;</type>
         <type name="eglplatform" requires="khrplatform">#include &lt;EGL/eglplatform.h&gt;</type>
         <type name="khronos_utime_nanoseconds_t" requires="khrplatform"/>
+        <type name="khronos_stime_nanoseconds_t" requires="khrplatform"/>
         <type name="khronos_uint64_t" requires="khrplatform"/>
         <type name="khronos_ssize_t" requires="khrplatform"/>
         <type name="EGLNativeDisplayType" requires="eglplatform"/>
@@ -47,6 +48,7 @@
         <type name="NativeDisplayType" requires="eglplatform"/>
         <type name="NativePixmapType" requires="eglplatform"/>
         <type name="NativeWindowType" requires="eglplatform"/>
+        <type>struct <name>AHardwareBuffer</name>;</type>
         <!-- Dummy placeholders for non-EGL types -->
         <type name="Bool"/>
             <!-- These are actual EGL types.  -->
@@ -147,6 +149,7 @@
     <enums namespace="EGLDRMBufferUseMESAMask" type="bitmask" comment="EGL_DRM_BUFFER_USE_MESA bits">
         <enum value="0x00000001" name="EGL_DRM_BUFFER_USE_SCANOUT_MESA"/>
         <enum value="0x00000002" name="EGL_DRM_BUFFER_USE_SHARE_MESA"/>
+        <enum value="0x00000004" name="EGL_DRM_BUFFER_USE_CURSOR_MESA"/>
     </enums>
 
     <!-- Should be shared with GL, but aren't aren't since the
@@ -185,25 +188,25 @@
     </enums>
 
     <enums namespace="EGL" group="SpecialNumbers" vendor="ARB" comment="Tokens whose numeric value is intrinsically meaningful">
-        <enum value="((EGLint)-1)" name="EGL_DONT_CARE"/>
-        <enum value="((EGLint)-1)" name="EGL_UNKNOWN"/>
+        <enum value="EGL_CAST(EGLint,-1)" name="EGL_DONT_CARE"/>
+        <enum value="EGL_CAST(EGLint,-1)" name="EGL_UNKNOWN"/>
         <enum value="-1" name="EGL_NO_NATIVE_FENCE_FD_ANDROID"/>
         <enum value="0" name="EGL_DEPTH_ENCODING_NONE_NV"/>
-        <enum value="((EGLContext)0)" name="EGL_NO_CONTEXT"/>
-        <enum value="((EGLDeviceEXT)(0))" name="EGL_NO_DEVICE_EXT"/>
-        <enum value="((EGLDisplay)0)" name="EGL_NO_DISPLAY"/>
-        <enum value="((EGLImage)0)" name="EGL_NO_IMAGE"/>
-        <enum value="((EGLImageKHR)0)" name="EGL_NO_IMAGE_KHR"/>
-        <enum value="((EGLNativeDisplayType)0)" name="EGL_DEFAULT_DISPLAY"/>
-        <enum value="((EGLNativeFileDescriptorKHR)(-1))" name="EGL_NO_FILE_DESCRIPTOR_KHR"/>
-        <enum value="((EGLOutputLayerEXT)0)" name="EGL_NO_OUTPUT_LAYER_EXT"/>
-        <enum value="((EGLOutputPortEXT)0)" name="EGL_NO_OUTPUT_PORT_EXT"/>
-        <enum value="((EGLStreamKHR)0)" name="EGL_NO_STREAM_KHR"/>
-        <enum value="((EGLSurface)0)" name="EGL_NO_SURFACE"/>
-        <enum value="((EGLSync)0)" name="EGL_NO_SYNC"/>
-        <enum value="((EGLSyncKHR)0)" name="EGL_NO_SYNC_KHR" alias="EGL_NO_SYNC"/>
-        <enum value="((EGLSyncNV)0)" name="EGL_NO_SYNC_NV" alias="EGL_NO_SYNC"/>
-        <enum value="((EGLConfig)0)" name="EGL_NO_CONFIG_KHR"/>
+        <enum value="EGL_CAST(EGLContext,0)" name="EGL_NO_CONTEXT"/>
+        <enum value="EGL_CAST(EGLDeviceEXT,0)" name="EGL_NO_DEVICE_EXT"/>
+        <enum value="EGL_CAST(EGLDisplay,0)" name="EGL_NO_DISPLAY"/>
+        <enum value="EGL_CAST(EGLImage,0)" name="EGL_NO_IMAGE"/>
+        <enum value="EGL_CAST(EGLImageKHR,0)" name="EGL_NO_IMAGE_KHR"/>
+        <enum value="EGL_CAST(EGLNativeDisplayType,0)" name="EGL_DEFAULT_DISPLAY"/>
+        <enum value="EGL_CAST(EGLNativeFileDescriptorKHR,-1)" name="EGL_NO_FILE_DESCRIPTOR_KHR"/>
+        <enum value="EGL_CAST(EGLOutputLayerEXT,0)" name="EGL_NO_OUTPUT_LAYER_EXT"/>
+        <enum value="EGL_CAST(EGLOutputPortEXT,0)" name="EGL_NO_OUTPUT_PORT_EXT"/>
+        <enum value="EGL_CAST(EGLStreamKHR,0)" name="EGL_NO_STREAM_KHR"/>
+        <enum value="EGL_CAST(EGLSurface,0)" name="EGL_NO_SURFACE"/>
+        <enum value="EGL_CAST(EGLSync,0)" name="EGL_NO_SYNC"/>
+        <enum value="EGL_CAST(EGLSyncKHR,0)" name="EGL_NO_SYNC_KHR" alias="EGL_NO_SYNC"/>
+        <enum value="EGL_CAST(EGLSyncNV,0)" name="EGL_NO_SYNC_NV" alias="EGL_NO_SYNC"/>
+        <enum value="EGL_CAST(EGLConfig,0)" name="EGL_NO_CONFIG_KHR"/>
         <enum value="10000" name="EGL_DISPLAY_SCALING"/>
         <enum value="0xFFFFFFFFFFFFFFFF" name="EGL_FOREVER" type="ull"/>
         <enum value="0xFFFFFFFFFFFFFFFF" name="EGL_FOREVER_KHR" type="ull" alias="EGL_FOREVER"/>
@@ -465,8 +468,20 @@
             <unused start="0x3111" end="0x311F"/>
     </enums>
 
-    <enums namespace="EGL" start="0x3120" end="0x312F" vendor="AMD" comment="Reserved for David Garcia (Khronos bug 5149)">
-            <unused start="0x3120" end="0x312F"/>
+    <enums namespace="EGL" start="0x3120" end="0x312F" vendor="QCOM" comment="EGL_QCOM_create_image">
+        <enum value="0x3120" name="EGL_NEW_IMAGE_QCOM"/>
+        <enum value="0x3121" name="EGL_IMAGE_FORMAT_QCOM"/>
+        <enum value="0x3122" name="EGL_FORMAT_RGBA_8888_QCOM"/>
+        <enum value="0x3123" name="EGL_FORMAT_RGB_565_QCOM"/>
+        <enum value="0x3124" name="EGL_FORMAT_YUYV_QCOM"/>
+        <enum value="0x3125" name="EGL_FORMAT_UYVY_QCOM"/>
+        <enum value="0x3126" name="EGL_FORMAT_YV12_QCOM"/>
+        <enum value="0x3127" name="EGL_FORMAT_NV21_QCOM"/>
+        <enum value="0x3128" name="EGL_FORMAT_NV12_TILED_QCOM"/>
+        <enum value="0x3129" name="EGL_FORMAT_BGRA_8888_QCOM"/>
+        <enum value="0x312A" name="EGL_FORMAT_BGRX_8888_QCOM"/>
+            <unused start="0x312B" end="0x312E"/>
+        <enum value="0x312F" name="EGL_FORMAT_RGBX_8888_QCOM"/>
     </enums>
 
     <enums namespace="EGL" start="0x3130" end="0x313F" vendor="NV" comment="Reserved for Greg Prisament (Khronos bug 5166)">
@@ -496,8 +511,9 @@
         <enum value="0x3146" name="EGL_SYNC_NATIVE_FENCE_SIGNALED_ANDROID"/>
         <enum value="0x3147" name="EGL_FRAMEBUFFER_TARGET_ANDROID"/>
             <unused start="0x3148" end="0x314B"/>
-        <enum value="0x314C"     name="EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID"/>
-            <unused start="0x314D" end="0x314F"/>
+        <enum value="0x314C" name="EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID"/>
+        <enum value="0x314D" name="EGL_GL_COLORSPACE_DEFAULT_EXT"/>
+            <unused start="0x314E" end="0x314F"/>
     </enums>
 
     <enums namespace="EGL" start="0x3150" end="0x315F" vendor="NOK" comment="Reserved for Robert Palmer (Khronos bug 5368)">
@@ -532,8 +548,23 @@
         <enum value="0x31BF" name="EGL_LOSE_CONTEXT_ON_RESET_EXT" alias="EGL_LOSE_CONTEXT_ON_RESET"/>
     </enums>
 
-    <enums namespace="EGL" start="0x31C0" end="0x31CF" vendor="QCOM" comment="Reserved for Maurice Ribble (Khronos bug 6644) - EGL_QCOM_create_image spec TBD">
-            <unused start="0x31C0" end="0x31CF"/>
+    <enums namespace="EGL" start="0x31C0" end="0x31CF" vendor="QCOM" comment="Reserved for Maurice Ribble (Khronos bug 6644) - EGL_QCOM_create_image spec">
+        <enum value="0x31C0" name="EGL_FORMAT_R8_QCOM"/>
+        <enum value="0x31C1" name="EGL_FORMAT_RG88_QCOM"/>
+        <enum value="0x31C2" name="EGL_FORMAT_NV12_QCOM"/>
+        <enum value="0x31C3" name="EGL_FORMAT_SRGBX_8888_QCOM"/>
+        <enum value="0x31C4" name="EGL_FORMAT_SRGBA_8888_QCOM"/>
+        <enum value="0x31C5" name="EGL_FORMAT_YVYU_QCOM"/>
+        <enum value="0x31C6" name="EGL_FORMAT_VYUY_QCOM"/>
+        <enum value="0x31C7" name="EGL_FORMAT_IYUV_QCOM"/>
+        <enum value="0x31C8" name="EGL_FORMAT_RGB_888_QCOM"/>
+        <enum value="0x31C9" name="EGL_FORMAT_RGBA_5551_QCOM"/>
+        <enum value="0x31CA" name="EGL_FORMAT_RGBA_4444_QCOM"/>
+        <enum value="0x31CB" name="EGL_FORMAT_R_16_FLOAT_QCOM"/>
+        <enum value="0x31CC" name="EGL_FORMAT_RG_1616_FLOAT_QCOM"/>
+        <enum value="0x31CD" name="EGL_FORMAT_RGBA_16_FLOAT_QCOM"/>
+        <enum value="0x31CE" name="EGL_FORMAT_RGBA_1010102_QCOM"/>
+        <enum value="0x31CF" name="EGL_FORMAT_FLAG_QCOM"/>
     </enums>
 
     <enums namespace="EGL" start="0x31D0" end="0x31DF" vendor="MESA" comment="Reserved for Kristian H&#248;gsberg (Khronos bug 6757)">
@@ -613,7 +644,9 @@
         <enum value="0x322D" name="EGL_BAD_OUTPUT_LAYER_EXT"/>
         <enum value="0x322E" name="EGL_BAD_OUTPUT_PORT_EXT"/>
         <enum value="0x322F" name="EGL_SWAP_INTERVAL_EXT"/>
-            <unused start="0x3230" end="0x3232"/>
+        <enum value="0x3230" name="EGL_TRIPLE_BUFFER_NV"/>
+        <enum value="0x3231" name="EGL_QUADRUPLE_BUFFER_NV"/>
+            <unused start="0x3232"/>
         <enum value="0x3233" name="EGL_DRM_DEVICE_FILE_EXT"/>
         <enum value="0x3234" name="EGL_DRM_CRTC_EXT"/>
         <enum value="0x3235" name="EGL_DRM_PLANE_EXT"/>
@@ -701,8 +734,23 @@
             <unused start="0x32A2" end="0x32AF"/>
     </enums>
 
-    <enums namespace="EGL" start="0x32B0" end="0x32BF" vendor="QCOM" comment="Reserved for Jeff Vigil (Bug 10663) - EGL_QCOM_lock_image spec TBD">
-            <unused start="0x32B0" end="0x32BF"/>
+    <enums namespace="EGL" start="0x32B0" end="0x32BF" vendor="QCOM" comment="Reserved for Jeff Vigil (Bug 10663) - EGL_QCOM_lock_image2 spec">
+        <enum value="0x32B0" name="EGL_IMAGE_NUM_PLANES_QCOM"/>
+        <enum value="0x32B1" name="EGL_IMAGE_PLANE_PITCH_0_QCOM"/>
+        <enum value="0x32B2" name="EGL_IMAGE_PLANE_PITCH_1_QCOM"/>
+        <enum value="0x32B3" name="EGL_IMAGE_PLANE_PITCH_2_QCOM"/>
+        <enum value="0x32B4" name="EGL_IMAGE_PLANE_DEPTH_0_QCOM"/>
+        <enum value="0x32B5" name="EGL_IMAGE_PLANE_DEPTH_1_QCOM"/>
+        <enum value="0x32B6" name="EGL_IMAGE_PLANE_DEPTH_2_QCOM"/>
+        <enum value="0x32B7" name="EGL_IMAGE_PLANE_WIDTH_0_QCOM"/>
+        <enum value="0x32B8" name="EGL_IMAGE_PLANE_WIDTH_1_QCOM"/>
+        <enum value="0x32B9" name="EGL_IMAGE_PLANE_WIDTH_2_QCOM"/>
+        <enum value="0x32BA" name="EGL_IMAGE_PLANE_HEIGHT_0_QCOM"/>
+        <enum value="0x32BB" name="EGL_IMAGE_PLANE_HEIGHT_1_QCOM"/>
+        <enum value="0x32BC" name="EGL_IMAGE_PLANE_HEIGHT_2_QCOM"/>
+        <enum value="0x32BD" name="EGL_IMAGE_PLANE_POINTER_0_QCOM"/>
+        <enum value="0x32BE" name="EGL_IMAGE_PLANE_POINTER_1_QCOM"/>
+        <enum value="0x32BF" name="EGL_IMAGE_PLANE_POINTER_2_QCOM"/>
     </enums>
 
     <enums namespace="EGL" start="0x32C0" end="0x32CF" vendor="Vivante" comment="Reserved for Yanjun Zhang (Bug 11498)">
@@ -710,8 +758,10 @@
             <unused start="0x32C1" end="0x32CF"/>
     </enums>
 
-    <enums namespace="EGL" start="0x32D0" end="0x32EF" vendor="QCOM" comment="Reserved for Jeff Vigil (Bug 11735) - EGL_QCOM_gpu_perf spec TBD + Bug 12286 - EGL_QCOM_content_protection spec TBD">
-            <unused start="0x32D0" end="0x32EF"/>
+    <enums namespace="EGL" start="0x32D0" end="0x32EF" vendor="QCOM" comment="Reserved for Jeff Vigil (Bug 11735) - EGL_QCOM_gpu_perf spec">
+        <enum value="0x32D0" name="EGL_GPU_PERF_HINT_QCOM"/>
+        <enum value="0x32D1" name="EGL_HINT_PERSISTENT_QCOM"/>
+            <unused start="0x32D2" end="0x32EF"/>
     </enums>
 
     <enums namespace="EGL" start="0x32F0" end="0x32FF" vendor="BCOM" comment="Reserved for Gary Sweet, Broadcom (Bug 12870)">
@@ -768,7 +818,8 @@
         <enum value="0x3339" name="EGL_COLOR_COMPONENT_TYPE_EXT"/>
         <enum value="0x333A" name="EGL_COLOR_COMPONENT_TYPE_FIXED_EXT"/>
         <enum value="0x333B" name="EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT"/>
-            <unused start="0x333C" end="0x333E"/>
+        <enum value="0x333C" name="EGL_DRM_MASTER_FD_EXT"/>
+            <unused start="0x333D" end="0x333E"/>
         <enum value="0x333F" name="EGL_GL_COLORSPACE_BT2020_LINEAR_EXT"/>
         <enum value="0x3340" name="EGL_GL_COLORSPACE_BT2020_PQ_EXT"/>
         <enum value="0x3341" name="EGL_SMPTE2086_DISPLAY_PRIMARY_RX_EXT"/>
@@ -781,13 +832,38 @@
         <enum value="0x3348" name="EGL_SMPTE2086_WHITE_POINT_Y_EXT"/>
         <enum value="0x3349" name="EGL_SMPTE2086_MAX_LUMINANCE_EXT"/>
         <enum value="0x334A" name="EGL_SMPTE2086_MIN_LUMINANCE_EXT"/>
+        <enum value="50000"  name="EGL_METADATA_SCALING_EXT"/>
             <unused start="0x334B"/>
         <enum value="0x334C" name="EGL_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV"/>
         <enum value="0x334D" name="EGL_STREAM_CROSS_OBJECT_NV"/>
         <enum value="0x334E" name="EGL_STREAM_CROSS_DISPLAY_NV"/>
         <enum value="0x334F" name="EGL_STREAM_CROSS_SYSTEM_NV"/>
         <enum value="0x3350" name="EGL_GL_COLORSPACE_SCRGB_LINEAR_EXT"/>
-            <unused start="0x3351" end="0x339F"/>
+        <enum value="0x3351" name="EGL_GL_COLORSPACE_SCRGB_EXT"/>
+        <enum value="0x3352" name="EGL_TRACK_REFERENCES_KHR"/>
+            <unused start="0x3353" end="0x3356"/>
+        <enum value="0x3357" name="EGL_CONTEXT_PRIORITY_REALTIME_NV"/>
+            <unused start="0x3358" end="0x335F"/>
+        <enum value="0x3360" name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
+        <enum value="0x3361" name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
+        <enum value="0x3362" name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
+        <enum value="0x3363" name="EGL_GL_COLORSPACE_DISPLAY_P3_EXT"/>
+        <enum value="0x3364" name="EGL_SYNC_CLIENT_EXT"/>
+        <enum value="0x3365" name="EGL_SYNC_CLIENT_SIGNAL_EXT"/>
+        <enum value="0x3366" name="EGL_STREAM_FRAME_ORIGIN_X_NV"/>
+        <enum value="0x3367" name="EGL_STREAM_FRAME_ORIGIN_Y_NV"/>
+        <enum value="0x3368" name="EGL_STREAM_FRAME_MAJOR_AXIS_NV"/>
+        <enum value="0x3369" name="EGL_CONSUMER_AUTO_ORIENTATION_NV"/>
+        <enum value="0x336A" name="EGL_PRODUCER_AUTO_ORIENTATION_NV"/>
+        <enum value="0x336B" name="EGL_LEFT_NV"/>
+        <enum value="0x336C" name="EGL_RIGHT_NV"/>
+        <enum value="0x336D" name="EGL_TOP_NV"/>
+        <enum value="0x336E" name="EGL_BOTTOM_NV"/>
+        <enum value="0x336F" name="EGL_X_AXIS_NV"/>
+        <enum value="0x3370" name="EGL_Y_AXIS_NV"/>
+        <enum value="0x3371" name="EGL_STREAM_DMA_NV"/>
+        <enum value="0x3372" name="EGL_STREAM_DMA_SERVER_NV"/>
+            <unused start="0x3373" end="0x339F"/>
     </enums>
 
     <enums namespace="EGL" start="0x33A0" end="0x33AF" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 13175)">
@@ -817,12 +893,73 @@
             <unused start="0x33C0" end="0x33DF"/>
     </enums>
 
-    <enums namespace="EGL" start="0x33E0" end="0x342F" vendor="QCOM" comment="Reserved for Jeff Vigil (Bugs 10663,13364)">
-            <unused start="0x33E0" end="0x342F"/>
+    <enums namespace="EGL" start="0x33E0" end="0x342F" vendor="QCOM" comment="EGL_QCOM_create_image and EGL_QCOM_lock_image2">
+        <enum value="0x33E0" name="EGL_FORMAT_FLAG_UBWC_QCOM"/>
+        <enum value="0x33E1" name="EGL_FORMAT_FLAG_MACROTILE_QCOM"/>
+        <enum value="0x33E2" name="EGL_FORMAT_ASTC_4X4_QCOM"/>
+        <enum value="0x33E3" name="EGL_FORMAT_ASTC_5X4_QCOM"/>
+        <enum value="0x33E4" name="EGL_FORMAT_ASTC_5X5_QCOM"/>
+        <enum value="0x33E5" name="EGL_FORMAT_ASTC_6X5_QCOM"/>
+        <enum value="0x33E6" name="EGL_FORMAT_ASTC_6X6_QCOM"/>
+        <enum value="0x33E7" name="EGL_FORMAT_ASTC_8X5_QCOM"/>
+        <enum value="0x33E8" name="EGL_FORMAT_ASTC_8X6_QCOM"/>
+        <enum value="0x33E9" name="EGL_FORMAT_ASTC_8X8_QCOM"/>
+        <enum value="0x33EA" name="EGL_FORMAT_ASTC_10X5_QCOM"/>
+        <enum value="0x33EB" name="EGL_FORMAT_ASTC_10X6_QCOM"/>
+        <enum value="0x33EC" name="EGL_FORMAT_ASTC_10X8_QCOM"/>
+        <enum value="0x33ED" name="EGL_FORMAT_ASTC_10X10_QCOM"/>
+        <enum value="0x33EE" name="EGL_FORMAT_ASTC_12X10_QCOM"/>
+        <enum value="0x33EF" name="EGL_FORMAT_ASTC_12X12_QCOM"/>
+        <enum value="0x3400" name="EGL_FORMAT_ASTC_4X4_SRGB_QCOM"/>
+        <enum value="0x3401" name="EGL_FORMAT_ASTC_5X4_SRGB_QCOM"/>
+        <enum value="0x3402" name="EGL_FORMAT_ASTC_5X5_SRGB_QCOM"/>
+        <enum value="0x3403" name="EGL_FORMAT_ASTC_6X5_SRGB_QCOM"/>
+        <enum value="0x3404" name="EGL_FORMAT_ASTC_6X6_SRGB_QCOM"/>
+        <enum value="0x3405" name="EGL_FORMAT_ASTC_8X5_SRGB_QCOM"/>
+        <enum value="0x3406" name="EGL_FORMAT_ASTC_8X6_SRGB_QCOM"/>
+        <enum value="0x3407" name="EGL_FORMAT_ASTC_8X8_SRGB_QCOM"/>
+        <enum value="0x3408" name="EGL_FORMAT_ASTC_10X5_SRGB_QCOM"/>
+        <enum value="0x3409" name="EGL_FORMAT_ASTC_10X6_SRGB_QCOM"/>
+        <enum value="0x340A" name="EGL_FORMAT_ASTC_10X8_SRGB_QCOM"/>
+        <enum value="0x340B" name="EGL_FORMAT_ASTC_10X10_SRGB_QCOM"/>
+        <enum value="0x340C" name="EGL_FORMAT_ASTC_12X10_SRGB_QCOM"/>
+        <enum value="0x340D" name="EGL_FORMAT_ASTC_12X12_SRGB_QCOM"/>
+        <enum value="0x340E" name="EGL_FORMAT_TP10_QCOM"/>
+        <enum value="0x340F" name="EGL_FORMAT_NV12_Y_QCOM"/>
+        <enum value="0x3410" name="EGL_FORMAT_NV12_UV_QCOM"/>
+        <enum value="0x3411" name="EGL_FORMAT_NV21_VU_QCOM"/>
+        <enum value="0x3412" name="EGL_FORMAT_NV12_4R_QCOM"/>
+        <enum value="0x3413" name="EGL_FORMAT_NV12_4R_Y_QCOM"/>
+        <enum value="0x3414" name="EGL_FORMAT_NV12_4R_UV_QCOM"/>
+        <enum value="0x3415" name="EGL_FORMAT_P010_QCOM"/>
+        <enum value="0x3416" name="EGL_FORMAT_P010_Y_QCOM"/>
+        <enum value="0x3417" name="EGL_FORMAT_P010_UV_QCOM"/>
+        <enum value="0x3418" name="EGL_FORMAT_TP10_Y_QCOM"/>
+        <enum value="0x3419" name="EGL_FORMAT_TP10_UV_QCOM"/>
+            <unused start="0x341A" end="0x341F"/>
+        <enum value="0x3420" name="EGL_GENERIC_TOKEN_1_QCOM"/>
+        <enum value="0x3421" name="EGL_GENERIC_TOKEN_2_QCOM"/>
+        <enum value="0x3422" name="EGL_GENERIC_TOKEN_3_QCOM"/>
+            <unused start="0x3423" end="0x342F"/>
     </enums>
 
     <enums namespace="EGL" start="0x3430" end="0x343F" vendor="ANDROID" comment="Reserved for Pablo Ceballos (Bug 15874)">
-            <unused start="0x3430" end="0x343F"/>
+        <enum value="EGL_CAST(EGLnsecsANDROID,-2)" name="EGL_TIMESTAMP_PENDING_ANDROID"/>
+        <enum value="EGL_CAST(EGLnsecsANDROID,-1)" name="EGL_TIMESTAMP_INVALID_ANDROID"/>
+        <enum value="0x3430" name="EGL_TIMESTAMPS_ANDROID"/>
+        <enum value="0x3431" name="EGL_COMPOSITE_DEADLINE_ANDROID"/>
+        <enum value="0x3432" name="EGL_COMPOSITE_INTERVAL_ANDROID"/>
+        <enum value="0x3433" name="EGL_COMPOSITE_TO_PRESENT_LATENCY_ANDROID"/>
+        <enum value="0x3434" name="EGL_REQUESTED_PRESENT_TIME_ANDROID"/>
+        <enum value="0x3435" name="EGL_RENDERING_COMPLETE_TIME_ANDROID"/>
+        <enum value="0x3436" name="EGL_COMPOSITION_LATCH_TIME_ANDROID"/>
+        <enum value="0x3437" name="EGL_FIRST_COMPOSITION_START_TIME_ANDROID"/>
+        <enum value="0x3438" name="EGL_LAST_COMPOSITION_START_TIME_ANDROID"/>
+        <enum value="0x3439" name="EGL_FIRST_COMPOSITION_GPU_FINISHED_TIME_ANDROID"/>
+        <enum value="0x343A" name="EGL_DISPLAY_PRESENT_TIME_ANDROID"/>
+        <enum value="0x343B" name="EGL_DEQUEUE_READY_TIME_ANDROID"/>
+        <enum value="0x343C" name="EGL_READS_DONE_TIME_ANDROID"/>
+            <unused start="0x343D" end="0x343F"/>
     </enums>
 
     <enums namespace="EGL" start="0x3440" end="0x344F" vendor="ANDROID" comment="Reserved for Kristian Kristensen (Bug 16033)">
@@ -844,6 +981,28 @@
             <unused start="0x3450" end="0x345F"/>
     </enums>
 
+    <enums namespace="EGL" start="0x3460" end="0x346F" vendor="COREAVI" comment="Reserved for Daniel Herring (Bug 16162)">
+        <enum value="0x3460" name="EGL_PRIMARY_COMPOSITOR_CONTEXT_EXT"/>
+        <enum value="0x3461" name="EGL_EXTERNAL_REF_ID_EXT"/>
+        <enum value="0x3462" name="EGL_COMPOSITOR_DROP_NEWEST_FRAME_EXT"/>
+        <enum value="0x3463" name="EGL_COMPOSITOR_KEEP_NEWEST_FRAME_EXT"/>
+        <enum value="0x3464" name="EGL_FRONT_BUFFER_EXT"/>
+        <unused start="0x3465" end="0x346F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3470" end="0x347F" vendor="EXT" comment="Reserved for Daniel Stone (PR 14)">
+        <enum value="0x3470" name="EGL_IMPORT_SYNC_TYPE_EXT"/>
+        <enum value="0x3471" name="EGL_IMPORT_IMPLICIT_SYNC_EXT"/>
+        <enum value="0x3472" name="EGL_IMPORT_EXPLICIT_SYNC_EXT"/>
+    </enums>
+    <enums namespace="EGL" start="0x3480" end="0x348F" vendor="ANGLE" comment="Reserved for Courtney Goeltzenleuchter - ANGLE (gitlab EGL bug 7)">
+            <unused start="0x3480" end="0x348F"/>
+    </enums>
+    <enums namespace="EGL" start="0x3490" end="0x349F" vendor="EXT" comment="Reserved for Courtney Goeltzenleuchter - Android (gitlab EGL bug 69)">
+        <enum value="0x3490" name="EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT"/>
+            <unused start="0x3491" end="0x349F"/>
+    </enums>
+
 <!-- Please remember that new enumerant allocations must be obtained by
      request to the Khronos API registrar (see comments at the top of this
      file) File requests in the Khronos Bugzilla, EGL project, Registry
@@ -853,8 +1012,8 @@
 
 <!-- Reservable for future use. To generate a new range, allocate multiples
      of 16 starting at the lowest available point in this block. -->
-    <enums namespace="EGL" start="0x3460" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
-            <unused start="0x3460" end="0x3FFF"/>
+    <enums namespace="EGL" start="0x34A0" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
+            <unused start="0x34A0" end="0x3FFF"/>
     </enums>
 
     <enums namespace="EGL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with GL.">
@@ -884,6 +1043,12 @@
             <param><ptype>EGLConfig</ptype> *<name>configs</name></param>
             <param><ptype>EGLint</ptype> <name>config_size</name></param>
             <param><ptype>EGLint</ptype> *<name>num_config</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglClientSignalSyncEXT</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSync</ptype> <name>sync</name></param>
+            <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
         </command>
         <command>
             <proto><ptype>EGLint</ptype> <name>eglClientWaitSync</name></proto>
@@ -1168,7 +1333,19 @@
             <param><ptype>EGLNativeDisplayType</ptype> <name>display_id</name></param>
         </command>
         <command>
+            <proto>char *<name>eglGetDisplayDriverConfig</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+        </command>
+        <command>
+            <proto>const char *<name>eglGetDisplayDriverName</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+        </command>
+        <command>
             <proto><ptype>EGLint</ptype> <name>eglGetError</name></proto>
+        </command>
+        <command>
+            <proto><ptype>EGLClientBuffer</ptype> <name>eglGetNativeClientBufferANDROID</name></proto>
+            <param>const struct <ptype>AHardwareBuffer</ptype> *<name>buffer</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglGetOutputLayersEXT</name></proto>
@@ -1289,6 +1466,41 @@
             <param><ptype>EGLnsecsANDROID</ptype> <name>time</name></param>
         </command>
         <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetCompositorTimingSupportedANDROID</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLint</ptype> <name>name</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetCompositorTimingANDROID</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLint</ptype> <name>numTimestamps</name></param>
+            <param> const <ptype>EGLint</ptype> *<name>names</name></param>
+            <param><ptype>EGLnsecsANDROID</ptype> *<name>values</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetNextFrameIdANDROID</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLuint64KHR</ptype> *<name>frameId</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetFrameTimestampSupportedANDROID</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLint</ptype> <name>timestamp</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetFrameTimestampsANDROID</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLuint64KHR</ptype> <name>frameId</name></param>
+            <param><ptype>EGLint</ptype> <name>numTimestamps</name></param>
+            <param> const <ptype>EGLint</ptype> *<name>timestamps</name></param>
+            <param><ptype>EGLnsecsANDROID</ptype> *<name>values</name></param>
+        </command>
+        <command>
             <proto><ptype>EGLenum</ptype> <name>eglQueryAPI</name></proto>
         </command>
         <command>
@@ -1325,29 +1537,36 @@
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLint</ptype> <name>attribute</name></param>
             <param><ptype>EGLAttrib</ptype> *<name>value</name></param>
+            <alias name="eglQueryDisplayAttribKHR"/>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglQueryDisplayAttribKHR</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLint</ptype> <name>name</name></param>
+            <param><ptype>EGLAttrib</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQueryDisplayAttribNV</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLint</ptype> <name>attribute</name></param>
             <param><ptype>EGLAttrib</ptype> *<name>value</name></param>
-            <alias name="eglQueryDisplayAttribEXT"/>
+            <alias name="eglQueryDisplayAttribKHR"/>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQueryDmaBufFormatsEXT</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLint</ptype> <name>max_formats</name></param>
-            <param><ptype>EGLint</ptype> <name>*formats</name></param>
-            <param><ptype>EGLint</ptype> <name>*num_formats</name></param>
+            <param><ptype>EGLint</ptype> *<name>formats</name></param>
+            <param><ptype>EGLint</ptype> *<name>num_formats</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQueryDmaBufModifiersEXT</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLint</ptype> <name>format</name></param>
             <param><ptype>EGLint</ptype> <name>max_modifiers</name></param>
-            <param><ptype>EGLuint64KHR</ptype> <name>*modifiers</name></param>
-            <param><ptype>EGLBoolean</ptype> <name>*external_only</name></param>
-            <param><ptype>EGLint</ptype> <name>*num_modifiers</name></param>
+            <param><ptype>EGLuint64KHR</ptype> *<name>modifiers</name></param>
+            <param><ptype>EGLBoolean</ptype> *<name>external_only</name></param>
+            <param><ptype>EGLint</ptype> *<name>num_modifiers</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQueryNativeDisplayNV</name></proto>
@@ -1537,7 +1756,7 @@
             <proto><ptype>EGLBoolean</ptype> <name>eglStreamConsumerGLTextureExternalAttribsNV</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
-            <param><ptype>EGLAttrib</ptype> <name>*attrib_list</name></param>
+            <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglStreamConsumerOutputEXT</name></proto>
@@ -1555,6 +1774,11 @@
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
             <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglStreamFlushNV</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglSurfaceAttrib</name></proto>
@@ -1611,6 +1835,12 @@
             <param><ptype>EGLSurface</ptype> <name>surface</name></param>
         </command>
         <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglUnsignalSyncEXT</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSync</ptype> <name>sync</name></param>
+            <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
+        </command>
+        <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglWaitClient</name></proto>
         </command>
         <command>
@@ -1631,6 +1861,44 @@
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLSyncKHR</ptype> <name>sync</name></param>
             <param><ptype>EGLint</ptype> <name>flags</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSetContextListEXT</name></proto>
+            <param>const <ptype>EGLint</ptype> *<name>external_ref_ids</name></param>
+            <param><ptype>EGLint</ptype> <name>num_entries</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSetContextAttributesEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_ref_id</name></param>
+            <param>const <ptype>EGLint</ptype> *<name>context_attributes</name></param>
+            <param><ptype>EGLint</ptype> <name>num_entries</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSetWindowListEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_ref_id</name></param>
+            <param>const <ptype>EGLint</ptype> *<name>external_win_ids</name></param>
+            <param><ptype>EGLint</ptype> <name>num_entries</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSetWindowAttributesEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
+            <param>const <ptype>EGLint</ptype> *<name>window_attributes</name></param>
+            <param><ptype>EGLint</ptype> <name>num_entries</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorBindTexWindowEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSetSizeEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
+            <param><ptype>EGLint</ptype> <name>width</name></param>
+            <param><ptype>EGLint</ptype> <name>height</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSwapPolicyEXT</name></proto>
+            <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
+            <param><ptype>EGLint</ptype> <name>policy</name></param>
         </command>
     </commands>
 
@@ -1918,6 +2186,11 @@
                 <enum name="EGL_FRAMEBUFFER_TARGET_ANDROID"/>
             </require>
         </extension>
+        <extension name="EGL_ANDROID_get_native_client_buffer" supported="egl">
+            <require>
+                <command name="eglGetNativeClientBufferANDROID"/>
+            </require>
+        </extension>
         <extension name="EGL_ANDROID_front_buffer_auto_refresh" supported="egl">
             <require>
                 <enum name="EGL_FRONT_BUFFER_AUTO_REFRESH_ANDROID"/>
@@ -1942,11 +2215,36 @@
                 <command name="eglPresentationTimeANDROID"/>
             </require>
         </extension>
+        <extension name="EGL_ANDROID_get_frame_timestamps" supported="egl">
+            <require>
+                <enum name="EGL_TIMESTAMP_PENDING_ANDROID"/>
+                <enum name="EGL_TIMESTAMP_INVALID_ANDROID"/>
+                <enum name="EGL_TIMESTAMPS_ANDROID"/>
+                <enum name="EGL_COMPOSITE_DEADLINE_ANDROID"/>
+                <enum name="EGL_COMPOSITE_INTERVAL_ANDROID"/>
+                <enum name="EGL_COMPOSITE_TO_PRESENT_LATENCY_ANDROID"/>
+                <enum name="EGL_REQUESTED_PRESENT_TIME_ANDROID"/>
+                <enum name="EGL_RENDERING_COMPLETE_TIME_ANDROID"/>
+                <enum name="EGL_COMPOSITION_LATCH_TIME_ANDROID"/>
+                <enum name="EGL_FIRST_COMPOSITION_START_TIME_ANDROID"/>
+                <enum name="EGL_LAST_COMPOSITION_START_TIME_ANDROID"/>
+                <enum name="EGL_FIRST_COMPOSITION_GPU_FINISHED_TIME_ANDROID"/>
+                <enum name="EGL_DISPLAY_PRESENT_TIME_ANDROID"/>
+                <enum name="EGL_DEQUEUE_READY_TIME_ANDROID"/>
+                <enum name="EGL_READS_DONE_TIME_ANDROID"/>
+                <command name="eglGetCompositorTimingSupportedANDROID"/>
+                <command name="eglGetCompositorTimingANDROID"/>
+                <command name="eglGetNextFrameIdANDROID"/>
+                <command name="eglGetFrameTimestampSupportedANDROID"/>
+                <command name="eglGetFrameTimestampsANDROID"/>
+            </require>
+        </extension>
         <extension name="EGL_ANDROID_recordable" supported="egl">
             <require>
                 <enum name="EGL_RECORDABLE_ANDROID"/>
             </require>
         </extension>
+        <extension name="EGL_ANDROID_GLES_layers" supported="egl"/>
         <extension name="EGL_ANGLE_d3d_share_handle_client_buffer" supported="egl">
             <require>
                 <enum name="EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE"/>
@@ -1989,6 +2287,13 @@
             </require>
         </extension>
         <extension name="EGL_EXT_client_extensions" supported="egl"/>
+        <extension name="EGL_EXT_client_sync" supported="egl">
+            <require>
+                <enum name="EGL_SYNC_CLIENT_EXT"/>
+                <enum name="EGL_SYNC_CLIENT_SIGNAL_EXT"/>
+                <command name="eglClientSignalSyncEXT"/>
+            </require>
+        </extension>
         <extension name="EGL_EXT_create_context_robustness" supported="egl">
             <require>
                 <enum name="EGL_CONTEXT_OPENGL_ROBUST_ACCESS_EXT"/>
@@ -2011,6 +2316,7 @@
         <extension name="EGL_EXT_device_drm" supported="egl">
             <require>
                 <enum name="EGL_DRM_DEVICE_FILE_EXT"/>
+                <enum name="EGL_DRM_MASTER_FD_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_device_enumeration" supported="egl">
@@ -2043,9 +2349,29 @@
                 <enum name="EGL_GL_COLORSPACE_BT2020_PQ_EXT"/>
             </require>
         </extension>
+        <extension name="EGL_EXT_gl_colorspace_scrgb" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_SCRGB_EXT"/>
+            </require>
+        </extension>
         <extension name="EGL_EXT_gl_colorspace_scrgb_linear" supported="egl">
             <require>
                 <enum name="EGL_GL_COLORSPACE_SCRGB_LINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3_linear" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_display_p3_passthrough" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_image_dma_buf_import" supported="egl">
@@ -2089,6 +2415,12 @@
                 <enum name="EGL_DMA_BUF_PLANE3_MODIFIER_HI_EXT"/>
                 <command name="eglQueryDmaBufFormatsEXT"/>
                 <command name="eglQueryDmaBufModifiersEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_image_gl_colorspace" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE"/>
+                <enum name="EGL_GL_COLORSPACE_DEFAULT_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_multiview_window" supported="egl">
@@ -2185,11 +2517,17 @@
                 <enum name="EGL_SMPTE2086_WHITE_POINT_Y_EXT"/>
                 <enum name="EGL_SMPTE2086_MAX_LUMINANCE_EXT"/>
                 <enum name="EGL_SMPTE2086_MIN_LUMINANCE_EXT"/>
+                <enum name="EGL_METADATA_SCALING_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_swap_buffers_with_damage" supported="egl">
             <require>
                 <command name="eglSwapBuffersWithDamageEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_sync_reuse" supported="egl">
+            <require>
+                <command name="eglUnsignalSyncEXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_yuv_surface" supported="egl">
@@ -2322,6 +2660,12 @@
                 <command name="eglDebugMessageControlKHR"/>
                 <command name="eglQueryDebugKHR"/>
                 <command name="eglLabelObjectKHR"/>
+            </require>
+        </extension>
+        <extension name="EGL_KHR_display_reference" supported="egl">
+            <require>
+                <enum name="EGL_TRACK_REFERENCES_KHR"/>
+                <command name="eglQueryDisplayAttribKHR"/>
             </require>
         </extension>
         <extension name="EGL_KHR_fence_sync" protect="KHRONOS_SUPPORT_INT64" supported="egl">
@@ -2600,6 +2944,7 @@
                 <enum name="EGL_DRM_BUFFER_STRIDE_MESA"/>
                 <enum name="EGL_DRM_BUFFER_USE_SCANOUT_MESA"/>
                 <enum name="EGL_DRM_BUFFER_USE_SHARE_MESA"/>
+                <enum name="EGL_DRM_BUFFER_USE_CURSOR_MESA"/>
                 <command name="eglCreateDRMImageMESA"/>
                 <command name="eglExportDRMImageMESA"/>
             </require>
@@ -2619,6 +2964,12 @@
         <extension name="EGL_MESA_platform_surfaceless" supported="egl">
             <require>
                 <enum name="EGL_PLATFORM_SURFACELESS_MESA"/>
+            </require>
+        </extension>
+        <extension name="EGL_MESA_query_driver" supported="egl">
+            <require>
+                <command name="eglGetDisplayDriverConfig"/>
+                <command name="eglGetDisplayDriverName"/>
             </require>
         </extension>
         <extension name="EGL_NOK_swap_region" supported="egl">
@@ -2645,6 +2996,11 @@
             <require>
                 <enum name="EGL_COVERAGE_BUFFERS_NV"/>
                 <enum name="EGL_COVERAGE_SAMPLES_NV"/>
+            </require>
+        </extension>
+        <extension name="EGL_NV_context_priority_realtime" supported="egl">
+            <require>
+                <enum name="EGL_CONTEXT_PRIORITY_REALTIME_NV"/>
             </require>
         </extension>
         <extension name="EGL_NV_coverage_sample_resolve" supported="egl">
@@ -2690,6 +3046,11 @@
                 <command name="eglPostSubBufferNV"/>
             </require>
         </extension>
+        <extension name="EGL_NV_quadruple_buffer" supported="egl">
+            <require>
+                <enum name="EGL_QUADRUPLE_BUFFER_NV"/>
+            </require>
+        </extension>
         <extension name="EGL_NV_robustness_video_memory_purge" supported="egl">
             <require>
                 <enum name="EGL_GENERATE_RESET_ON_VIDEO_MEMORY_PURGE_NV"/>
@@ -2730,6 +3091,12 @@
                 <enum name="EGL_STREAM_CROSS_SYSTEM_NV"/>
             </require>
         </extension>
+        <extension name="EGL_NV_stream_dma" supported="egl">
+            <require>
+                <enum name="EGL_STREAM_DMA_NV"/>
+                <enum name="EGL_STREAM_DMA_SERVER_NV"/>
+            </require>
+        </extension>
         <extension name="EGL_NV_stream_fifo_next" supported="egl">
             <require>
                 <enum name="EGL_PENDING_FRAME_NV"/>
@@ -2739,6 +3106,11 @@
         <extension name="EGL_NV_stream_fifo_synchronous" supported="egl">
             <require>
                 <enum name="EGL_STREAM_FIFO_SYNCHRONOUS_NV"/>
+            </require>
+        </extension>
+        <extension name="EGL_NV_stream_flush" supported="egl">
+            <require>
+                <command name="eglStreamFlushNV"/>
             </require>
         </extension>
         <extension name="EGL_NV_stream_frame_limits" supported="egl">
@@ -2842,6 +3214,11 @@
                 <command name="eglGetSystemTimeNV"/>
             </require>
         </extension>
+        <extension name="EGL_NV_triple_buffer" supported="egl">
+            <require>
+                <enum name="EGL_TRIPLE_BUFFER_NV"/>
+            </require>
+        </extension>
         <extension name="EGL_TIZEN_image_native_buffer" supported="egl">
             <require>
                 <enum name="EGL_NATIVE_BUFFER_TIZEN"/>
@@ -2850,6 +3227,55 @@
         <extension name="EGL_TIZEN_image_native_surface" supported="egl">
             <require>
                 <enum name="EGL_NATIVE_SURFACE_TIZEN"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_compositor" supported="egl">
+            <require>
+                <enum name="EGL_PRIMARY_COMPOSITOR_CONTEXT_EXT"/>
+                <enum name="EGL_EXTERNAL_REF_ID_EXT"/>
+                <enum name="EGL_COMPOSITOR_DROP_NEWEST_FRAME_EXT"/>
+                <enum name="EGL_COMPOSITOR_KEEP_NEWEST_FRAME_EXT"/>
+
+                <command name="eglCompositorSetContextListEXT"/>
+                <command name="eglCompositorSetContextAttributesEXT"/>
+                <command name="eglCompositorSetWindowListEXT"/>
+                <command name="eglCompositorSetWindowAttributesEXT"/>
+                <command name="eglCompositorBindTexWindowEXT"/>
+                <command name="eglCompositorSetSizeEXT"/>
+                <command name="eglCompositorSwapPolicyEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_surface_CTA861_3_metadata" supported="egl">
+            <require>
+                <enum name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
+                <enum name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_image_implicit_sync_control" supported="egl">
+            <require>
+                <enum name="EGL_IMPORT_SYNC_TYPE_EXT"/>
+                <enum name="EGL_IMPORT_IMPLICIT_SYNC_EXT"/>
+                <enum name="EGL_IMPORT_EXPLICIT_SYNC_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_bind_to_front" supported="egl">
+            <require>
+                <enum name="EGL_FRONT_BUFFER_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_NV_stream_origin" supported="egl">
+            <require>
+                <enum name="EGL_STREAM_FRAME_ORIGIN_X_NV"/>
+                <enum name="EGL_STREAM_FRAME_ORIGIN_Y_NV"/>
+                <enum name="EGL_STREAM_FRAME_MAJOR_AXIS_NV"/>
+                <enum name="EGL_CONSUMER_AUTO_ORIENTATION_NV"/>
+                <enum name="EGL_PRODUCER_AUTO_ORIENTATION_NV"/>
+                <enum name="EGL_LEFT_NV"/>
+                <enum name="EGL_RIGHT_NV"/>
+                <enum name="EGL_TOP_NV"/>
+                <enum name="EGL_BOTTOM_NV"/>
+                <enum name="EGL_X_AXIS_NV"/>
+                <enum name="EGL_Y_AXIS_NV"/>
             </require>
         </extension>
     </extensions>

--- a/registry/gl.xml
+++ b/registry/gl.xml
@@ -1,97 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <comment>
-Copyright (c) 2013-2016 The Khronos Group Inc.
+Copyright (c) 2013-2018 The Khronos Group Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and/or associated documentation files (the
-"Materials"), to deal in the Materials without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Materials, and to
-permit persons to whom the Materials are furnished to do so, subject to
-the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Materials.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 ------------------------------------------------------------------------
 
-This file, gl.xml, is the OpenGL and OpenGL API Registry. The older
-".spec" file format has been retired and will no longer be updated with
-new extensions and API versions. The canonical version of the registry,
-together with documentation, schema, and Python generator scripts used
-to generate C header files for OpenGL and OpenGL ES, can always be found
-in the Khronos Registry at
-        http://www.opengl.org/registry/
+This file, gl.xml, is the OpenGL and OpenGL API Registry. The canonical
+version of the registry, together with documentation, schema, and Python
+generator scripts used to generate C header files for OpenGL and OpenGL ES,
+can always be found in the Khronos Registry at
+        https://github.com/KhronosGroup/OpenGL-Registry
     </comment>
 
     <!-- SECTION: GL type definitions. -->
     <types>
             <!-- These are dependencies GL types require to be declared legally -->
-        <type name="stddef">#include &lt;stddef.h&gt;</type>
         <type name="khrplatform">#include &lt;KHR/khrplatform.h&gt;</type>
-        <type name="inttypes">#ifndef GLEXT_64_TYPES_DEFINED
-/* This code block is duplicated in glxext.h, so must be protected */
-#define GLEXT_64_TYPES_DEFINED
-/* Define int32_t, int64_t, and uint64_t types for UST/MSC */
-/* (as used in the GL_EXT_timer_query extension). */
-#if defined(__STDC_VERSION__) &amp;&amp; __STDC_VERSION__ &gt;= 199901L
-#include &lt;inttypes.h&gt;
-#elif defined(__sun__) || defined(__digital__)
-#include &lt;inttypes.h&gt;
-#if defined(__STDC__)
-#if defined(__arch64__) || defined(_LP64)
-typedef long int int64_t;
-typedef unsigned long int uint64_t;
-#else
-typedef long long int int64_t;
-typedef unsigned long long int uint64_t;
-#endif /* __arch64__ */
-#endif /* __STDC__ */
-#elif defined( __VMS ) || defined(__sgi)
-#include &lt;inttypes.h&gt;
-#elif defined(__SCO__) || defined(__USLC__)
-#include &lt;stdint.h&gt;
-#elif defined(__UNIXOS2__) || defined(__SOL64__)
-typedef long int int32_t;
-typedef long long int int64_t;
-typedef unsigned long long int uint64_t;
-#elif defined(_WIN32) &amp;&amp; defined(__GNUC__)
-#include &lt;stdint.h&gt;
-#elif defined(_WIN32)
-typedef __int32 int32_t;
-typedef __int64 int64_t;
-typedef unsigned __int64 uint64_t;
-#else
-/* Fallback if nothing above works */
-#include &lt;inttypes.h&gt;
-#endif
-#endif</type>
             <!-- These are actual GL types -->
         <type>typedef unsigned int <name>GLenum</name>;</type>
         <type>typedef unsigned char <name>GLboolean</name>;</type>
         <type>typedef unsigned int <name>GLbitfield</name>;</type>
         <type comment="Not an actual GL type, though used in headers in the past">typedef void <name>GLvoid</name>;</type>
-        <type>typedef signed char <name>GLbyte</name>;</type>
-        <type>typedef short <name>GLshort</name>;</type>
+        <type requires="khrplatform">typedef khronos_int8_t <name>GLbyte</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint8_t <name>GLubyte</name>;</type>
+        <type requires="khrplatform">typedef khronos_int16_t <name>GLshort</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint16_t <name>GLushort</name>;</type>
         <type>typedef int <name>GLint</name>;</type>
-        <type>typedef int <name>GLclampx</name>;</type>
-        <type>typedef unsigned char <name>GLubyte</name>;</type>
-        <type>typedef unsigned short <name>GLushort</name>;</type>
         <type>typedef unsigned int <name>GLuint</name>;</type>
+        <type requires="khrplatform">typedef khronos_int32_t <name>GLclampx</name>;</type>
         <type>typedef int <name>GLsizei</name>;</type>
-        <type>typedef float <name>GLfloat</name>;</type>
-        <type>typedef float <name>GLclampf</name>;</type>
+        <type requires="khrplatform">typedef khronos_float_t <name>GLfloat</name>;</type>
+        <type requires="khrplatform">typedef khronos_float_t <name>GLclampf</name>;</type>
         <type>typedef double <name>GLdouble</name>;</type>
         <type>typedef double <name>GLclampd</name>;</type>
+        <type>typedef void *<name>GLeglClientBufferEXT</name>;</type>
         <type>typedef void *<name>GLeglImageOES</name>;</type>
         <type>typedef char <name>GLchar</name>;</type>
         <type>typedef char <name>GLcharARB</name>;</type>
@@ -100,62 +54,664 @@ typedef void *GLhandleARB;
 #else
 typedef unsigned int GLhandleARB;
 #endif</type>
-        <type>typedef unsigned short <name>GLhalfARB</name>;</type>
-        <type>typedef unsigned short <name>GLhalf</name>;</type>
-        <type comment="Must be 32 bits">typedef GLint <name>GLfixed</name>;</type>
-        <type requires="stddef">typedef ptrdiff_t <name>GLintptr</name>;</type>
-        <type requires="stddef">typedef ptrdiff_t <name>GLsizeiptr</name>;</type>
-        <type requires="inttypes">typedef int64_t <name>GLint64</name>;</type>
-        <type requires="inttypes">typedef uint64_t <name>GLuint64</name>;</type>
-        <type requires="stddef">typedef ptrdiff_t <name>GLintptrARB</name>;</type>
-        <type requires="stddef">typedef ptrdiff_t <name>GLsizeiptrARB</name>;</type>
-        <type requires="inttypes">typedef int64_t <name>GLint64EXT</name>;</type>
-        <type requires="inttypes">typedef uint64_t <name>GLuint64EXT</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint16_t <name>GLhalf</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint16_t <name>GLhalfARB</name>;</type>
+        <type requires="khrplatform">typedef khronos_int32_t <name>GLfixed</name>;</type>
+        <type requires="khrplatform">typedef khronos_intptr_t <name>GLintptr</name>;</type>
+        <type requires="khrplatform">typedef khronos_intptr_t <name>GLintptrARB</name>;</type>
+        <type requires="khrplatform">typedef khronos_ssize_t <name>GLsizeiptr</name>;</type>
+        <type requires="khrplatform">typedef khronos_ssize_t <name>GLsizeiptrARB</name>;</type>
+        <type requires="khrplatform">typedef khronos_int64_t <name>GLint64</name>;</type>
+        <type requires="khrplatform">typedef khronos_int64_t <name>GLint64EXT</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint64_t <name>GLuint64</name>;</type>
+        <type requires="khrplatform">typedef khronos_uint64_t <name>GLuint64EXT</name>;</type>
         <type>typedef struct __GLsync *<name>GLsync</name>;</type>
         <type comment="compatible with OpenCL cl_context"><name>struct _cl_context</name>;</type>
         <type comment="compatible with OpenCL cl_event"><name>struct _cl_event</name>;</type>
         <type>typedef void (<apientry/> *<name>GLDEBUGPROC</name>)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);</type>
         <type>typedef void (<apientry/> *<name>GLDEBUGPROCARB</name>)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);</type>
         <type>typedef void (<apientry/> *<name>GLDEBUGPROCKHR</name>)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);</type>
-            <!-- GLES 1 types -->
-        <type api="gles1" requires="khrplatform">typedef khronos_int32_t <name>GLclampx</name>;</type>
-            <!-- GLES 1/2 types (tagged for GLES 1) -->
-        <type api="gles1" requires="khrplatform">typedef khronos_int8_t <name>GLbyte</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_uint8_t <name>GLubyte</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_float_t <name>GLfloat</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_float_t <name>GLclampf</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_int32_t <name>GLfixed</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_int64_t <name>GLint64</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_uint64_t <name>GLuint64</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_intptr_t <name>GLintptr</name>;</type>
-        <type api="gles1" requires="khrplatform">typedef khronos_ssize_t <name>GLsizeiptr</name>;</type>
-            <!-- GLES 1/2 types (tagged for GLES 2 - attribute syntax is limited) -->
-        <type api="gles2" requires="khrplatform">typedef khronos_int8_t <name>GLbyte</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_uint8_t <name>GLubyte</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_float_t <name>GLfloat</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_float_t <name>GLclampf</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_int32_t <name>GLfixed</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_int64_t <name>GLint64</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_uint64_t <name>GLuint64</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_int64_t <name>GLint64EXT</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_uint64_t <name>GLuint64EXT</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_intptr_t <name>GLintptr</name>;</type>
-        <type api="gles2" requires="khrplatform">typedef khronos_ssize_t <name>GLsizeiptr</name>;</type>
-            <!-- GLES 2 types (none currently) -->
-            <!-- GLSC 2 types -->
-        <type api="glsc2" requires="khrplatform">typedef khronos_uint8_t <name>GLubyte</name>;</type>
-        <type api="glsc2" requires="khrplatform">typedef khronos_float_t <name>GLfloat</name>;</type>
-        <type api="glsc2" requires="khrplatform">typedef khronos_intptr_t <name>GLintptr</name>;</type>
-        <type api="glsc2" requires="khrplatform">typedef khronos_ssize_t <name>GLsizeiptr</name>;</type>
+
             <!-- Vendor extension types -->
         <type>typedef void (<apientry/> *<name>GLDEBUGPROCAMD</name>)(GLuint id,GLenum category,GLenum severity,GLsizei length,const GLchar *message,void *userParam);</type>
         <type>typedef unsigned short <name>GLhalfNV</name>;</type>
         <type requires="GLintptr">typedef GLintptr <name>GLvdpauSurfaceNV</name>;</type>
+        <type>typedef void (<apientry/> *<name>GLVULKANPROCNV</name>)(void);</type>
     </types>
 
     <!-- SECTION: GL parameter class type definitions. -->
 
     <groups>
+        <group name="EvalMapsModeNV">
+            <enum name="GL_FILL_NV"/>
+        </group>
+
+        <group name="ProgramTarget">
+            <enum name="GL_TEXT_FRAGMENT_SHADER"/>
+        </group>
+
+        <group name="CombinerStageNV">
+            <enum name="GL_COMBINER0_NV"/>
+            <enum name="GL_COMBINER1_NV"/>
+            <enum name="GL_COMBINER2_NV"/>
+            <enum name="GL_COMBINER3_NV"/>
+            <enum name="GL_COMBINER4_NV"/>
+            <enum name="GL_COMBINER5_NV"/>
+            <enum name="GL_COMBINER6_NV"/>
+            <enum name="GL_COMBINER7_NV"/>
+        </group>
+
+        <group name="CombinerPortionNV">
+            <enum name="GL_RGB_NV"/>
+            <enum name="GL_ALPHA_NV"/>
+        </group>
+
+        <group name="MapTypeNV">
+            <enum name="GL_FLOAT_NV"/>
+            <enum name="GL_DOUBLE_NV"/>
+        </group>
+
+        <group name="ScalarType">
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+        </group>
+
+        <group name="VertexShaderTextureUnitParameter">
+            <enum name="GL_CURRENT_TEXTURE_COORDS"/>
+            <enum name="GL_TEXTURE_MATRIX"/>
+        </group>
+
+        <group name="ProgramStringProperty">
+            <enum name="GL_PROGRAM_STRING"/>
+        </group>
+
+        <group name="ProgramFormat">
+            <enum name="GL_PROGRAM_FORMAT_ASCII"/>
+        </group>
+
+        <group name="PathColorFormat">
+            <enum name="GL_NONE"/>
+            <enum name="GL_LUMINANCE"/>
+            <enum name="GL_ALPHA"/>
+            <enum name="GL_INTENSITY"/>
+            <enum name="GL_LUMINANCE_ALPHA"/>
+            <enum name="GL_RGB"/>
+            <enum name="GL_RGBA"/>
+        </group>
+
+        <group name="ReplacementCodeTypeSUN">
+            <enum name="GL_UNSIGNED_BYTE_SUN"/>
+            <enum name="GL_UNSIGNED_SHORT_SUN"/>
+            <enum name="GL_UNSIGNED_INT_SUN"/>
+        </group>
+
+        <group name="SecondaryColorPointerTypeIBM">
+            <enum name="GL_SHORT_IBM"/>
+            <enum name="GL_INT_IBM"/>
+            <enum name="GL_FLOAT_IBM"/>
+            <enum name="GL_DOUBLE_IBM"/>
+        </group>
+
+        <group name="FragmentLightNameSGIX">
+            <enum name="GL_FRAGMENT_LIGHT0_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT1_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT2_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT3_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT4_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT5_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT6_SGIX"/>
+            <enum name="GL_FRAGMENT_LIGHT7_SGIX"/>
+        </group>
+
+        <group name="FragmentLightParameterSGIX">
+            <enum name="GL_SPOT_EXPONENT_SGIX"/>
+            <enum name="GL_SPOT_CUTOFF_SGIX"/>
+            <enum name="GL_CONSTANT_ATTENUATION_SGIX"/>
+            <enum name="GL_LINEAR_ATTENUATION_SGIX"/>
+            <enum name="GL_QUADRATIC_ATTENUATION_SGIX"/>
+            <enum name="GL_AMBIENT_SGIX"/>
+            <enum name="GL_DIFFUSE_SGIX"/>
+            <enum name="GL_SPECULAR_SGIX"/>
+            <enum name="GL_POSITION_SGIX"/>
+            <enum name="GL_SPOT_DIRECTION_SGIX"/>
+            <enum name="GL_SPOT_EXPONENT_SGIX"/>
+            <enum name="GL_SPOT_CUTOFF_SGIX"/>
+            <enum name="GL_CONSTANT_ATTENUATION_SGIX"/>
+            <enum name="GL_LINEAR_ATTENUATION_SGIX"/>
+            <enum name="GL_QUADRATIC_ATTENUATION_SGIX"/>
+        </group>
+
+        <group name="ElementPointerTypeATI">
+            <enum name="GL_UNSIGNED_BYTE_ATI"/>
+            <enum name="GL_UNSIGNED_SHORT_ATI"/>
+            <enum name="GL_UNSIGNED_INT_ATI"/>
+        </group>
+
+        <group name="MatrixIndexPointerTypeARB">
+            <enum name="GL_UNSIGNED_BYTE_ARB"/>
+            <enum name="GL_UNSIGNED_SHORT_ARB"/>
+            <enum name="GL_UNSIGNED_INT_ARB"/>
+        </group>
+
+        <group name="WeightPointerTypeARB">
+            <enum name="GL_BYTE_ARB"/>
+            <enum name="GL_UNSIGNED_BYTE_ARB"/>
+            <enum name="GL_SHORT_ARB"/>
+            <enum name="GL_UNSIGNED_SHORT_ARB"/>
+            <enum name="GL_INT_ARB"/>
+            <enum name="GL_UNSIGNED_INT_ARB"/>
+            <enum name="GL_FLOAT_ARB"/>
+            <enum name="GL_DOUBLE_ARB"/>
+        </group>
+
+        <group name="CullParameterEXT">
+            <enum name="GL_CULL_VERTEX_EYE_POSITION_EXT"/>
+            <enum name="GL_CULL_VERTEX_OBJECT_POSITION_EXT"/>
+        </group>
+
+        <group name="DataTypeEXT">
+            <enum name="GL_SCALAR_EXT"/>
+            <enum name="GL_VECTOR_EXT"/>
+            <enum name="GL_MATRIX_EXT"/>
+        </group>
+
+        <group name="ParameterRangeEXT">
+            <enum name="GL_NORMALIZED_RANGE_EXT"/>
+            <enum name="GL_FULL_RANGE_EXT"/>
+        </group>
+
+        <group name="GetVariantValueEXT">
+            <enum name="GL_VARIANT_VALUE_EXT"/>
+            <enum name="GL_VARIANT_DATATYPE_EXT"/>
+            <enum name="GL_VARIANT_ARRAY_STRIDE_EXT"/>
+            <enum name="GL_VARIANT_ARRAY_TYPE_EXT"/>
+        </group>
+
+        <group name="IndexFunctionEXT">
+            <enum name="GL_NEVER_EXT"/>
+            <enum name="GL_ALWAYS_EXT"/>
+            <enum name="GL_LESS_EXT"/>
+            <enum name="GL_LEQUAL_EXT"/>
+            <enum name="GL_EQUAL_EXT"/>
+            <enum name="GL_GEQUAL_EXT"/>
+            <enum name="GL_GREATER_EXT"/>
+            <enum name="GL_NOTEQUAL_EXT"/>
+        </group>
+
+        <group name="IndexMaterialParameterEXT">
+            <enum name="GL_INDEX_OFFSET"/>
+        </group>
+
+        <group name="VariantCapEXT">
+            <enum name="GL_VARIANT_ARRAY_EXT"/>
+        </group>
+
+        <group name="PixelTransformTargetEXT">
+            <enum name="GL_PIXEL_TRANSFORM_2D_EXT"/>
+        </group>
+
+        <group name="PixelTransformPNameEXT">
+            <enum name="GL_PIXEL_MAG_FILTER_EXT"/>
+            <enum name="GL_PIXEL_MIN_FILTER_EXT"/>
+            <enum name="GL_PIXEL_CUBIC_WEIGHT_EXT"/>
+        </group>
+
+        <group name="VertexWeightPointerTypeEXT">
+            <enum name="GL_FLOAT_EXT"/>
+        </group>
+
+        <group name="VertexShaderWriteMaskEXT">
+            <enum name="GL_TRUE_EXT"/>
+            <enum name="GL_FALSE_EXT"/>
+        </group>
+
+        <group name="CombinerComponentUsageNV">
+            <enum name="GL_RGB_NV"/>
+            <enum name="GL_ALPHA_NV"/>
+            <enum name="GL_BLUE_NV"/>
+        </group>
+
+        <group name="TangentPointerTypeEXT">
+            <enum name="GL_BYTE_EXT"/>
+            <enum name="GL_SHORT_EXT"/>
+            <enum name="GL_FLOAT_EXT"/>
+            <enum name="GL_DOUBLE_EXT"/>
+        </group>
+
+        <group name="BinormalPointerTypeEXT">
+            <enum name="GL_BYTE_EXT"/>
+            <enum name="GL_SHORT_EXT"/>
+            <enum name="GL_FLOAT_EXT"/>
+            <enum name="GL_DOUBLE_EXT"/>
+        </group>
+
+        <group name="TextureNormalModeEXT">
+            <enum name="GL_PERTURB_EXT"/>
+        </group>
+
+        <group name="LightTexturePNameEXT">
+            <enum name="GL_ATTENUATION_EXT"/>
+            <enum name="GL_SHADOW_ATTENUATION_EXT"/>
+        </group>
+
+        <group name="VertexShaderCoordOutEXT">
+            <enum name="GL_X_EXT"/>
+            <enum name="GL_Y_EXT"/>
+            <enum name="GL_Z_EXT"/>
+            <enum name="GL_W_EXT"/>
+            <enum name="GL_NEGATIVE_X_EXT"/>
+            <enum name="GL_NEGATIVE_Y_EXT"/>
+            <enum name="GL_NEGATIVE_Z_EXT"/>
+            <enum name="GL_NEGATIVE_W_EXT"/>
+            <enum name="GL_ZERO_EXT"/>
+            <enum name="GL_ONE_EXT"/>
+            <enum name="GL_NEGATIVE_ONE_EXT"/>
+        </group>
+
+        <group name="SamplePatternEXT">
+            <enum name="GL_1PASS_EXT"/>
+            <enum name="GL_2PASS_0_EXT"/>
+            <enum name="GL_2PASS_1_EXT"/>
+            <enum name="GL_4PASS_0_EXT"/>
+            <enum name="GL_4PASS_1_EXT"/>
+            <enum name="GL_4PASS_2_EXT"/>
+            <enum name="GL_4PASS_3_EXT"/>
+        </group>
+
+        <group name="VertexShaderStorageTypeEXT">
+            <enum name="GL_VARIANT_EXT"/>
+            <enum name="GL_INVARIANT_EXT"/>
+            <enum name="GL_LOCAL_CONSTANT_EXT"/>
+            <enum name="GL_LOCAL_EXT"/>
+        </group>
+
+        <group name="VertexShaderParameterEXT">
+            <enum name="GL_CURRENT_VERTEX_EXT"/>
+            <enum name="GL_MVP_MATRIX_EXT"/>
+        </group>
+
+        <group name="LightTextureModeEXT">
+            <enum name="GL_FRAGMENT_MATERIAL_EXT"/>
+            <enum name="GL_FRAGMENT_NORMAL_EXT"/>
+            <enum name="GL_FRAGMENT_DEPTH_EXT"/>
+            <enum name="GL_FRAGMENT_COLOR_EXT"/>
+        </group>
+
+        <group name="VertexShaderOpEXT">
+            <enum name="GL_OP_INDEX_EXT"/>
+            <enum name="GL_OP_NEGATE_EXT"/>
+            <enum name="GL_OP_DOT3_EXT"/>
+            <enum name="GL_OP_DOT4_EXT"/>
+            <enum name="GL_OP_MUL_EXT"/>
+            <enum name="GL_OP_ADD_EXT"/>
+            <enum name="GL_OP_MADD_EXT"/>
+            <enum name="GL_OP_FRAC_EXT"/>
+            <enum name="GL_OP_MAX_EXT"/>
+            <enum name="GL_OP_MIN_EXT"/>
+            <enum name="GL_OP_SET_GE_EXT"/>
+            <enum name="GL_OP_SET_LT_EXT"/>
+            <enum name="GL_OP_CLAMP_EXT"/>
+            <enum name="GL_OP_FLOOR_EXT"/>
+            <enum name="GL_OP_ROUND_EXT"/>
+            <enum name="GL_OP_EXP_BASE_2_EXT"/>
+            <enum name="GL_OP_LOG_BASE_2_EXT"/>
+            <enum name="GL_OP_POWER_EXT"/>
+            <enum name="GL_OP_RECIP_EXT"/>
+            <enum name="GL_OP_RECIP_SQRT_EXT"/>
+            <enum name="GL_OP_SUB_EXT"/>
+            <enum name="GL_OP_CROSS_PRODUCT_EXT"/>
+            <enum name="GL_OP_MULTIPLY_MATRIX_EXT"/>
+            <enum name="GL_OP_MOV_EXT"/>
+        </group>
+
+        <group name="ProgramFormatARB">
+            <enum name="GL_PROGRAM_FORMAT_ASCII_ARB"/>
+        </group>
+
+        <group name="PointParameterNameARB">
+            <enum name="GL_POINT_SIZE_MIN_EXT"/>
+            <enum name="GL_POINT_SIZE_MAX_EXT"/>
+            <enum name="GL_POINT_FADE_THRESHOLD_SIZE_EXT"/>
+            <enum name="GL_POINT_FADE_THRESHOLD_SIZE"/>
+        </group>
+
+        <group name="VertexAttribPropertyARB">
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_ENABLED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_SIZE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_STRIDE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_TYPE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_NORMALIZED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_LONG"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR"/>
+            <enum name="GL_VERTEX_ATTRIB_BINDING"/>
+            <enum name="GL_VERTEX_ATTRIB_RELATIVE_OFFSET"/>
+            <enum name="GL_CURRENT_VERTEX_ATTRIB"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER_EXT"/>
+        </group>
+
+        <group name="VertexAttribPointerPropertyARB">
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_POINTER_ARB"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_POINTER"/>
+        </group>
+
+        <group name="ProgramStringPropertyARB">
+            <enum name="GL_PROGRAM_STRING_ARB"/>
+        </group>
+
+        <group name="BufferPointerNameARB">
+            <enum name="GL_BUFFER_MAP_POINTER_ARB"/>
+            <enum name="GL_BUFFER_MAP_POINTER"/>
+        </group>
+
+        <group name="BufferPNameARB">
+            <enum name="GL_BUFFER_SIZE_ARB"/>
+            <enum name="GL_BUFFER_USAGE_ARB"/>
+            <enum name="GL_BUFFER_ACCESS_ARB"/>
+            <enum name="GL_BUFFER_MAPPED_ARB"/>
+            <enum name="GL_BUFFER_SIZE"/>
+            <enum name="GL_BUFFER_USAGE"/>
+            <enum name="GL_BUFFER_ACCESS"/>
+            <enum name="GL_BUFFER_ACCESS_FLAGS"/>
+            <enum name="GL_BUFFER_IMMUTABLE_STORAGE"/>
+            <enum name="GL_BUFFER_MAPPED"/>
+            <enum name="GL_BUFFER_MAP_OFFSET"/>
+            <enum name="GL_BUFFER_MAP_LENGTH"/>
+            <enum name="GL_BUFFER_STORAGE_FLAGS"/>
+        </group>
+
+        <group name="ClampColorModeARB">
+            <enum name="GL_FIXED_ONLY_ARB"/>
+            <enum name="GL_FALSE"/>
+            <enum name="GL_TRUE"/>
+            <enum name="GL_TRUE"/>
+            <enum name="GL_FALSE"/>
+            <enum name="GL_FIXED_ONLY"/>
+        </group>
+
+        <group name="ClampColorTargetARB">
+            <enum name="GL_CLAMP_VERTEX_COLOR_ARB"/>
+            <enum name="GL_CLAMP_FRAGMENT_COLOR_ARB"/>
+            <enum name="GL_CLAMP_READ_COLOR_ARB"/>
+            <enum name="GL_CLAMP_READ_COLOR"/>
+        </group>
+
+        <group name="ProgramTargetARB">
+            <enum name="GL_TEXT_FRAGMENT_SHADER_ATI"/>
+        </group>
+
+        <group name="VertexArrayPNameAPPLE">
+            <enum name="GL_STORAGE_CLIENT_APPLE"/>
+            <enum name="GL_STORAGE_CACHED_APPLE"/>
+            <enum name="GL_STORAGE_SHARED_APPLE"/>
+        </group>
+
+        <group name="ObjectTypeAPPLE">
+            <enum name="GL_DRAW_PIXELS_APPLE"/>
+            <enum name="GL_FENCE_APPLE"/>
+        </group>
+
+        <group name="PreserveModeATI">
+            <enum name="GL_PRESERVE_ATI"/>
+            <enum name="GL_DISCARD_ATI"/>
+        </group>
+
+        <group name="TexBumpParameterATI">
+            <enum name="GL_BUMP_ROT_MATRIX_ATI"/>
+        </group>
+
+        <group name="SwizzleOpATI">
+            <enum name="GL_SWIZZLE_STR_ATI"/>
+            <enum name="GL_SWIZZLE_STQ_ATI"/>
+            <enum name="GL_SWIZZLE_STR_DR_ATI"/>
+            <enum name="GL_SWIZZLE_STQ_DQ_ATI"/>
+        </group>
+
+        <group name="PNTrianglesPNameATI">
+            <enum name="GL_PN_TRIANGLES_POINT_MODE_ATI"/>
+            <enum name="GL_PN_TRIANGLES_NORMAL_MODE_ATI"/>
+            <enum name="GL_PN_TRIANGLES_TESSELATION_LEVEL_ATI"/>
+        </group>
+
+        <group name="ArrayObjectUsageATI">
+            <enum name="GL_STATIC_ATI"/>
+            <enum name="GL_DYNAMIC_ATI"/>
+        </group>
+
+        <group name="GetTexBumpParameterATI">
+            <enum name="GL_BUMP_ROT_MATRIX_ATI"/>
+            <enum name="GL_BUMP_ROT_MATRIX_SIZE_ATI"/>
+            <enum name="GL_BUMP_NUM_TEX_UNITS_ATI"/>
+            <enum name="GL_BUMP_TEX_UNITS_ATI"/>
+        </group>
+
+        <group name="ArrayObjectPNameATI">
+            <enum name="GL_OBJECT_BUFFER_SIZE_ATI"/>
+            <enum name="GL_OBJECT_BUFFER_USAGE_ATI"/>
+        </group>
+
+        <group name="DrawBufferModeATI">
+            <enum name="GL_COLOR_ATTACHMENT0_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT1_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT2_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT3_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT4_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT5_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT6_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT7_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT8_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT9_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT10_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT11_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT12_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT13_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT14_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT15_NV"/>
+        </group>
+
+        <group name="VertexStreamATI">
+            <enum name="GL_VERTEX_STREAM0_ATI"/>
+            <enum name="GL_VERTEX_STREAM1_ATI"/>
+            <enum name="GL_VERTEX_STREAM2_ATI"/>
+            <enum name="GL_VERTEX_STREAM3_ATI"/>
+            <enum name="GL_VERTEX_STREAM4_ATI"/>
+            <enum name="GL_VERTEX_STREAM5_ATI"/>
+            <enum name="GL_VERTEX_STREAM6_ATI"/>
+            <enum name="GL_VERTEX_STREAM7_ATI"/>
+        </group>
+
+        <group name="SpriteParameterNameSGIX">
+            <enum name="GL_SPRITE_MODE_SGIX"/>
+        </group>
+
+        <group name="PixelTexGenModeSGIX">
+            <enum name="GL_PIXEL_TEX_GEN_Q_CEILING_SGIX"/>
+            <enum name="GL_PIXEL_TEX_GEN_Q_FLOOR_SGIX"/>
+            <enum name="GL_PIXEL_TEX_GEN_Q_ROUND_SGIX"/>
+            <enum name="GL_PIXEL_TEX_GEN_ALPHA_LS_SGIX"/>
+            <enum name="GL_PIXEL_TEX_GEN_ALPHA_MS_SGIX"/>
+        </group>
+
+        <group name="IglooFunctionSelectSGIX">
+            <enum name="GL_IGLOO_FULLSCREEN_SGIX"/>
+            <enum name="GL_IGLOO_VIEWPORT_OFFSET_SGIX"/>
+            <enum name="GL_IGLOO_SWAPTMESH_SGIX"/>
+            <enum name="GL_IGLOO_COLORNORMAL_SGIX"/>
+            <enum name="GL_IGLOO_IRISGL_MODE_SGIX"/>
+            <enum name="GL_IGLOO_LMC_COLOR_SGIX"/>
+            <enum name="GL_IGLOO_TMESHMODE_SGIX"/>
+        </group>
+
+        <group name="HintTargetPGI">
+            <enum name="GL_VERTEX_DATA_HINT_PGI"/>
+            <enum name="GL_VERTEX_CONSISTENT_HINT_PGI"/>
+            <enum name="GL_MATERIAL_SIDE_HINT_PGI"/>
+            <enum name="GL_MAX_VERTEX_HINT_PGI"/>
+        </group>
+
+        <group name="ImageTransformPNameHP">
+            <enum name="GL_IMAGE_SCALE_X_HP"/>
+            <enum name="GL_IMAGE_SCALE_Y_HP"/>
+            <enum name="GL_IMAGE_TRANSLATE_X_HP"/>
+            <enum name="GL_IMAGE_TRANSLATE_Y_HP"/>
+            <enum name="GL_IMAGE_ROTATE_ANGLE_HP"/>
+            <enum name="GL_IMAGE_ROTATE_ORIGIN_X_HP"/>
+            <enum name="GL_IMAGE_ROTATE_ORIGIN_Y_HP"/>
+            <enum name="GL_IMAGE_MAG_FILTER_HP"/>
+            <enum name="GL_IMAGE_MIN_FILTER_HP"/>
+            <enum name="GL_IMAGE_CUBIC_WEIGHT_HP"/>
+        </group>
+
+        <group name="ImageTransformTargetHP">
+            <enum name="GL_IMAGE_TRANSFORM_2D_HP"/>
+        </group>
+
+        <group name="TextureFilterSGIS">
+            <enum name="GL_FILTER4_SGIS"/>
+        </group>
+
+        <group name="OcclusionQueryParameterNameNV">
+            <enum name="GL_PIXEL_COUNT_NV"/>
+            <enum name="GL_PIXEL_COUNT_AVAILABLE_NV"/>
+        </group>
+
+        <group name="GetMultisamplePNameNV">
+            <enum name="GL_SAMPLE_POSITION"/>
+            <enum name="GL_SAMPLE_LOCATION_ARB"/>
+            <enum name="GL_PROGRAMMABLE_SAMPLE_LOCATION_ARB"/>
+        </group>
+
+        <group name="MapParameterNV">
+            <enum name="GL_MAP_TESSELLATION_NV"/>
+        </group>
+
+        <group name="MapAttribParameterNV">
+            <enum name="GL_MAP_ATTRIB_U_ORDER_NV"/>
+            <enum name="GL_MAP_ATTRIB_V_ORDER_NV"/>
+        </group>
+
+        <group name="FenceParameterNameNV">
+            <enum name="GL_FENCE_STATUS_NV"/>
+            <enum name="GL_FENCE_CONDITION_NV"/>
+        </group>
+
+        <group name="CombinerParameterNV">
+            <enum name="GL_COMBINER_INPUT_NV"/>
+            <enum name="GL_COMBINER_MAPPING_NV"/>
+            <enum name="GL_COMBINER_COMPONENT_USAGE_NV"/>
+        </group>
+
+        <group name="CombinerBiasNV">
+            <enum name="GL_NONE"/>
+            <enum name="GL_BIAS_BY_NEGATIVE_ONE_HALF_NV"/>
+        </group>
+
+        <group name="CombinerScaleNV">
+            <enum name="GL_NONE"/>
+            <enum name="GL_SCALE_BY_TWO_NV"/>
+            <enum name="GL_SCALE_BY_FOUR_NV"/>
+            <enum name="GL_SCALE_BY_ONE_HALF_NV"/>
+        </group>
+
+        <group name="CombinerMappingNV">
+            <enum name="GL_UNSIGNED_IDENTITY_NV"/>
+            <enum name="GL_UNSIGNED_INVERT_NV"/>
+            <enum name="GL_EXPAND_NORMAL_NV"/>
+            <enum name="GL_EXPAND_NEGATE_NV"/>
+            <enum name="GL_HALF_BIAS_NORMAL_NV"/>
+            <enum name="GL_HALF_BIAS_NEGATE_NV"/>
+            <enum name="GL_SIGNED_IDENTITY_NV"/>
+            <enum name="GL_SIGNED_NEGATE_NV"/>
+        </group>
+
+        <group name="CombinerRegisterNV">
+            <enum name="GL_DISCARD_NV"/>
+            <enum name="GL_PRIMARY_COLOR_NV"/>
+            <enum name="GL_SECONDARY_COLOR_NV"/>
+            <enum name="GL_SPARE0_NV"/>
+            <enum name="GL_SPARE1_NV"/>
+            <enum name="GL_TEXTURE0_ARB"/>
+            <enum name="GL_TEXTURE1_ARB"/>
+        </group>
+
+        <group name="CombinerVariableNV">
+            <enum name="GL_VARIABLE_A_NV"/>
+            <enum name="GL_VARIABLE_B_NV"/>
+            <enum name="GL_VARIABLE_C_NV"/>
+            <enum name="GL_VARIABLE_D_NV"/>
+            <enum name="GL_VARIABLE_E_NV"/>
+            <enum name="GL_VARIABLE_F_NV"/>
+            <enum name="GL_VARIABLE_G_NV"/>
+        </group>
+
+        <group name="PixelDataRangeTargetNV">
+            <enum name="GL_WRITE_PIXEL_DATA_RANGE_NV"/>
+            <enum name="GL_READ_PIXEL_DATA_RANGE_NV"/>
+        </group>
+
+        <group name="EvalTargetNV">
+            <enum name="GL_EVAL_2D_NV"/>
+            <enum name="GL_EVAL_TRIANGULAR_2D_NV"/>
+        </group>
+
+        <group name="VertexAttribEnumNV">
+            <enum name="GL_PROGRAM_PARAMETER_NV"/>
+        </group>
+
+        <group name="FenceConditionNV">
+            <enum name="GL_ALL_COMPLETED_NV"/>
+        </group>
+
+        <group name="PathCoordType">
+            <enum name="GL_CLOSE_PATH_NV"/>
+            <enum name="GL_MOVE_TO_NV"/>
+            <enum name="GL_RELATIVE_MOVE_TO_NV"/>
+            <enum name="GL_LINE_TO_NV"/>
+            <enum name="GL_RELATIVE_LINE_TO_NV"/>
+            <enum name="GL_HORIZONTAL_LINE_TO_NV"/>
+            <enum name="GL_RELATIVE_HORIZONTAL_LINE_TO_NV"/>
+            <enum name="GL_VERTICAL_LINE_TO_NV"/>
+            <enum name="GL_RELATIVE_VERTICAL_LINE_TO_NV"/>
+            <enum name="GL_QUADRATIC_CURVE_TO_NV"/>
+            <enum name="GL_RELATIVE_QUADRATIC_CURVE_TO_NV"/>
+            <enum name="GL_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_RELATIVE_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_SMOOTH_QUADRATIC_CURVE_TO_NV"/>
+            <enum name="GL_RELATIVE_SMOOTH_QUADRATIC_CURVE_TO_NV"/>
+            <enum name="GL_SMOOTH_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_RELATIVE_SMOOTH_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_SMALL_CCW_ARC_TO_NV"/>
+            <enum name="GL_RELATIVE_SMALL_CCW_ARC_TO_NV"/>
+            <enum name="GL_SMALL_CW_ARC_TO_NV"/>
+            <enum name="GL_RELATIVE_SMALL_CW_ARC_TO_NV"/>
+            <enum name="GL_LARGE_CCW_ARC_TO_NV"/>
+            <enum name="GL_RELATIVE_LARGE_CCW_ARC_TO_NV"/>
+            <enum name="GL_LARGE_CW_ARC_TO_NV"/>
+            <enum name="GL_RELATIVE_LARGE_CW_ARC_TO_NV"/>
+            <enum name="GL_CONIC_CURVE_TO_NV"/>
+            <enum name="GL_RELATIVE_CONIC_CURVE_TO_NV"/>
+            <enum name="GL_ROUNDED_RECT_NV"/>
+            <enum name="GL_RELATIVE_ROUNDED_RECT_NV"/>
+            <enum name="GL_ROUNDED_RECT2_NV"/>
+            <enum name="GL_RELATIVE_ROUNDED_RECT2_NV"/>
+            <enum name="GL_ROUNDED_RECT4_NV"/>
+            <enum name="GL_RELATIVE_ROUNDED_RECT4_NV"/>
+            <enum name="GL_ROUNDED_RECT8_NV"/>
+            <enum name="GL_RELATIVE_ROUNDED_RECT8_NV"/>
+            <enum name="GL_RESTART_PATH_NV"/>
+            <enum name="GL_DUP_FIRST_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_DUP_LAST_CUBIC_CURVE_TO_NV"/>
+            <enum name="GL_RECT_NV"/>
+            <enum name="GL_RELATIVE_RECT_NV"/>
+            <enum name="GL_CIRCULAR_CCW_ARC_TO_NV"/>
+            <enum name="GL_CIRCULAR_CW_ARC_TO_NV"/>
+            <enum name="GL_CIRCULAR_TANGENT_ARC_TO_NV"/>
+            <enum name="GL_ARC_TO_NV"/>
+            <enum name="GL_RELATIVE_ARC_TO_NV"/>
+        </group>
+
         <group name="AccumOp">
             <enum name="GL_ACCUM"/>
             <enum name="GL_LOAD"/>
@@ -206,48 +762,110 @@ typedef unsigned int GLhandleARB;
         <group name="BlendEquationModeEXT">
             <enum name="GL_ALPHA_MAX_SGIX"/>
             <enum name="GL_ALPHA_MIN_SGIX"/>
+            <enum name="GL_FUNC_ADD"/>
             <enum name="GL_FUNC_ADD_EXT"/>
+            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
             <enum name="GL_FUNC_REVERSE_SUBTRACT_EXT"/>
+            <enum name="GL_FUNC_SUBTRACT"/>
             <enum name="GL_FUNC_SUBTRACT_EXT"/>
-            <enum name="GL_LOGIC_OP"/>
+            <enum name="GL_MAX"/>
             <enum name="GL_MAX_EXT"/>
+            <enum name="GL_MIN"/>
             <enum name="GL_MIN_EXT"/>
-        </group>
-
-        <group name="BlendingFactorDest">
-            <enum name="GL_CONSTANT_ALPHA_EXT"/>
-            <enum name="GL_CONSTANT_COLOR_EXT"/>
-            <enum name="GL_DST_ALPHA"/>
-            <enum name="GL_ONE"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_ALPHA_EXT"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_COLOR_EXT"/>
-            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
-            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
-            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
-            <enum name="GL_SRC_ALPHA"/>
-            <enum name="GL_SRC_COLOR"/>
-            <enum name="GL_ZERO"/>
-        </group>
-
-        <group name="BlendingFactorSrc">
-            <enum name="GL_CONSTANT_ALPHA_EXT"/>
-            <enum name="GL_CONSTANT_COLOR_EXT"/>
-            <enum name="GL_DST_ALPHA"/>
-            <enum name="GL_DST_COLOR"/>
-            <enum name="GL_ONE"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_ALPHA_EXT"/>
-            <enum name="GL_ONE_MINUS_CONSTANT_COLOR_EXT"/>
-            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
-            <enum name="GL_ONE_MINUS_DST_COLOR"/>
-            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
-            <enum name="GL_SRC_ALPHA"/>
-            <enum name="GL_SRC_ALPHA_SATURATE"/>
-            <enum name="GL_ZERO"/>
         </group>
 
         <group name="Boolean">
             <enum name="GL_FALSE"/>
             <enum name="GL_TRUE"/>
+        </group>
+
+        <group name="BufferBitQCOM">
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT7_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT6_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT5_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT4_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT3_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT2_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT1_QCOM"/>
+            <enum name="GL_MULTISAMPLE_BUFFER_BIT0_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT7_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT6_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT5_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT4_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT3_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT2_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT1_QCOM"/>
+            <enum name="GL_STENCIL_BUFFER_BIT0_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT7_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT6_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT5_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT4_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT3_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT2_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT1_QCOM"/>
+            <enum name="GL_DEPTH_BUFFER_BIT0_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT7_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT6_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT5_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT4_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT3_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT2_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT1_QCOM"/>
+            <enum name="GL_COLOR_BUFFER_BIT0_QCOM"/>
+        </group>
+
+        <group name="BufferTargetARB">
+          <enum name="GL_ARRAY_BUFFER"/>
+          <enum name="GL_ATOMIC_COUNTER_BUFFER" />
+          <enum name="GL_COPY_READ_BUFFER" />
+          <enum name="GL_COPY_WRITE_BUFFER" />
+          <enum name="GL_DISPATCH_INDIRECT_BUFFER" />
+          <enum name="GL_DRAW_INDIRECT_BUFFER" />
+          <enum name="GL_ELEMENT_ARRAY_BUFFER" />
+          <enum name="GL_PIXEL_PACK_BUFFER" />
+          <enum name="GL_PIXEL_UNPACK_BUFFER" />
+          <enum name="GL_QUERY_BUFFER" />
+          <enum name="GL_SHADER_STORAGE_BUFFER" />
+          <enum name="GL_TEXTURE_BUFFER" />
+          <enum name="GL_TRANSFORM_FEEDBACK_BUFFER" />
+          <enum name="GL_UNIFORM_BUFFER" />
+          <enum name="GL_PARAMETER_BUFFER" />
+        </group>
+
+        <group name="BufferUsageARB">
+          <enum name="GL_STREAM_DRAW"/>
+          <enum name="GL_STREAM_READ"/>
+          <enum name="GL_STREAM_COPY"/>
+          <enum name="GL_STATIC_DRAW"/>
+          <enum name="GL_STATIC_READ"/>
+          <enum name="GL_STATIC_COPY"/>
+          <enum name="GL_DYNAMIC_DRAW"/>
+          <enum name="GL_DYNAMIC_READ"/>
+          <enum name="GL_DYNAMIC_COPY"/>
+        </group>
+
+        <group name="BufferAccessARB">
+          <enum name="GL_READ_ONLY"/>
+          <enum name="GL_WRITE_ONLY"/>
+          <enum name="GL_READ_WRITE"/>
+        </group>
+
+        <group name="BufferStorageMask">
+            <enum name="GL_CLIENT_STORAGE_BIT"/>
+            <enum name="GL_CLIENT_STORAGE_BIT_EXT"/>
+            <enum name="GL_DYNAMIC_STORAGE_BIT"/>
+            <enum name="GL_DYNAMIC_STORAGE_BIT_EXT"/>
+            <enum name="GL_MAP_COHERENT_BIT"/>
+            <enum name="GL_MAP_COHERENT_BIT_EXT"/>
+            <enum name="GL_MAP_PERSISTENT_BIT"/>
+            <enum name="GL_MAP_PERSISTENT_BIT_EXT"/>
+            <enum name="GL_MAP_READ_BIT"/>
+            <enum name="GL_MAP_READ_BIT_EXT"/>
+            <enum name="GL_MAP_WRITE_BIT"/>
+            <enum name="GL_MAP_WRITE_BIT_EXT"/>
+            <enum name="GL_SPARSE_STORAGE_BIT_ARB"/>
+            <enum name="GL_LGPU_SEPARATE_STORAGE_BIT_NVX"/>
+            <enum name="GL_PER_GPU_STORAGE_BIT_NV"/>
         </group>
 
         <group name="ClearBufferMask">
@@ -334,8 +952,11 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONTEXT_FLAG_DEBUG_BIT"/>
             <enum name="GL_CONTEXT_FLAG_DEBUG_BIT_KHR"/>
             <enum name="GL_CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT"/>
+            <enum name="GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT"/>
             <enum name="GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB"/>
             <enum name="GL_CONTEXT_FLAG_PROTECTED_CONTENT_BIT_EXT"/>
+            <enum name="GL_CONTEXT_FLAG_NO_ERROR_BIT"/>
+            <enum name="GL_CONTEXT_FLAG_NO_ERROR_BIT_KHR"/>
         </group>
 
         <group name="ContextProfileMask">
@@ -399,6 +1020,44 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_NONE"/>
             <enum name="GL_NONE_OES"/>
             <enum name="GL_RIGHT"/>
+            <enum name="GL_COLOR_ATTACHMENT0"/>
+            <enum name="GL_COLOR_ATTACHMENT1"/>
+            <enum name="GL_COLOR_ATTACHMENT2"/>
+            <enum name="GL_COLOR_ATTACHMENT3"/>
+            <enum name="GL_COLOR_ATTACHMENT4"/>
+            <enum name="GL_COLOR_ATTACHMENT5"/>
+            <enum name="GL_COLOR_ATTACHMENT6"/>
+            <enum name="GL_COLOR_ATTACHMENT7"/>
+            <enum name="GL_COLOR_ATTACHMENT8"/>
+            <enum name="GL_COLOR_ATTACHMENT9"/>
+            <enum name="GL_COLOR_ATTACHMENT10"/>
+            <enum name="GL_COLOR_ATTACHMENT11"/>
+            <enum name="GL_COLOR_ATTACHMENT12"/>
+            <enum name="GL_COLOR_ATTACHMENT13"/>
+            <enum name="GL_COLOR_ATTACHMENT14"/>
+            <enum name="GL_COLOR_ATTACHMENT15"/>
+            <enum name="GL_COLOR_ATTACHMENT16"/>
+            <enum name="GL_COLOR_ATTACHMENT17"/>
+            <enum name="GL_COLOR_ATTACHMENT18"/>
+            <enum name="GL_COLOR_ATTACHMENT19"/>
+            <enum name="GL_COLOR_ATTACHMENT20"/>
+            <enum name="GL_COLOR_ATTACHMENT21"/>
+            <enum name="GL_COLOR_ATTACHMENT22"/>
+            <enum name="GL_COLOR_ATTACHMENT23"/>
+            <enum name="GL_COLOR_ATTACHMENT24"/>
+            <enum name="GL_COLOR_ATTACHMENT25"/>
+            <enum name="GL_COLOR_ATTACHMENT26"/>
+            <enum name="GL_COLOR_ATTACHMENT27"/>
+            <enum name="GL_COLOR_ATTACHMENT28"/>
+            <enum name="GL_COLOR_ATTACHMENT29"/>
+            <enum name="GL_COLOR_ATTACHMENT30"/>
+            <enum name="GL_COLOR_ATTACHMENT31"/>
+        </group>
+
+        <group name="DrawElementsType">
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_UNSIGNED_INT"/>
         </group>
 
         <group name="EnableCap">
@@ -410,6 +1069,14 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_AUTO_NORMAL"/>
             <enum name="GL_BLEND"/>
             <enum name="GL_CALLIGRAPHIC_FRAGMENT_SGIX"/>
+            <enum name="GL_CLIP_DISTANCE0"/>
+            <enum name="GL_CLIP_DISTANCE1"/>
+            <enum name="GL_CLIP_DISTANCE2"/>
+            <enum name="GL_CLIP_DISTANCE3"/>
+            <enum name="GL_CLIP_DISTANCE4"/>
+            <enum name="GL_CLIP_DISTANCE5"/>
+            <enum name="GL_CLIP_DISTANCE6"/>
+            <enum name="GL_CLIP_DISTANCE7"/>
             <enum name="GL_CLIP_PLANE0"/>
             <enum name="GL_CLIP_PLANE1"/>
             <enum name="GL_CLIP_PLANE2"/>
@@ -423,6 +1090,9 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONVOLUTION_1D_EXT"/>
             <enum name="GL_CONVOLUTION_2D_EXT"/>
             <enum name="GL_CULL_FACE"/>
+            <enum name="GL_DEBUG_OUTPUT"/>
+            <enum name="GL_DEBUG_OUTPUT_SYNCHRONOUS"/>
+            <enum name="GL_DEPTH_CLAMP"/>
             <enum name="GL_DEPTH_TEST"/>
             <enum name="GL_DITHER"/>
             <enum name="GL_EDGE_FLAG_ARRAY"/>
@@ -438,6 +1108,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FRAGMENT_LIGHT6_SGIX"/>
             <enum name="GL_FRAGMENT_LIGHT7_SGIX"/>
             <enum name="GL_FRAGMENT_LIGHTING_SGIX"/>
+            <enum name="GL_FRAMEBUFFER_SRGB"/>
             <enum name="GL_FRAMEZOOM_SGIX"/>
             <enum name="GL_HISTOGRAM_EXT"/>
             <enum name="GL_INDEX_ARRAY"/>
@@ -474,6 +1145,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MAP2_VERTEX_3"/>
             <enum name="GL_MAP2_VERTEX_4"/>
             <enum name="GL_MINMAX_EXT"/>
+            <enum name="GL_MULTISAMPLE"/>
             <enum name="GL_MULTISAMPLE_SGIS"/>
             <enum name="GL_NORMALIZE"/>
             <enum name="GL_NORMAL_ARRAY"/>
@@ -487,11 +1159,20 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_POLYGON_STIPPLE"/>
             <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE_SGI"/>
             <enum name="GL_POST_CONVOLUTION_COLOR_TABLE_SGI"/>
+            <enum name="GL_PRIMITIVE_RESTART"/>
+            <enum name="GL_PRIMITIVE_RESTART_FIXED_INDEX"/>
+            <enum name="GL_PROGRAM_POINT_SIZE"/>
+            <enum name="GL_RASTERIZER_DISCARD"/>
             <enum name="GL_REFERENCE_PLANE_SGIX"/>
             <enum name="GL_RESCALE_NORMAL_EXT"/>
+            <enum name="GL_SAMPLE_ALPHA_TO_COVERAGE"/>
             <enum name="GL_SAMPLE_ALPHA_TO_MASK_SGIS"/>
+            <enum name="GL_SAMPLE_ALPHA_TO_ONE"/>
             <enum name="GL_SAMPLE_ALPHA_TO_ONE_SGIS"/>
+            <enum name="GL_SAMPLE_COVERAGE"/>
+            <enum name="GL_SAMPLE_MASK"/>
             <enum name="GL_SAMPLE_MASK_SGIS"/>
+            <enum name="GL_SAMPLE_SHADING"/>
             <enum name="GL_SCISSOR_TEST"/>
             <enum name="GL_SEPARABLE_2D_EXT"/>
             <enum name="GL_SHARED_TEXTURE_PALETTE_EXT"/>
@@ -503,6 +1184,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_4D_SGIS"/>
             <enum name="GL_TEXTURE_COLOR_TABLE_SGI"/>
             <enum name="GL_TEXTURE_COORD_ARRAY"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_SEAMLESS"/>
             <enum name="GL_TEXTURE_GEN_Q"/>
             <enum name="GL_TEXTURE_GEN_R"/>
             <enum name="GL_TEXTURE_GEN_S"/>
@@ -524,6 +1206,17 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TABLE_TOO_LARGE"/>
             <enum name="GL_TABLE_TOO_LARGE_EXT"/>
             <enum name="GL_TEXTURE_TOO_LARGE_EXT"/>
+        </group>
+
+        <group name="ExternalHandleType">
+            <enum name="GL_HANDLE_TYPE_OPAQUE_FD_EXT"/>
+            <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_EXT"/>
+            <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT"/>
+            <enum name="GL_HANDLE_TYPE_D3D12_TILEPOOL_EXT"/>
+            <enum name="GL_HANDLE_TYPE_D3D12_RESOURCE_EXT"/>
+            <enum name="GL_HANDLE_TYPE_D3D11_IMAGE_EXT"/>
+            <enum name="GL_HANDLE_TYPE_D3D11_IMAGE_KMT_EXT"/>
+            <enum name="GL_HANDLE_TYPE_D3D12_FENCE_EXT"/>
         </group>
 
         <group name="FeedbackType">
@@ -591,6 +1284,10 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FRAGMENT_LIGHT_MODEL_TWO_SIDE_SGIX"/>
         </group>
 
+        <group name="FramebufferFetchNoncoherent">
+            <enum name="GL_FRAMEBUFFER_FETCH_NONCOHERENT_QCOM"/>
+        </group>
+
         <group name="FrontFaceDirection">
             <enum name="GL_CCW"/>
             <enum name="GL_CW"/>
@@ -607,6 +1304,16 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_COLOR_TABLE_RED_SIZE_SGI"/>
             <enum name="GL_COLOR_TABLE_SCALE_SGI"/>
             <enum name="GL_COLOR_TABLE_WIDTH_SGI"/>
+            <enum name="GL_COLOR_TABLE_BIAS"/>
+            <enum name="GL_COLOR_TABLE_SCALE"/>
+            <enum name="GL_COLOR_TABLE_FORMAT"/>
+            <enum name="GL_COLOR_TABLE_WIDTH"/>
+            <enum name="GL_COLOR_TABLE_RED_SIZE"/>
+            <enum name="GL_COLOR_TABLE_GREEN_SIZE"/>
+            <enum name="GL_COLOR_TABLE_BLUE_SIZE"/>
+            <enum name="GL_COLOR_TABLE_ALPHA_SIZE"/>
+            <enum name="GL_COLOR_TABLE_LUMINANCE_SIZE"/>
+            <enum name="GL_COLOR_TABLE_INTENSITY_SIZE"/>
         </group>
 
         <group name="GetConvolutionParameter">
@@ -618,9 +1325,34 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONVOLUTION_WIDTH_EXT"/>
             <enum name="GL_MAX_CONVOLUTION_HEIGHT_EXT"/>
             <enum name="GL_MAX_CONVOLUTION_WIDTH_EXT"/>
+            <enum name="GL_CONVOLUTION_BORDER_MODE"/>
+            <enum name="GL_CONVOLUTION_BORDER_COLOR"/>
+            <enum name="GL_CONVOLUTION_FILTER_SCALE"/>
+            <enum name="GL_CONVOLUTION_FILTER_BIAS"/>
+            <enum name="GL_CONVOLUTION_FORMAT"/>
+            <enum name="GL_CONVOLUTION_WIDTH"/>
+            <enum name="GL_CONVOLUTION_HEIGHT"/>
+            <enum name="GL_MAX_CONVOLUTION_WIDTH"/>
+            <enum name="GL_MAX_CONVOLUTION_HEIGHT"/>
         </group>
 
         <group name="GetHistogramParameterPNameEXT">
+            <enum name="GL_HISTOGRAM_ALPHA_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_BLUE_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_FORMAT_EXT"/>
+            <enum name="GL_HISTOGRAM_GREEN_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_LUMINANCE_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_RED_SIZE_EXT"/>
+            <enum name="GL_HISTOGRAM_SINK_EXT"/>
+            <enum name="GL_HISTOGRAM_WIDTH_EXT"/>
+            <enum name="GL_HISTOGRAM_WIDTH"/>
+            <enum name="GL_HISTOGRAM_FORMAT"/>
+            <enum name="GL_HISTOGRAM_RED_SIZE"/>
+            <enum name="GL_HISTOGRAM_GREEN_SIZE"/>
+            <enum name="GL_HISTOGRAM_BLUE_SIZE"/>
+            <enum name="GL_HISTOGRAM_ALPHA_SIZE"/>
+            <enum name="GL_HISTOGRAM_LUMINANCE_SIZE"/>
+            <enum name="GL_HISTOGRAM_SINK"/>
             <enum name="GL_HISTOGRAM_ALPHA_SIZE_EXT"/>
             <enum name="GL_HISTOGRAM_BLUE_SIZE_EXT"/>
             <enum name="GL_HISTOGRAM_FORMAT_EXT"/>
@@ -642,6 +1374,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MINMAX_FORMAT_EXT"/>
             <enum name="GL_MINMAX_SINK"/>
             <enum name="GL_MINMAX_SINK_EXT"/>
+            <enum name="GL_MINMAX_FORMAT"/>
+            <enum name="GL_MINMAX_SINK"/>
         </group>
 
         <group name="GetPixelMap">
@@ -663,6 +1397,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_ACCUM_CLEAR_VALUE"/>
             <enum name="GL_ACCUM_GREEN_BITS"/>
             <enum name="GL_ACCUM_RED_BITS"/>
+            <enum name="GL_ACTIVE_TEXTURE"/>
             <enum name="GL_ALIASED_LINE_WIDTH_RANGE"/>
             <enum name="GL_ALIASED_POINT_SIZE_RANGE"/>
             <enum name="GL_ALPHA_BIAS"/>
@@ -674,6 +1409,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_ALPHA_TEST_QCOM"/>
             <enum name="GL_ALPHA_TEST_REF"/>
             <enum name="GL_ALPHA_TEST_REF_QCOM"/>
+            <enum name="GL_ARRAY_BUFFER_BINDING"/>
             <enum name="GL_ASYNC_DRAW_PIXELS_SGIX"/>
             <enum name="GL_ASYNC_HISTOGRAM_SGIX"/>
             <enum name="GL_ASYNC_MARKER_SGIX"/>
@@ -683,10 +1419,17 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_AUTO_NORMAL"/>
             <enum name="GL_AUX_BUFFERS"/>
             <enum name="GL_BLEND"/>
+            <enum name="GL_BLEND_COLOR"/>
             <enum name="GL_BLEND_COLOR_EXT"/>
             <enum name="GL_BLEND_DST"/>
+            <enum name="GL_BLEND_DST_ALPHA"/>
+            <enum name="GL_BLEND_DST_RGB"/>
+            <enum name="GL_BLEND_EQUATION_ALPHA"/>
             <enum name="GL_BLEND_EQUATION_EXT"/>
+            <enum name="GL_BLEND_EQUATION_RGB"/>
             <enum name="GL_BLEND_SRC"/>
+            <enum name="GL_BLEND_SRC_ALPHA"/>
+            <enum name="GL_BLEND_SRC_RGB"/>
             <enum name="GL_BLUE_BIAS"/>
             <enum name="GL_BLUE_BITS"/>
             <enum name="GL_BLUE_SCALE"/>
@@ -712,6 +1455,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_COLOR_MATRIX_STACK_DEPTH_SGI"/>
             <enum name="GL_COLOR_TABLE_SGI"/>
             <enum name="GL_COLOR_WRITEMASK"/>
+            <enum name="GL_COMPRESSED_TEXTURE_FORMATS"/>
+            <enum name="GL_CONTEXT_FLAGS"/>
             <enum name="GL_CONVOLUTION_1D_EXT"/>
             <enum name="GL_CONVOLUTION_2D_EXT"/>
             <enum name="GL_CONVOLUTION_HINT_SGIX"/>
@@ -720,6 +1465,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CURRENT_COLOR"/>
             <enum name="GL_CURRENT_INDEX"/>
             <enum name="GL_CURRENT_NORMAL"/>
+            <enum name="GL_CURRENT_PROGRAM"/>
             <enum name="GL_CURRENT_RASTER_COLOR"/>
             <enum name="GL_CURRENT_RASTER_DISTANCE"/>
             <enum name="GL_CURRENT_RASTER_INDEX"/>
@@ -727,6 +1473,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CURRENT_RASTER_POSITION_VALID"/>
             <enum name="GL_CURRENT_RASTER_TEXTURE_COORDS"/>
             <enum name="GL_CURRENT_TEXTURE_COORDS"/>
+            <enum name="GL_DEBUG_GROUP_STACK_DEPTH"/>
             <enum name="GL_DEFORMATIONS_MASK_SGIX"/>
             <enum name="GL_DEPTH_BIAS"/>
             <enum name="GL_DEPTH_BITS"/>
@@ -737,15 +1484,22 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_DEPTH_TEST"/>
             <enum name="GL_DEPTH_WRITEMASK"/>
             <enum name="GL_DETAIL_TEXTURE_2D_BINDING_SGIS"/>
+            <enum name="GL_DEVICE_LUID_EXT"/>
+            <enum name="GL_DEVICE_NODE_MASK_EXT"/>
+            <enum name="GL_DEVICE_UUID_EXT"/>
+            <enum name="GL_DISPATCH_INDIRECT_BUFFER_BINDING"/>
             <enum name="GL_DISTANCE_ATTENUATION_SGIS"/>
             <enum name="GL_DITHER"/>
             <enum name="GL_DOUBLEBUFFER"/>
             <enum name="GL_DRAW_BUFFER"/>
             <enum name="GL_DRAW_BUFFER_EXT"/>
+            <enum name="GL_DRAW_FRAMEBUFFER_BINDING"/>
+            <enum name="GL_DRIVER_UUID_EXT"/>
             <enum name="GL_EDGE_FLAG"/>
             <enum name="GL_EDGE_FLAG_ARRAY"/>
             <enum name="GL_EDGE_FLAG_ARRAY_COUNT_EXT"/>
             <enum name="GL_EDGE_FLAG_ARRAY_STRIDE"/>
+            <enum name="GL_ELEMENT_ARRAY_BUFFER_BINDING"/>
             <enum name="GL_FEEDBACK_BUFFER_SIZE"/>
             <enum name="GL_FEEDBACK_BUFFER_TYPE"/>
             <enum name="GL_FOG"/>
@@ -768,6 +1522,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FRAGMENT_LIGHT_MODEL_LOCAL_VIEWER_SGIX"/>
             <enum name="GL_FRAGMENT_LIGHT_MODEL_NORMAL_INTERPOLATION_SGIX"/>
             <enum name="GL_FRAGMENT_LIGHT_MODEL_TWO_SIDE_SGIX"/>
+            <enum name="GL_FRAGMENT_SHADER_DERIVATIVE_HINT"/>
             <enum name="GL_FRAMEZOOM_FACTOR_SGIX"/>
             <enum name="GL_FRAMEZOOM_SGIX"/>
             <enum name="GL_FRONT_FACE"/>
@@ -776,6 +1531,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_GREEN_BITS"/>
             <enum name="GL_GREEN_SCALE"/>
             <enum name="GL_HISTOGRAM_EXT"/>
+            <enum name="GL_IMPLEMENTATION_COLOR_READ_FORMAT"/>
+            <enum name="GL_IMPLEMENTATION_COLOR_READ_TYPE"/>
             <enum name="GL_INDEX_ARRAY"/>
             <enum name="GL_INDEX_ARRAY_COUNT_EXT"/>
             <enum name="GL_INDEX_ARRAY_STRIDE"/>
@@ -790,6 +1547,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_INSTRUMENT_MEASUREMENTS_SGIX"/>
             <enum name="GL_INTERLACE_SGIX"/>
             <enum name="GL_IR_INSTRUMENT1_SGIX"/>
+            <enum name="GL_LAYER_PROVOKING_VERTEX"/>
             <enum name="GL_LIGHT0"/>
             <enum name="GL_LIGHT1"/>
             <enum name="GL_LIGHT2"/>
@@ -817,6 +1575,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_LIST_MODE"/>
             <enum name="GL_LOGIC_OP"/>
             <enum name="GL_LOGIC_OP_MODE"/>
+            <enum name="GL_MAJOR_VERSION"/>
             <enum name="GL_MAP1_COLOR_4"/>
             <enum name="GL_MAP1_GRID_DOMAIN"/>
             <enum name="GL_MAP1_GRID_SEGMENTS"/>
@@ -842,9 +1601,11 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MAP_COLOR"/>
             <enum name="GL_MAP_STENCIL"/>
             <enum name="GL_MATRIX_MODE"/>
+            <enum name="GL_MAX_3D_TEXTURE_SIZE"/>
             <enum name="GL_MAX_3D_TEXTURE_SIZE_EXT"/>
             <enum name="GL_MAX_4D_TEXTURE_SIZE_SGIS"/>
             <enum name="GL_MAX_ACTIVE_LIGHTS_SGIX"/>
+            <enum name="GL_MAX_ARRAY_TEXTURE_LAYERS"/>
             <enum name="GL_MAX_ASYNC_DRAW_PIXELS_SGIX"/>
             <enum name="GL_MAX_ASYNC_HISTOGRAM_SGIX"/>
             <enum name="GL_MAX_ASYNC_READ_PIXELS_SGIX"/>
@@ -856,20 +1617,98 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MAX_CLIP_DISTANCES"/>
             <enum name="GL_MAX_CLIP_PLANES"/>
             <enum name="GL_MAX_COLOR_MATRIX_STACK_DEPTH_SGI"/>
+            <enum name="GL_MAX_COLOR_TEXTURE_SAMPLES"/>
+            <enum name="GL_MAX_COMBINED_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_COMBINED_COMPUTE_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_COMBINED_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS"/>
+            <enum name="GL_MAX_COMBINED_UNIFORM_BLOCKS"/>
+            <enum name="GL_MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_COMPUTE_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_COMPUTE_ATOMIC_COUNTER_BUFFERS"/>
+            <enum name="GL_MAX_COMPUTE_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_COMPUTE_TEXTURE_IMAGE_UNITS"/>
+            <enum name="GL_MAX_COMPUTE_UNIFORM_BLOCKS"/>
+            <enum name="GL_MAX_COMPUTE_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_COMPUTE_WORK_GROUP_COUNT"/>
+            <enum name="GL_MAX_COMPUTE_WORK_GROUP_INVOCATIONS"/>
+            <enum name="GL_MAX_COMPUTE_WORK_GROUP_SIZE"/>
+            <enum name="GL_MAX_CUBE_MAP_TEXTURE_SIZE"/>
+            <enum name="GL_MAX_DEBUG_GROUP_STACK_DEPTH"/>
+            <enum name="GL_MAX_DEPTH_TEXTURE_SAMPLES"/>
+            <enum name="GL_MAX_DRAW_BUFFERS"/>
+            <enum name="GL_MAX_DUAL_SOURCE_DRAW_BUFFERS"/>
+            <enum name="GL_MAX_ELEMENTS_INDICES"/>
+            <enum name="GL_MAX_ELEMENTS_VERTICES"/>
+            <enum name="GL_MAX_ELEMENT_INDEX"/>
             <enum name="GL_MAX_EVAL_ORDER"/>
             <enum name="GL_MAX_FOG_FUNC_POINTS_SGIS"/>
+            <enum name="GL_MAX_FRAGMENT_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_FRAGMENT_INPUT_COMPONENTS"/>
             <enum name="GL_MAX_FRAGMENT_LIGHTS_SGIX"/>
+            <enum name="GL_MAX_FRAGMENT_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_FRAGMENT_UNIFORM_BLOCKS"/>
+            <enum name="GL_MAX_FRAGMENT_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_FRAGMENT_UNIFORM_VECTORS"/>
+            <enum name="GL_MAX_FRAMEBUFFER_HEIGHT"/>
+            <enum name="GL_MAX_FRAMEBUFFER_LAYERS"/>
+            <enum name="GL_MAX_FRAMEBUFFER_SAMPLES"/>
+            <enum name="GL_MAX_FRAMEBUFFER_WIDTH"/>
             <enum name="GL_MAX_FRAMEZOOM_FACTOR_SGIX"/>
+            <enum name="GL_MAX_GEOMETRY_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_GEOMETRY_INPUT_COMPONENTS"/>
+            <enum name="GL_MAX_GEOMETRY_OUTPUT_COMPONENTS"/>
+            <enum name="GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS"/>
+            <enum name="GL_MAX_GEOMETRY_UNIFORM_BLOCKS"/>
+            <enum name="GL_MAX_GEOMETRY_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_INTEGER_SAMPLES"/>
+            <enum name="GL_MAX_LABEL_LENGTH"/>
             <enum name="GL_MAX_LIGHTS"/>
             <enum name="GL_MAX_LIST_NESTING"/>
             <enum name="GL_MAX_MODELVIEW_STACK_DEPTH"/>
             <enum name="GL_MAX_NAME_STACK_DEPTH"/>
             <enum name="GL_MAX_PIXEL_MAP_TABLE"/>
+            <enum name="GL_MAX_PROGRAM_TEXEL_OFFSET"/>
             <enum name="GL_MAX_PROJECTION_STACK_DEPTH"/>
+            <enum name="GL_MAX_RECTANGLE_TEXTURE_SIZE"/>
+            <enum name="GL_MAX_RENDERBUFFER_SIZE"/>
+            <enum name="GL_MAX_SAMPLE_MASK_WORDS"/>
+            <enum name="GL_MAX_SERVER_WAIT_TIMEOUT"/>
+            <enum name="GL_MAX_SHADER_STORAGE_BUFFER_BINDINGS"/>
+            <enum name="GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_TEXTURE_BUFFER_SIZE"/>
+            <enum name="GL_MAX_TEXTURE_IMAGE_UNITS"/>
+            <enum name="GL_MAX_TEXTURE_LOD_BIAS"/>
             <enum name="GL_MAX_TEXTURE_SIZE"/>
             <enum name="GL_MAX_TEXTURE_STACK_DEPTH"/>
+            <enum name="GL_MAX_UNIFORM_BLOCK_SIZE"/>
+            <enum name="GL_MAX_UNIFORM_BUFFER_BINDINGS"/>
+            <enum name="GL_MAX_UNIFORM_LOCATIONS"/>
+            <enum name="GL_MAX_VARYING_COMPONENTS"/>
+            <enum name="GL_MAX_VARYING_FLOATS"/>
+            <enum name="GL_MAX_VARYING_VECTORS"/>
+            <enum name="GL_MAX_VERTEX_ATOMIC_COUNTERS"/>
+            <enum name="GL_MAX_VERTEX_ATTRIBS"/>
+            <enum name="GL_MAX_VERTEX_ATTRIB_BINDINGS"/>
+            <enum name="GL_MAX_VERTEX_ATTRIB_RELATIVE_OFFSET"/>
+            <enum name="GL_MAX_VERTEX_OUTPUT_COMPONENTS"/>
+            <enum name="GL_MAX_VERTEX_SHADER_STORAGE_BLOCKS"/>
+            <enum name="GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS"/>
+            <enum name="GL_MAX_VERTEX_UNIFORM_BLOCKS"/>
+            <enum name="GL_MAX_VERTEX_UNIFORM_COMPONENTS"/>
+            <enum name="GL_MAX_VERTEX_UNIFORM_VECTORS"/>
+            <enum name="GL_MAX_VIEWPORTS"/>
             <enum name="GL_MAX_VIEWPORT_DIMS"/>
             <enum name="GL_MINMAX_EXT"/>
+            <enum name="GL_MINOR_VERSION"/>
+            <enum name="GL_MIN_MAP_BUFFER_ALIGNMENT"/>
+            <enum name="GL_MIN_PROGRAM_TEXEL_OFFSET"/>
             <enum name="GL_MODELVIEW0_MATRIX_EXT"/>
             <enum name="GL_MODELVIEW0_STACK_DEPTH_EXT"/>
             <enum name="GL_MODELVIEW_MATRIX"/>
@@ -881,13 +1720,20 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_NORMAL_ARRAY_COUNT_EXT"/>
             <enum name="GL_NORMAL_ARRAY_STRIDE"/>
             <enum name="GL_NORMAL_ARRAY_TYPE"/>
+            <enum name="GL_NUM_COMPRESSED_TEXTURE_FORMATS"/>
+            <enum name="GL_NUM_DEVICE_UUIDS_EXT"/>
+            <enum name="GL_NUM_EXTENSIONS"/>
+            <enum name="GL_NUM_PROGRAM_BINARY_FORMATS"/>
+            <enum name="GL_NUM_SHADER_BINARY_FORMATS"/>
             <enum name="GL_PACK_ALIGNMENT"/>
             <enum name="GL_PACK_CMYK_HINT_EXT"/>
             <enum name="GL_PACK_IMAGE_DEPTH_SGIS"/>
+            <enum name="GL_PACK_IMAGE_HEIGHT"/>
             <enum name="GL_PACK_IMAGE_HEIGHT_EXT"/>
             <enum name="GL_PACK_LSB_FIRST"/>
             <enum name="GL_PACK_RESAMPLE_SGIX"/>
             <enum name="GL_PACK_ROW_LENGTH"/>
+            <enum name="GL_PACK_SKIP_IMAGES"/>
             <enum name="GL_PACK_SKIP_IMAGES_EXT"/>
             <enum name="GL_PACK_SKIP_PIXELS"/>
             <enum name="GL_PACK_SKIP_ROWS"/>
@@ -905,6 +1751,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_PIXEL_MAP_I_TO_R_SIZE"/>
             <enum name="GL_PIXEL_MAP_R_TO_R_SIZE"/>
             <enum name="GL_PIXEL_MAP_S_TO_S_SIZE"/>
+            <enum name="GL_PIXEL_PACK_BUFFER_BINDING"/>
             <enum name="GL_PIXEL_TEXTURE_SGIS"/>
             <enum name="GL_PIXEL_TEX_GEN_MODE_SGIX"/>
             <enum name="GL_PIXEL_TEX_GEN_SGIX"/>
@@ -916,6 +1763,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_PIXEL_TILE_GRID_WIDTH_SGIX"/>
             <enum name="GL_PIXEL_TILE_HEIGHT_SGIX"/>
             <enum name="GL_PIXEL_TILE_WIDTH_SGIX"/>
+            <enum name="GL_PIXEL_UNPACK_BUFFER_BINDING"/>
+            <enum name="GL_POINT_FADE_THRESHOLD_SIZE"/>
             <enum name="GL_POINT_FADE_THRESHOLD_SIZE_SGIS"/>
             <enum name="GL_POINT_SIZE"/>
             <enum name="GL_POINT_SIZE_GRANULARITY"/>
@@ -954,23 +1803,35 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_POST_CONVOLUTION_RED_SCALE_EXT"/>
             <enum name="GL_POST_TEXTURE_FILTER_BIAS_RANGE_SGIX"/>
             <enum name="GL_POST_TEXTURE_FILTER_SCALE_RANGE_SGIX"/>
+            <enum name="GL_PRIMITIVE_RESTART_INDEX"/>
+            <enum name="GL_PROGRAM_BINARY_FORMATS"/>
+            <enum name="GL_PROGRAM_PIPELINE_BINDING"/>
+            <enum name="GL_PROGRAM_POINT_SIZE"/>
             <enum name="GL_PROJECTION_MATRIX"/>
             <enum name="GL_PROJECTION_STACK_DEPTH"/>
+            <enum name="GL_PROVOKING_VERTEX"/>
             <enum name="GL_READ_BUFFER"/>
             <enum name="GL_READ_BUFFER_EXT"/>
             <enum name="GL_READ_BUFFER_NV"/>
+            <enum name="GL_READ_FRAMEBUFFER_BINDING"/>
             <enum name="GL_RED_BIAS"/>
             <enum name="GL_RED_BITS"/>
             <enum name="GL_RED_SCALE"/>
             <enum name="GL_REFERENCE_PLANE_EQUATION_SGIX"/>
             <enum name="GL_REFERENCE_PLANE_SGIX"/>
+            <enum name="GL_RENDERBUFFER_BINDING"/>
             <enum name="GL_RENDER_MODE"/>
             <enum name="GL_RESCALE_NORMAL_EXT"/>
             <enum name="GL_RGBA_MODE"/>
+            <enum name="GL_SAMPLER_BINDING"/>
+            <enum name="GL_SAMPLES"/>
             <enum name="GL_SAMPLES_SGIS"/>
             <enum name="GL_SAMPLE_ALPHA_TO_MASK_SGIS"/>
             <enum name="GL_SAMPLE_ALPHA_TO_ONE_SGIS"/>
+            <enum name="GL_SAMPLE_BUFFERS"/>
             <enum name="GL_SAMPLE_BUFFERS_SGIS"/>
+            <enum name="GL_SAMPLE_COVERAGE_INVERT"/>
+            <enum name="GL_SAMPLE_COVERAGE_VALUE"/>
             <enum name="GL_SAMPLE_MASK_INVERT_SGIS"/>
             <enum name="GL_SAMPLE_MASK_SGIS"/>
             <enum name="GL_SAMPLE_MASK_VALUE_SGIS"/>
@@ -979,6 +1840,11 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_SCISSOR_TEST"/>
             <enum name="GL_SELECTION_BUFFER_SIZE"/>
             <enum name="GL_SEPARABLE_2D_EXT"/>
+            <enum name="GL_SHADER_COMPILER"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER_BINDING"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER_SIZE"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER_START"/>
             <enum name="GL_SHADE_MODEL"/>
             <enum name="GL_SHARED_TEXTURE_PALETTE_EXT"/>
             <enum name="GL_SMOOTH_LINE_WIDTH_GRANULARITY"/>
@@ -989,6 +1855,13 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_SPRITE_MODE_SGIX"/>
             <enum name="GL_SPRITE_SGIX"/>
             <enum name="GL_SPRITE_TRANSLATION_SGIX"/>
+            <enum name="GL_STENCIL_BACK_FAIL"/>
+            <enum name="GL_STENCIL_BACK_FUNC"/>
+            <enum name="GL_STENCIL_BACK_PASS_DEPTH_FAIL"/>
+            <enum name="GL_STENCIL_BACK_PASS_DEPTH_PASS"/>
+            <enum name="GL_STENCIL_BACK_REF"/>
+            <enum name="GL_STENCIL_BACK_VALUE_MASK"/>
+            <enum name="GL_STENCIL_BACK_WRITEMASK"/>
             <enum name="GL_STENCIL_BITS"/>
             <enum name="GL_STENCIL_CLEAR_VALUE"/>
             <enum name="GL_STENCIL_FAIL"/>
@@ -1008,9 +1881,18 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_4D_BINDING_SGIS"/>
             <enum name="GL_TEXTURE_4D_SGIS"/>
             <enum name="GL_TEXTURE_BINDING_1D"/>
+            <enum name="GL_TEXTURE_BINDING_1D_ARRAY"/>
             <enum name="GL_TEXTURE_BINDING_2D"/>
+            <enum name="GL_TEXTURE_BINDING_2D_ARRAY"/>
+            <enum name="GL_TEXTURE_BINDING_2D_MULTISAMPLE"/>
+            <enum name="GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY"/>
             <enum name="GL_TEXTURE_BINDING_3D"/>
+            <enum name="GL_TEXTURE_BINDING_BUFFER"/>
+            <enum name="GL_TEXTURE_BINDING_CUBE_MAP"/>
+            <enum name="GL_TEXTURE_BINDING_RECTANGLE"/>
+            <enum name="GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT"/>
             <enum name="GL_TEXTURE_COLOR_TABLE_SGI"/>
+            <enum name="GL_TEXTURE_COMPRESSION_HINT"/>
             <enum name="GL_TEXTURE_COORD_ARRAY"/>
             <enum name="GL_TEXTURE_COORD_ARRAY_COUNT_EXT"/>
             <enum name="GL_TEXTURE_COORD_ARRAY_SIZE"/>
@@ -1022,13 +1904,23 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_GEN_T"/>
             <enum name="GL_TEXTURE_MATRIX"/>
             <enum name="GL_TEXTURE_STACK_DEPTH"/>
+            <enum name="GL_TIMESTAMP"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_BINDING"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_SIZE"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_START"/>
+            <enum name="GL_UNIFORM_BUFFER_BINDING"/>
+            <enum name="GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT"/>
+            <enum name="GL_UNIFORM_BUFFER_SIZE"/>
+            <enum name="GL_UNIFORM_BUFFER_START"/>
             <enum name="GL_UNPACK_ALIGNMENT"/>
             <enum name="GL_UNPACK_CMYK_HINT_EXT"/>
             <enum name="GL_UNPACK_IMAGE_DEPTH_SGIS"/>
+            <enum name="GL_UNPACK_IMAGE_HEIGHT"/>
             <enum name="GL_UNPACK_IMAGE_HEIGHT_EXT"/>
             <enum name="GL_UNPACK_LSB_FIRST"/>
             <enum name="GL_UNPACK_RESAMPLE_SGIX"/>
             <enum name="GL_UNPACK_ROW_LENGTH"/>
+            <enum name="GL_UNPACK_SKIP_IMAGES"/>
             <enum name="GL_UNPACK_SKIP_IMAGES_EXT"/>
             <enum name="GL_UNPACK_SKIP_PIXELS"/>
             <enum name="GL_UNPACK_SKIP_ROWS"/>
@@ -1036,13 +1928,20 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_UNPACK_SUBSAMPLE_RATE_SGIX"/>
             <enum name="GL_UNPACK_SWAP_BYTES"/>
             <enum name="GL_VERTEX_ARRAY"/>
+            <enum name="GL_VERTEX_ARRAY_BINDING"/>
             <enum name="GL_VERTEX_ARRAY_COUNT_EXT"/>
             <enum name="GL_VERTEX_ARRAY_SIZE"/>
             <enum name="GL_VERTEX_ARRAY_STRIDE"/>
             <enum name="GL_VERTEX_ARRAY_TYPE"/>
+            <enum name="GL_VERTEX_BINDING_DIVISOR"/>
+            <enum name="GL_VERTEX_BINDING_OFFSET"/>
+            <enum name="GL_VERTEX_BINDING_STRIDE"/>
             <enum name="GL_VERTEX_PRECLIP_HINT_SGIX"/>
             <enum name="GL_VERTEX_PRECLIP_SGIX"/>
             <enum name="GL_VIEWPORT"/>
+            <enum name="GL_VIEWPORT_BOUNDS_RANGE"/>
+            <enum name="GL_VIEWPORT_INDEX_PROVOKING_VERTEX"/>
+            <enum name="GL_VIEWPORT_SUBPIXEL_BITS"/>
             <enum name="GL_ZOOM_X"/>
             <enum name="GL_ZOOM_Y"/>
         </group>
@@ -1063,6 +1962,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_COORD_ARRAY_POINTER_EXT"/>
             <enum name="GL_VERTEX_ARRAY_POINTER"/>
             <enum name="GL_VERTEX_ARRAY_POINTER_EXT"/>
+            <enum name="GL_DEBUG_CALLBACK_FUNCTION"/>
+            <enum name="GL_DEBUG_CALLBACK_USER_PARAM"/>
         </group>
 
         <group name="GetTextureParameter">
@@ -1311,10 +2212,9 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_XOR"/>
         </group>
 
-        <group name="MapBufferUsageMask">
-            <enum name="GL_CLIENT_STORAGE_BIT"/>
-            <enum name="GL_DYNAMIC_STORAGE_BIT"/>
+        <group name="MapBufferAccessMask">
             <enum name="GL_MAP_COHERENT_BIT"/>
+            <enum name="GL_MAP_COHERENT_BIT_EXT"/>
             <enum name="GL_MAP_FLUSH_EXPLICIT_BIT"/>
             <enum name="GL_MAP_FLUSH_EXPLICIT_BIT_EXT"/>
             <enum name="GL_MAP_INVALIDATE_BUFFER_BIT"/>
@@ -1322,6 +2222,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_MAP_INVALIDATE_RANGE_BIT"/>
             <enum name="GL_MAP_INVALIDATE_RANGE_BIT_EXT"/>
             <enum name="GL_MAP_PERSISTENT_BIT"/>
+            <enum name="GL_MAP_PERSISTENT_BIT_EXT"/>
             <enum name="GL_MAP_READ_BIT"/>
             <enum name="GL_MAP_READ_BIT_EXT"/>
             <enum name="GL_MAP_UNSYNCHRONIZED_BIT"/>
@@ -1390,6 +2291,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_BUFFER_UPDATE_BARRIER_BIT"/>
             <enum name="GL_BUFFER_UPDATE_BARRIER_BIT_EXT"/>
             <enum name="GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT"/>
+            <enum name="GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT_EXT"/>
             <enum name="GL_COMMAND_BARRIER_BIT"/>
             <enum name="GL_COMMAND_BARRIER_BIT_EXT"/>
             <enum name="GL_ELEMENT_ARRAY_BARRIER_BIT"/>
@@ -1413,6 +2315,11 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_UNIFORM_BARRIER_BIT_EXT"/>
             <enum name="GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT"/>
             <enum name="GL_VERTEX_ATTRIB_ARRAY_BARRIER_BIT_EXT"/>
+        </group>
+
+        <group name="MemoryObjectParameterName">
+            <enum name="GL_DEDICATED_MEMORY_OBJECT_EXT"/>
+            <enum name="GL_PROTECTED_MEMORY_OBJECT_EXT"/>
         </group>
 
         <group name="MeshMode1">
@@ -1451,18 +2358,30 @@ typedef unsigned int GLhandleARB;
         <group name="PixelFormat">
             <enum name="GL_ABGR_EXT"/>
             <enum name="GL_ALPHA"/>
+            <enum name="GL_BGR"/>
+            <enum name="GL_BGR_INTEGER"/>
+            <enum name="GL_BGRA"/>
+            <enum name="GL_BGRA_INTEGER"/>
             <enum name="GL_BLUE"/>
+            <enum name="GL_BLUE_INTEGER"/>
             <enum name="GL_CMYKA_EXT"/>
             <enum name="GL_CMYK_EXT"/>
             <enum name="GL_COLOR_INDEX"/>
             <enum name="GL_DEPTH_COMPONENT"/>
+            <enum name="GL_DEPTH_STENCIL"/>
             <enum name="GL_GREEN"/>
+            <enum name="GL_GREEN_INTEGER"/>
             <enum name="GL_LUMINANCE"/>
             <enum name="GL_LUMINANCE_ALPHA"/>
             <enum name="GL_RED"/>
             <enum name="GL_RED_EXT"/>
+            <enum name="GL_RED_INTEGER"/>
+            <enum name="GL_RG"/>
+            <enum name="GL_RG_INTEGER"/>
             <enum name="GL_RGB"/>
+            <enum name="GL_RGB_INTEGER"/>
             <enum name="GL_RGBA"/>
+            <enum name="GL_RGBA_INTEGER"/>
             <enum name="GL_STENCIL_INDEX"/>
             <enum name="GL_UNSIGNED_INT"/>
             <enum name="GL_UNSIGNED_SHORT"/>
@@ -1471,15 +2390,13 @@ typedef unsigned int GLhandleARB;
         </group>
 
         <group name="InternalFormat" comment="Was PixelInternalFormat">
+            <!-- Compatibility -->
             <enum name="GL_ALPHA12"/>
             <enum name="GL_ALPHA16"/>
-            <enum name="GL_ALPHA16_ICC_SGIX"/>
+            <!-- <enum name="GL_ALPHA16_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_ALPHA4"/>
             <enum name="GL_ALPHA8"/>
-            <enum name="GL_ALPHA_ICC_SGIX"/>
-            <enum name="GL_DEPTH_COMPONENT16_SGIX"/>
-            <enum name="GL_DEPTH_COMPONENT24_SGIX"/>
-            <enum name="GL_DEPTH_COMPONENT32_SGIX"/>
+            <!-- <enum name="GL_ALPHA_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_DUAL_ALPHA12_SGIS"/>
             <enum name="GL_DUAL_ALPHA16_SGIS"/>
             <enum name="GL_DUAL_ALPHA4_SGIS"/>
@@ -1497,49 +2414,303 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_INTENSITY"/>
             <enum name="GL_INTENSITY12"/>
             <enum name="GL_INTENSITY16"/>
-            <enum name="GL_INTENSITY16_ICC_SGIX"/>
+            <!-- <enum name="GL_INTENSITY16_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_INTENSITY4"/>
             <enum name="GL_INTENSITY8"/>
-            <enum name="GL_INTENSITY_ICC_SGIX"/>
+            <!-- <enum name="GL_INTENSITY_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_LUMINANCE12"/>
             <enum name="GL_LUMINANCE12_ALPHA12"/>
             <enum name="GL_LUMINANCE12_ALPHA4"/>
             <enum name="GL_LUMINANCE16"/>
             <enum name="GL_LUMINANCE16_ALPHA16"/>
-            <enum name="GL_LUMINANCE16_ALPHA8_ICC_SGIX"/>
-            <enum name="GL_LUMINANCE16_ICC_SGIX"/>
+            <!-- <enum name="GL_LUMINANCE16_ALPHA8_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- <enum name="GL_LUMINANCE16_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_LUMINANCE4"/>
             <enum name="GL_LUMINANCE4_ALPHA4"/>
             <enum name="GL_LUMINANCE6_ALPHA2"/>
             <enum name="GL_LUMINANCE8"/>
             <enum name="GL_LUMINANCE8_ALPHA8"/>
-            <enum name="GL_LUMINANCE_ALPHA_ICC_SGIX"/>
-            <enum name="GL_LUMINANCE_ICC_SGIX"/>
+            <!-- <enum name="GL_LUMINANCE_ALPHA_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- <enum name="GL_LUMINANCE_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
             <enum name="GL_QUAD_ALPHA4_SGIS"/>
             <enum name="GL_QUAD_ALPHA8_SGIS"/>
             <enum name="GL_QUAD_INTENSITY4_SGIS"/>
             <enum name="GL_QUAD_INTENSITY8_SGIS"/>
             <enum name="GL_QUAD_LUMINANCE4_SGIS"/>
             <enum name="GL_QUAD_LUMINANCE8_SGIS"/>
-            <enum name="GL_R3_G3_B2"/>
-            <enum name="GL_R5_G6_B5_A8_ICC_SGIX"/>
-            <enum name="GL_R5_G6_B5_ICC_SGIX"/>
-            <enum name="GL_RGB10"/>
-            <enum name="GL_RGB10_A2"/>
-            <enum name="GL_RGB12"/>
-            <enum name="GL_RGB16"/>
+            <!-- <enum name="GL_R5_G6_B5_A8_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- <enum name="GL_R5_G6_B5_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- <enum name="GL_RGBA_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- <enum name="GL_RGB_ICC_SGIX" comment="Incomplete extension SGIX_icc_texture"/> -->
+            <!-- Base internal format: GL_RED -->
+            <enum name="GL_RED"/>
+            <enum name="GL_RED_EXT"/>
+            <enum name="GL_R8"/>
+            <enum name="GL_R8_EXT"/>
+            <enum name="GL_R8_SNORM"/>
+            <enum name="GL_R16"/>
+            <enum name="GL_R16_EXT"/>
+            <enum name="GL_R16_SNORM"/>
+            <enum name="GL_R16_SNORM_EXT"/>
+            <!-- <enum name="GL_R32" comment="cut & paste error?"/> -->
+            <!-- <enum name="GL_R32_EXT" comment="cut & paste error?"/> -->
+            <enum name="GL_R16F"/>
+            <enum name="GL_R16F_EXT"/>
+            <enum name="GL_R32F"/>
+            <enum name="GL_R32F_EXT"/>
+            <enum name="GL_R8I"/>
+            <enum name="GL_R16I"/>
+            <enum name="GL_R32I"/>
+            <enum name="GL_R8UI"/>
+            <enum name="GL_R16UI"/>
+            <enum name="GL_R32UI"/>
+            <!-- Base internal format: GL_RG -->
+            <enum name="GL_RG"/>
+            <enum name="GL_RG8"/>
+            <enum name="GL_RG8_EXT"/>
+            <enum name="GL_RG8_SNORM"/>
+            <enum name="GL_RG16"/>
+            <enum name="GL_RG16_EXT"/>
+            <enum name="GL_RG16_SNORM"/>
+            <enum name="GL_RG16_SNORM_EXT"/>
+            <enum name="GL_RG16F"/>
+            <enum name="GL_RG16F_EXT"/>
+            <enum name="GL_RG32F"/>
+            <enum name="GL_RG32F_EXT"/>
+            <enum name="GL_RG8I"/>
+            <enum name="GL_RG16I"/>
+            <enum name="GL_RG32I"/>
+            <enum name="GL_RG8UI"/>
+            <enum name="GL_RG16UI"/>
+            <enum name="GL_RG32UI"/>
+            <!-- Base internal format: GL_RGB -->
+            <enum name="GL_RGB"/>
+            <!-- <enum name="GL_RGB2" comment="Never actually added to core"/> -->
             <enum name="GL_RGB2_EXT"/>
             <enum name="GL_RGB4"/>
+            <enum name="GL_RGB4_EXT"/>
             <enum name="GL_RGB5"/>
-            <enum name="GL_RGB5_A1"/>
+            <enum name="GL_RGB5_EXT"/>
             <enum name="GL_RGB8"/>
-            <enum name="GL_RGBA12"/>
-            <enum name="GL_RGBA16"/>
-            <enum name="GL_RGBA2"/>
+            <enum name="GL_RGB8_EXT"/>
+            <enum name="GL_RGB8_OES"/>
+            <enum name="GL_RGB8_SNORM"/>
+            <enum name="GL_RGB10"/>
+            <enum name="GL_RGB10_EXT"/>
+            <enum name="GL_RGB12"/>
+            <enum name="GL_RGB12_EXT"/>
+            <enum name="GL_RGB16"/>
+            <enum name="GL_RGB16_EXT"/>
+            <enum name="GL_RGB16F"/>
+            <enum name="GL_RGB16F_ARB"/>
+            <enum name="GL_RGB16F_EXT"/>
+            <enum name="GL_RGB16_SNORM"/>
+            <enum name="GL_RGB16_SNORM_EXT"/>
+            <enum name="GL_RGB32F"/>
+            <enum name="GL_RGB8I"/>
+            <enum name="GL_RGB16I"/>
+            <enum name="GL_RGB32I"/>
+            <enum name="GL_RGB8UI"/>
+            <enum name="GL_RGB16UI"/>
+            <enum name="GL_RGB32UI"/>
+            <enum name="GL_SRGB"/>
+            <enum name="GL_SRGB_EXT"/>
+            <enum name="GL_SRGB_ALPHA"/>
+            <enum name="GL_SRGB_ALPHA_EXT"/>
+            <enum name="GL_SRGB8"/>
+            <enum name="GL_SRGB8_EXT"/>
+            <enum name="GL_SRGB8_NV"/>
+            <enum name="GL_SRGB8_ALPHA8"/>
+            <enum name="GL_SRGB8_ALPHA8_EXT"/>
+            <enum name="GL_R3_G3_B2"/>
+            <enum name="GL_R11F_G11F_B10F"/>
+            <enum name="GL_R11F_G11F_B10F_APPLE"/>
+            <enum name="GL_R11F_G11F_B10F_EXT"/>
+            <enum name="GL_RGB9_E5"/>
+            <enum name="GL_RGB9_E5_APPLE"/>
+            <enum name="GL_RGB9_E5_EXT"/>
+            <!-- Base internal format: GL_RGBA -->
+            <enum name="GL_RGBA"/>
             <enum name="GL_RGBA4"/>
+            <enum name="GL_RGBA4_EXT"/>
+            <enum name="GL_RGBA4_OES"/>
+            <enum name="GL_RGB5_A1"/>
+            <enum name="GL_RGB5_A1_EXT"/>
+            <enum name="GL_RGB5_A1_OES"/>
             <enum name="GL_RGBA8"/>
-            <enum name="GL_RGBA_ICC_SGIX"/>
-            <enum name="GL_RGB_ICC_SGIX"/>
+            <enum name="GL_RGBA8_EXT"/>
+            <enum name="GL_RGBA8_OES"/>
+            <enum name="GL_RGBA8_SNORM"/>
+            <enum name="GL_RGB10_A2"/>
+            <enum name="GL_RGB10_A2_EXT"/>
+            <enum name="GL_RGBA12"/>
+            <enum name="GL_RGBA12_EXT"/>
+            <enum name="GL_RGBA16"/>
+            <enum name="GL_RGBA16_EXT"/>
+            <enum name="GL_RGBA16F"/>
+            <enum name="GL_RGBA16F_ARB"/>
+            <enum name="GL_RGBA16F_EXT"/>
+            <enum name="GL_RGBA32F"/>
+            <enum name="GL_RGBA32F_ARB"/>
+            <enum name="GL_RGBA32F_EXT"/>
+            <enum name="GL_RGBA8I"/>
+            <enum name="GL_RGBA16I"/>
+            <enum name="GL_RGBA32I"/>
+            <enum name="GL_RGBA8UI"/>
+            <enum name="GL_RGBA16UI"/>
+            <enum name="GL_RGBA32UI"/>
+            <enum name="GL_RGB10_A2UI"/>
+            <!-- Base internal format: GL_DEPTH_COMPONENT -->
+            <enum name="GL_DEPTH_COMPONENT"/>
+            <enum name="GL_DEPTH_COMPONENT16"/>
+            <enum name="GL_DEPTH_COMPONENT16_ARB"/>
+            <enum name="GL_DEPTH_COMPONENT16_OES"/>
+            <enum name="GL_DEPTH_COMPONENT16_SGIX"/>
+            <enum name="GL_DEPTH_COMPONENT24_ARB"/>
+            <enum name="GL_DEPTH_COMPONENT24_OES"/>
+            <enum name="GL_DEPTH_COMPONENT24_SGIX"/>
+            <enum name="GL_DEPTH_COMPONENT32_ARB"/>
+            <enum name="GL_DEPTH_COMPONENT32_OES"/>
+            <enum name="GL_DEPTH_COMPONENT32_SGIX"/>
+            <enum name="GL_DEPTH_COMPONENT32F"/>
+            <enum name="GL_DEPTH_COMPONENT32F_NV"/>
+            <!-- Base internal format: GL_DEPTH_STENCIL -->
+            <enum name="GL_DEPTH_STENCIL"/>
+            <enum name="GL_DEPTH_STENCIL_EXT"/>
+            <enum name="GL_DEPTH_STENCIL_MESA"/>
+            <enum name="GL_DEPTH_STENCIL_NV"/>
+            <enum name="GL_DEPTH_STENCIL_OES"/>
+            <enum name="GL_DEPTH24_STENCIL8"/>
+            <enum name="GL_DEPTH24_STENCIL8_EXT"/>
+            <enum name="GL_DEPTH24_STENCIL8_OES"/>
+            <enum name="GL_DEPTH32F_STENCIL8"/>
+            <enum name="GL_DEPTH32F_STENCIL8_NV"/>
+            <!-- Base internal format: GL_STENCIL_INDEX -->
+            <enum name="GL_STENCIL_INDEX"/>
+            <enum name="GL_STENCIL_INDEX_OES"/>
+            <enum name="GL_STENCIL_INDEX1"/>
+            <enum name="GL_STENCIL_INDEX1_OES"/>
+            <enum name="GL_STENCIL_INDEX1_EXT"/>
+            <enum name="GL_STENCIL_INDEX4"/>
+            <enum name="GL_STENCIL_INDEX4_OES"/>
+            <enum name="GL_STENCIL_INDEX4_EXT"/>
+            <enum name="GL_STENCIL_INDEX8"/>
+            <enum name="GL_STENCIL_INDEX8_OES"/>
+            <enum name="GL_STENCIL_INDEX8_EXT"/>
+            <enum name="GL_STENCIL_INDEX16"/>
+            <enum name="GL_STENCIL_INDEX16_EXT"/>
+            <!-- Compressed base internal formats -->
+            <enum name="GL_COMPRESSED_RED"/>
+            <enum name="GL_COMPRESSED_RG"/>
+            <enum name="GL_COMPRESSED_RGB"/>
+            <enum name="GL_COMPRESSED_RGBA"/>
+            <enum name="GL_COMPRESSED_SRGB"/>
+            <enum name="GL_COMPRESSED_SRGB_ALPHA"/>
+            <enum name="GL_COMPRESSED_RED_RGTC1"/>
+            <enum name="GL_COMPRESSED_RED_RGTC1_EXT"/>
+            <enum name="GL_COMPRESSED_SIGNED_RED_RGTC1"/>
+            <enum name="GL_COMPRESSED_SIGNED_RED_RGTC1_EXT"/>
+            <enum name="GL_COMPRESSED_R11_EAC"/>
+            <enum name="GL_COMPRESSED_SIGNED_R11_EAC"/>
+            <enum name="GL_COMPRESSED_RG_RGTC2"/>
+            <enum name="GL_COMPRESSED_SIGNED_RG_RGTC2"/>
+            <enum name="GL_COMPRESSED_RGBA_BPTC_UNORM"/>
+            <enum name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM"/>
+            <enum name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT"/>
+            <enum name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT"/>
+            <enum name="GL_COMPRESSED_RGB8_ETC2"/>
+            <enum name="GL_COMPRESSED_SRGB8_ETC2"/>
+            <enum name="GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2"/>
+            <enum name="GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2"/>
+            <enum name="GL_COMPRESSED_RGBA8_ETC2_EAC"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC"/>
+            <enum name="GL_COMPRESSED_RG11_EAC"/>
+            <enum name="GL_COMPRESSED_SIGNED_RG11_EAC"/>
+            <enum name="GL_COMPRESSED_RGB_S3TC_DXT1_EXT"/>
+            <enum name="GL_COMPRESSED_SRGB_S3TC_DXT1_EXT"/>
+            <enum name="GL_COMPRESSED_RGBA_S3TC_DXT1_EXT"/>
+            <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT"/>
+            <enum name="GL_COMPRESSED_RGBA_S3TC_DXT3_EXT"/>
+            <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT"/>
+            <enum name="GL_COMPRESSED_RGBA_S3TC_DXT5_EXT"/>
+            <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT"/>
+            <!-- Compressed ASTC internal formats -->
+            <enum name="GL_COMPRESSED_RGBA_ASTC_3x3x3_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_4x3x3_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_4x4"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_4x4_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_4x4x3_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_4x4x4_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x4"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x4_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x4x4_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x5"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x5_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x5x4_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_5x5x5_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x5"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x5_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x5x5_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x6"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x6_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x6x5_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_6x6x6_OES"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x5"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x5_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x6"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x6_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x8"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_8x8_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x10"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x10_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x5"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x5_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x6"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x6_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x8"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_10x8_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_12x10"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_12x10_KHR"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_12x12"/>
+            <enum name="GL_COMPRESSED_RGBA_ASTC_12x12_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_3x3x3_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x3x3_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x3_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x4_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4x4_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x4_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x5_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5x5_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x5_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x6_OES"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12"/>
+            <enum name="GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR"/>
         </group>
 
         <group name="PixelMap">
@@ -1770,6 +2941,22 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FRONT_RIGHT"/>
             <enum name="GL_LEFT"/>
             <enum name="GL_RIGHT"/>
+            <enum name="GL_COLOR_ATTACHMENT0"/>
+            <enum name="GL_COLOR_ATTACHMENT1"/>
+            <enum name="GL_COLOR_ATTACHMENT2"/>
+            <enum name="GL_COLOR_ATTACHMENT3"/>
+            <enum name="GL_COLOR_ATTACHMENT4"/>
+            <enum name="GL_COLOR_ATTACHMENT5"/>
+            <enum name="GL_COLOR_ATTACHMENT6"/>
+            <enum name="GL_COLOR_ATTACHMENT7"/>
+            <enum name="GL_COLOR_ATTACHMENT8"/>
+            <enum name="GL_COLOR_ATTACHMENT9"/>
+            <enum name="GL_COLOR_ATTACHMENT10"/>
+            <enum name="GL_COLOR_ATTACHMENT11"/>
+            <enum name="GL_COLOR_ATTACHMENT12"/>
+            <enum name="GL_COLOR_ATTACHMENT13"/>
+            <enum name="GL_COLOR_ATTACHMENT14"/>
+            <enum name="GL_COLOR_ATTACHMENT15"/>
         </group>
 
         <group name="RenderingMode">
@@ -1795,6 +2982,10 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_4PASS_3_SGIS"/>
         </group>
 
+        <group name="SemaphoreParameterName">
+            <enum name="GL_D3D12_FENCE_VALUE_EXT"/>
+        </group>
+
         <group name="SeparableTargetEXT">
             <enum name="GL_SEPARABLE_2D"/>
             <enum name="GL_SEPARABLE_2D_EXT"/>
@@ -1803,6 +2994,12 @@ typedef unsigned int GLhandleARB;
         <group name="ShadingModel">
             <enum name="GL_FLAT"/>
             <enum name="GL_SMOOTH"/>
+        </group>
+
+        <group name="StencilFaceDirection">
+             <enum name="GL_FRONT"/>
+             <enum name="GL_BACK"/>
+             <enum name="GL_FRONT_AND_BACK"/>
         </group>
 
         <group name="StencilFunction">
@@ -1818,7 +3015,9 @@ typedef unsigned int GLhandleARB;
 
         <group name="StencilOp">
             <enum name="GL_DECR"/>
+            <enum name="GL_DECR_WRAP"/>
             <enum name="GL_INCR"/>
+            <enum name="GL_INCR_WRAP"/>
             <enum name="GL_INVERT"/>
             <enum name="GL_KEEP"/>
             <enum name="GL_REPLACE"/>
@@ -1830,6 +3029,12 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_RENDERER"/>
             <enum name="GL_VENDOR"/>
             <enum name="GL_VERSION"/>
+            <enum name="GL_SHADING_LANGUAGE_VERSION"/>
+        </group>
+
+        <group name="SyncObjectMask">
+            <enum name="GL_SYNC_FLUSH_COMMANDS_BIT"/>
+            <enum name="GL_SYNC_FLUSH_COMMANDS_BIT_APPLE"/>
         </group>
 
         <group name="TexCoordPointerType">
@@ -1954,31 +3159,96 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_WRAP_R_OES"/>
             <enum name="GL_TEXTURE_WRAP_S"/>
             <enum name="GL_TEXTURE_WRAP_T"/>
+            <enum name="GL_TEXTURE_BASE_LEVEL"/>
+            <enum name="GL_TEXTURE_COMPARE_MODE"/>
+            <enum name="GL_TEXTURE_COMPARE_FUNC"/>
+            <enum name="GL_TEXTURE_LOD_BIAS"/>
+            <enum name="GL_TEXTURE_MIN_LOD"/>
+            <enum name="GL_TEXTURE_MAX_LOD"/>
+            <enum name="GL_TEXTURE_MAX_LEVEL"/>
+            <enum name="GL_TEXTURE_SWIZZLE_R"/>
+            <enum name="GL_TEXTURE_SWIZZLE_G"/>
+            <enum name="GL_TEXTURE_SWIZZLE_B"/>
+            <enum name="GL_TEXTURE_SWIZZLE_A"/>
+            <enum name="GL_TEXTURE_SWIZZLE_RGBA"/>
+            <enum name="GL_TEXTURE_TILING_EXT"/>
+            <enum name="GL_DEPTH_STENCIL_TEXTURE_MODE"/>
+            <enum name="GL_DETAIL_TEXTURE_FUNC_POINTS_SGIS"/>
+            <enum name="GL_SHARPEN_TEXTURE_FUNC_POINTS_SGIS"/>
+            <enum name="GL_TEXTURE_4DSIZE_SGIS"/>
+            <enum name="GL_TEXTURE_ALPHA_SIZE"/>
+            <enum name="GL_TEXTURE_BASE_LEVEL_SGIS"/>
+            <enum name="GL_TEXTURE_BLUE_SIZE"/>
+            <enum name="GL_TEXTURE_BORDER"/>
+            <enum name="GL_TEXTURE_BORDER_COLOR_NV"/>
+            <enum name="GL_TEXTURE_COMPARE_OPERATOR_SGIX"/>
+            <enum name="GL_TEXTURE_COMPONENTS"/>
+            <enum name="GL_TEXTURE_DEPTH_EXT"/>
+            <enum name="GL_TEXTURE_FILTER4_SIZE_SGIS"/>
+            <enum name="GL_TEXTURE_GEQUAL_R_SGIX"/>
+            <enum name="GL_TEXTURE_GREEN_SIZE"/>
+            <enum name="GL_TEXTURE_HEIGHT"/>
+            <enum name="GL_TEXTURE_INTENSITY_SIZE"/>
+            <enum name="GL_TEXTURE_INTERNAL_FORMAT"/>
+            <enum name="GL_TEXTURE_LEQUAL_R_SGIX"/>
+            <enum name="GL_TEXTURE_LUMINANCE_SIZE"/>
+            <enum name="GL_TEXTURE_MAX_LEVEL_SGIS"/>
+            <enum name="GL_TEXTURE_MAX_LOD_SGIS"/>
+            <enum name="GL_TEXTURE_MIN_LOD_SGIS"/>
+            <enum name="GL_TEXTURE_RED_SIZE"/>
+            <enum name="GL_TEXTURE_RESIDENT"/>
+            <enum name="GL_TEXTURE_WIDTH"/>
+        </group>
+
+        <group name="TextureStorageMaskAMD">
+            <enum name="GL_TEXTURE_STORAGE_SPARSE_BIT_AMD"/>
         </group>
 
         <group name="TextureTarget">
             <enum name="GL_DETAIL_TEXTURE_2D_SGIS"/>
             <enum name="GL_PROXY_TEXTURE_1D"/>
+            <enum name="GL_PROXY_TEXTURE_1D_ARRAY"/>
+            <enum name="GL_PROXY_TEXTURE_1D_ARRAY_EXT"/>
             <enum name="GL_PROXY_TEXTURE_1D_EXT"/>
             <enum name="GL_PROXY_TEXTURE_2D"/>
+            <enum name="GL_PROXY_TEXTURE_2D_ARRAY"/>
+            <enum name="GL_PROXY_TEXTURE_2D_ARRAY_EXT"/>
             <enum name="GL_PROXY_TEXTURE_2D_EXT"/>
+            <enum name="GL_PROXY_TEXTURE_2D_MULTISAMPLE"/>
+            <enum name="GL_PROXY_TEXTURE_2D_MULTISAMPLE_ARRAY"/>
             <enum name="GL_PROXY_TEXTURE_3D"/>
             <enum name="GL_PROXY_TEXTURE_3D_EXT"/>
             <enum name="GL_PROXY_TEXTURE_4D_SGIS"/>
+            <enum name="GL_PROXY_TEXTURE_CUBE_MAP"/>
+            <enum name="GL_PROXY_TEXTURE_CUBE_MAP_ARB"/>
+            <enum name="GL_PROXY_TEXTURE_CUBE_MAP_EXT"/>
+            <enum name="GL_PROXY_TEXTURE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_PROXY_TEXTURE_CUBE_MAP_ARRAY_ARB"/>
+            <enum name="GL_PROXY_TEXTURE_RECTANGLE"/>
+            <enum name="GL_PROXY_TEXTURE_RECTANGLE_ARB"/>
+            <enum name="GL_PROXY_TEXTURE_RECTANGLE_NV"/>
             <enum name="GL_TEXTURE_1D"/>
             <enum name="GL_TEXTURE_2D"/>
             <enum name="GL_TEXTURE_3D"/>
             <enum name="GL_TEXTURE_3D_EXT"/>
             <enum name="GL_TEXTURE_3D_OES"/>
             <enum name="GL_TEXTURE_4D_SGIS"/>
-            <enum name="GL_TEXTURE_BASE_LEVEL"/>
-            <enum name="GL_TEXTURE_BASE_LEVEL_SGIS"/>
-            <enum name="GL_TEXTURE_MAX_LEVEL"/>
-            <enum name="GL_TEXTURE_MAX_LEVEL_SGIS"/>
-            <enum name="GL_TEXTURE_MAX_LOD"/>
-            <enum name="GL_TEXTURE_MAX_LOD_SGIS"/>
-            <enum name="GL_TEXTURE_MIN_LOD"/>
-            <enum name="GL_TEXTURE_MIN_LOD_SGIS"/>
+            <enum name="GL_TEXTURE_RECTANGLE"/>
+            <enum name="GL_TEXTURE_CUBE_MAP"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_POSITIVE_X"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_NEGATIVE_X"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_POSITIVE_Y"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_NEGATIVE_Y"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_POSITIVE_Z"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_NEGATIVE_Z"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_ARRAY_ARB"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_ARRAY_EXT"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_ARRAY_OES"/>
+            <enum name="GL_TEXTURE_1D_ARRAY"/>
+            <enum name="GL_TEXTURE_2D_ARRAY"/>
+            <enum name="GL_TEXTURE_2D_MULTISAMPLE"/>
+            <enum name="GL_TEXTURE_2D_MULTISAMPLE_ARRAY"/>
         </group>
 
         <group name="TextureWrapMode">
@@ -1990,6 +3260,8 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CLAMP_TO_EDGE"/>
             <enum name="GL_CLAMP_TO_EDGE_SGIS"/>
             <enum name="GL_REPEAT"/>
+            <enum name="GL_LINEAR_MIPMAP_LINEAR"/>
+            <enum name="GL_MIRRORED_REPEAT"/>
         </group>
 
         <group name="UseProgramStageMask">
@@ -1999,13 +3271,30 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_FRAGMENT_SHADER_BIT_EXT"/>
             <enum name="GL_GEOMETRY_SHADER_BIT"/>
             <enum name="GL_GEOMETRY_SHADER_BIT_EXT"/>
+            <enum name="GL_GEOMETRY_SHADER_BIT_OES"/>
             <enum name="GL_TESS_CONTROL_SHADER_BIT"/>
             <enum name="GL_TESS_CONTROL_SHADER_BIT_EXT"/>
+            <enum name="GL_TESS_CONTROL_SHADER_BIT_OES"/>
             <enum name="GL_TESS_EVALUATION_SHADER_BIT"/>
             <enum name="GL_TESS_EVALUATION_SHADER_BIT_EXT"/>
+            <enum name="GL_TESS_EVALUATION_SHADER_BIT_OES"/>
             <enum name="GL_COMPUTE_SHADER_BIT"/>
+            <enum name="GL_MESH_SHADER_BIT_NV"/>
+            <enum name="GL_TASK_SHADER_BIT_NV"/>
             <enum name="GL_ALL_SHADER_BITS"/>
             <enum name="GL_ALL_SHADER_BITS_EXT"/>
+        </group>
+
+        <group name="SubgroupSupportedFeatures">
+            <enum name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+            <enum name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
         </group>
 
         <group name="VertexPointerType">
@@ -2014,6 +3303,1264 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_INT"/>
             <enum name="GL_SHORT"/>
         </group>
+
+        <group name="FramebufferAttachment">
+            <enum name="GL_MAX_COLOR_ATTACHMENTS"/>
+            <enum name="GL_MAX_COLOR_ATTACHMENTS_EXT"/>
+            <enum name="GL_MAX_COLOR_ATTACHMENTS_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT0"/>
+            <enum name="GL_COLOR_ATTACHMENT0_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT0_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT0_OES"/>
+            <enum name="GL_COLOR_ATTACHMENT1"/>
+            <enum name="GL_COLOR_ATTACHMENT1_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT1_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT2"/>
+            <enum name="GL_COLOR_ATTACHMENT2_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT2_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT3"/>
+            <enum name="GL_COLOR_ATTACHMENT3_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT3_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT4"/>
+            <enum name="GL_COLOR_ATTACHMENT4_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT4_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT5"/>
+            <enum name="GL_COLOR_ATTACHMENT5_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT5_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT6"/>
+            <enum name="GL_COLOR_ATTACHMENT6_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT6_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT7"/>
+            <enum name="GL_COLOR_ATTACHMENT7_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT7_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT8"/>
+            <enum name="GL_COLOR_ATTACHMENT8_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT8_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT9"/>
+            <enum name="GL_COLOR_ATTACHMENT9_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT9_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT10"/>
+            <enum name="GL_COLOR_ATTACHMENT10_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT10_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT11"/>
+            <enum name="GL_COLOR_ATTACHMENT11_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT11_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT12"/>
+            <enum name="GL_COLOR_ATTACHMENT12_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT12_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT13"/>
+            <enum name="GL_COLOR_ATTACHMENT13_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT13_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT14"/>
+            <enum name="GL_COLOR_ATTACHMENT14_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT14_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT15"/>
+            <enum name="GL_COLOR_ATTACHMENT15_EXT"/>
+            <enum name="GL_COLOR_ATTACHMENT15_NV"/>
+            <enum name="GL_COLOR_ATTACHMENT16"/>
+            <enum name="GL_COLOR_ATTACHMENT17"/>
+            <enum name="GL_COLOR_ATTACHMENT18"/>
+            <enum name="GL_COLOR_ATTACHMENT19"/>
+            <enum name="GL_COLOR_ATTACHMENT20"/>
+            <enum name="GL_COLOR_ATTACHMENT21"/>
+            <enum name="GL_COLOR_ATTACHMENT22"/>
+            <enum name="GL_COLOR_ATTACHMENT23"/>
+            <enum name="GL_COLOR_ATTACHMENT24"/>
+            <enum name="GL_COLOR_ATTACHMENT25"/>
+            <enum name="GL_COLOR_ATTACHMENT26"/>
+            <enum name="GL_COLOR_ATTACHMENT27"/>
+            <enum name="GL_COLOR_ATTACHMENT28"/>
+            <enum name="GL_COLOR_ATTACHMENT29"/>
+            <enum name="GL_COLOR_ATTACHMENT30"/>
+            <enum name="GL_COLOR_ATTACHMENT31"/>
+            <enum name="GL_DEPTH_ATTACHMENT"/>
+            <enum name="GL_DEPTH_STENCIL_ATTACHMENT"/>
+            <enum name="GL_DEPTH_ATTACHMENT_EXT"/>
+            <enum name="GL_DEPTH_ATTACHMENT_OES"/>
+        </group>
+
+        <group name="RenderbufferTarget">
+            <enum name="GL_RENDERBUFFER" />
+        </group>
+
+        <group name="FramebufferTarget">
+            <enum name="GL_FRAMEBUFFER" />
+            <enum name="GL_DRAW_FRAMEBUFFER" />
+            <enum name="GL_READ_FRAMEBUFFER" />
+        </group>
+
+        <group name="TextureUnit">
+            <enum name="GL_TEXTURE0"/>
+            <enum name="GL_TEXTURE1"/>
+            <enum name="GL_TEXTURE2"/>
+            <enum name="GL_TEXTURE3"/>
+            <enum name="GL_TEXTURE4"/>
+            <enum name="GL_TEXTURE5"/>
+            <enum name="GL_TEXTURE6"/>
+            <enum name="GL_TEXTURE7"/>
+            <enum name="GL_TEXTURE8"/>
+            <enum name="GL_TEXTURE9"/>
+            <enum name="GL_TEXTURE10"/>
+            <enum name="GL_TEXTURE11"/>
+            <enum name="GL_TEXTURE12"/>
+            <enum name="GL_TEXTURE13"/>
+            <enum name="GL_TEXTURE14"/>
+            <enum name="GL_TEXTURE15"/>
+            <enum name="GL_TEXTURE16"/>
+            <enum name="GL_TEXTURE17"/>
+            <enum name="GL_TEXTURE18"/>
+            <enum name="GL_TEXTURE19"/>
+            <enum name="GL_TEXTURE20"/>
+            <enum name="GL_TEXTURE21"/>
+            <enum name="GL_TEXTURE22"/>
+            <enum name="GL_TEXTURE23"/>
+            <enum name="GL_TEXTURE24"/>
+            <enum name="GL_TEXTURE25"/>
+            <enum name="GL_TEXTURE26"/>
+            <enum name="GL_TEXTURE27"/>
+            <enum name="GL_TEXTURE28"/>
+            <enum name="GL_TEXTURE29"/>
+            <enum name="GL_TEXTURE30"/>
+            <enum name="GL_TEXTURE31"/>
+        </group>
+
+        <group name="ConditionalRenderMode">
+            <enum name="GL_QUERY_WAIT"/>
+            <enum name="GL_QUERY_NO_WAIT"/>
+            <enum name="GL_QUERY_BY_REGION_WAIT"/>
+            <enum name="GL_QUERY_BY_REGION_NO_WAIT"/>
+            <enum name="GL_QUERY_WAIT_INVERTED"/>
+            <enum name="GL_QUERY_NO_WAIT_INVERTED"/>
+            <enum name="GL_QUERY_BY_REGION_WAIT_INVERTED"/>
+            <enum name="GL_QUERY_BY_REGION_NO_WAIT_INVERTED"/>
+        </group>
+
+        <group name="FragmentOpATI">
+            <enum name="GL_MOV_ATI"/>
+            <enum name="GL_ADD_ATI"/>
+            <enum name="GL_MUL_ATI"/>
+            <enum name="GL_SUB_ATI"/>
+            <enum name="GL_DOT3_ATI"/>
+            <enum name="GL_DOT4_ATI"/>
+            <enum name="GL_MAD_ATI"/>
+            <enum name="GL_LERP_ATI"/>
+            <enum name="GL_CND_ATI"/>
+            <enum name="GL_CND0_ATI"/>
+            <enum name="GL_DOT2_ADD_ATI"/>
+        </group>
+
+        <group name="FramebufferStatus">
+            <enum name="GL_FRAMEBUFFER_COMPLETE"/>
+            <enum name="GL_FRAMEBUFFER_UNDEFINED"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER"/>
+            <enum name="GL_FRAMEBUFFER_UNSUPPORTED"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"/>
+            <enum name="GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS"/>
+        </group>
+
+        <group name="GraphicsResetStatus">
+            <enum name="GL_NO_ERROR"/>
+            <enum name="GL_GUILTY_CONTEXT_RESET"/>
+            <enum name="GL_INNOCENT_CONTEXT_RESET"/>
+            <enum name="GL_UNKNOWN_CONTEXT_RESET"/>
+        </group>
+
+        <group name="SyncStatus">
+            <enum name="GL_ALREADY_SIGNALED"/>
+            <enum name="GL_TIMEOUT_EXPIRED"/>
+            <enum name="GL_CONDITION_SATISFIED"/>
+            <enum name="GL_WAIT_FAILED"/>
+        </group>
+
+        <group name="QueryTarget">
+            <enum name="GL_SAMPLES_PASSED"/>
+            <enum name="GL_ANY_SAMPLES_PASSED"/>
+            <enum name="GL_ANY_SAMPLES_PASSED_CONSERVATIVE"/>
+            <enum name="GL_PRIMITIVES_GENERATED"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN"/>
+            <enum name="GL_TIME_ELAPSED"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_OVERFLOW"/>
+            <enum name="GL_VERTICES_SUBMITTED"/>
+            <enum name="GL_PRIMITIVES_SUBMITTED"/>
+            <enum name="GL_VERTEX_SHADER_INVOCATIONS"/>
+        </group>
+
+        <group name="QueryCounterTarget">
+            <enum name="GL_TIMESTAMP"/>
+        </group>
+
+        <group name="ConvolutionTarget">
+            <enum name="GL_CONVOLUTION_1D"/>
+            <enum name="GL_CONVOLUTION_2D"/>
+        </group>
+
+        <group name="PathFillMode">
+            <enum name="GL_INVERT"/>
+            <enum name="GL_COUNT_UP_NV"/>
+            <enum name="GL_COUNT_DOWN_NV"/>
+            <enum name="GL_PATH_FILL_MODE_NV"/>
+        </group>
+
+        <group name="ColorTableTarget">
+            <enum name="GL_COLOR_TABLE"/>
+            <enum name="GL_POST_CONVOLUTION_COLOR_TABLE"/>
+            <enum name="GL_POST_COLOR_MATRIX_COLOR_TABLE"/>
+        </group>
+
+        <group name="VertexBufferObjectParameter">
+            <enum name="GL_BUFFER_ACCESS"/>
+            <enum name="GL_BUFFER_ACCESS_FLAGS"/>
+            <enum name="GL_BUFFER_IMMUTABLE_STORAGE"/>
+            <enum name="GL_BUFFER_MAPPED"/>
+            <enum name="GL_BUFFER_MAP_LENGTH"/>
+            <enum name="GL_BUFFER_MAP_OFFSET"/>
+            <enum name="GL_BUFFER_SIZE"/>
+            <enum name="GL_BUFFER_STORAGE_FLAGS"/>
+            <enum name="GL_BUFFER_USAGE"/>
+        </group>
+
+        <group name="RenderbufferParameterName">
+            <enum name="GL_RENDERBUFFER_WIDTH"/>
+            <enum name="GL_RENDERBUFFER_HEIGHT"/>
+            <enum name="GL_RENDERBUFFER_INTERNAL_FORMAT"/>
+            <enum name="GL_RENDERBUFFER_SAMPLES"/>
+            <enum name="GL_RENDERBUFFER_RED_SIZE"/>
+            <enum name="GL_RENDERBUFFER_GREEN_SIZE"/>
+            <enum name="GL_RENDERBUFFER_BLUE_SIZE"/>
+            <enum name="GL_RENDERBUFFER_ALPHA_SIZE"/>
+            <enum name="GL_RENDERBUFFER_DEPTH_SIZE"/>
+            <enum name="GL_RENDERBUFFER_STENCIL_SIZE"/>
+        </group>
+
+        <group name="VertexBufferObjectUsage">
+            <enum name="GL_STREAM_DRAW"/>
+            <enum name="GL_STREAM_READ"/>
+            <enum name="GL_STREAM_COPY"/>
+            <enum name="GL_STATIC_DRAW"/>
+            <enum name="GL_STATIC_READ"/>
+            <enum name="GL_STATIC_COPY"/>
+            <enum name="GL_DYNAMIC_DRAW"/>
+            <enum name="GL_DYNAMIC_READ"/>
+            <enum name="GL_DYNAMIC_COPY"/>
+        </group>
+
+        <group name="FramebufferParameterName">
+            <enum name="GL_FRAMEBUFFER_DEFAULT_WIDTH"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_HEIGHT"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_LAYERS"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_SAMPLES"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS"/>
+        </group>
+
+        <group name="ProgramParameterPName">
+            <enum name="GL_PROGRAM_BINARY_RETRIEVABLE_HINT"/>
+            <enum name="GL_PROGRAM_SEPARABLE"/>
+        </group>
+
+        <group name="BlendingFactor">
+            <enum name="GL_ZERO"/>
+            <enum name="GL_ONE"/>
+            <enum name="GL_SRC_COLOR"/>
+            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
+            <enum name="GL_DST_COLOR"/>
+            <enum name="GL_ONE_MINUS_DST_COLOR"/>
+            <enum name="GL_SRC_ALPHA"/>
+            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
+            <enum name="GL_DST_ALPHA"/>
+            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
+            <enum name="GL_CONSTANT_COLOR"/>
+            <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
+            <enum name="GL_CONSTANT_ALPHA"/>
+            <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
+            <enum name="GL_SRC_ALPHA_SATURATE"/>
+            <enum name="GL_SRC1_COLOR"/>
+            <enum name="GL_ONE_MINUS_SRC1_COLOR"/>
+            <enum name="GL_SRC1_ALPHA"/>
+            <enum name="GL_ONE_MINUS_SRC1_ALPHA"/>
+        </group>
+
+        <group name="BindTransformFeedbackTarget">
+            <enum name="GL_TRANSFORM_FEEDBACK"/>
+        </group>
+
+        <group name="BlitFramebufferFilter">
+            <enum name="GL_NEAREST"/>
+            <enum name="GL_LINEAR"/>
+        </group>
+
+        <group name="BufferStorageTarget">
+            <enum name="GL_ARRAY_BUFFER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER"/>
+            <enum name="GL_COPY_READ_BUFFER"/>
+            <enum name="GL_COPY_WRITE_BUFFER"/>
+            <enum name="GL_DISPATCH_INDIRECT_BUFFER"/>
+            <enum name="GL_DRAW_INDIRECT_BUFFER"/>
+            <enum name="GL_ELEMENT_ARRAY_BUFFER"/>
+            <enum name="GL_PIXEL_PACK_BUFFER"/>
+            <enum name="GL_PIXEL_UNPACK_BUFFER"/>
+            <enum name="GL_QUERY_BUFFER"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER"/>
+            <enum name="GL_TEXTURE_BUFFER"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
+            <enum name="GL_UNIFORM_BUFFER"/>
+        </group>
+
+        <group name="CheckFramebufferStatusTarget">
+            <enum name="GL_DRAW_FRAMEBUFFER"/>
+            <enum name="GL_READ_FRAMEBUFFER"/>
+            <enum name="GL_FRAMEBUFFER"/>
+        </group>
+
+        <group name="Buffer">
+            <enum name="GL_COLOR"/>
+            <enum name="GL_DEPTH"/>
+            <enum name="GL_STENCIL"/>
+        </group>
+
+        <group name="ClipControlOrigin">
+            <enum name="GL_LOWER_LEFT"/>
+            <enum name="GL_UPPER_LEFT"/>
+        </group>
+
+        <group name="ClipControlDepth">
+            <enum name="GL_NEGATIVE_ONE_TO_ONE"/>
+            <enum name="GL_ZERO_TO_ONE"/>
+        </group>
+
+        <group name="CopyBufferSubDataTarget">
+            <enum name="GL_ARRAY_BUFFER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER"/>
+            <enum name="GL_COPY_READ_BUFFER"/>
+            <enum name="GL_COPY_WRITE_BUFFER"/>
+            <enum name="GL_DISPATCH_INDIRECT_BUFFER"/>
+            <enum name="GL_DRAW_INDIRECT_BUFFER"/>
+            <enum name="GL_ELEMENT_ARRAY_BUFFER"/>
+            <enum name="GL_PIXEL_PACK_BUFFER"/>
+            <enum name="GL_PIXEL_UNPACK_BUFFER"/>
+            <enum name="GL_QUERY_BUFFER"/>
+            <enum name="GL_SHADER_STORAGE_BUFFER"/>
+            <enum name="GL_TEXTURE_BUFFER"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
+            <enum name="GL_UNIFORM_BUFFER"/>
+        </group>
+
+        <group name="CopyImageSubDataTarget">
+            <enum name="GL_RENDERBUFFER"/>
+            <enum name="GL_TEXTURE_1D"/>
+            <enum name="GL_TEXTURE_2D"/>
+            <enum name="GL_TEXTURE_3D"/>
+            <enum name="GL_TEXTURE_RECTANGLE"/>
+            <enum name="GL_TEXTURE_CUBE_MAP"/>
+            <enum name="GL_TEXTURE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_TEXTURE_1D_ARRAY"/>
+            <enum name="GL_TEXTURE_2D_ARRAY"/>
+            <enum name="GL_TEXTURE_2D_MULTISAMPLE"/>
+            <enum name="GL_TEXTURE_2D_MULTISAMPLE_ARRAY"/>
+        </group>
+
+        <group name="ShaderType">
+            <enum name="GL_COMPUTE_SHADER"/>
+            <enum name="GL_VERTEX_SHADER"/>
+            <enum name="GL_TESS_CONTROL_SHADER"/>
+            <enum name="GL_TESS_EVALUATION_SHADER"/>
+            <enum name="GL_GEOMETRY_SHADER"/>
+            <enum name="GL_FRAGMENT_SHADER"/>
+            <enum name="GL_FRAGMENT_SHADER_ARB"/>
+            <enum name="GL_VERTEX_SHADER_ARB"/>
+        </group>
+
+        <group name="DebugSource">
+            <enum name="GL_DEBUG_SOURCE_API"/>
+            <enum name="GL_DEBUG_SOURCE_WINDOW_SYSTEM"/>
+            <enum name="GL_DEBUG_SOURCE_SHADER_COMPILER"/>
+            <enum name="GL_DEBUG_SOURCE_THIRD_PARTY"/>
+            <enum name="GL_DEBUG_SOURCE_APPLICATION"/>
+            <enum name="GL_DEBUG_SOURCE_OTHER"/>
+            <enum name="GL_DONT_CARE"/>
+        </group>
+
+        <group name="DebugType">
+            <enum name="GL_DEBUG_TYPE_ERROR"/>
+            <enum name="GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR"/>
+            <enum name="GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR"/>
+            <enum name="GL_DEBUG_TYPE_PORTABILITY"/>
+            <enum name="GL_DEBUG_TYPE_PERFORMANCE"/>
+            <enum name="GL_DEBUG_TYPE_MARKER"/>
+            <enum name="GL_DEBUG_TYPE_PUSH_GROUP"/>
+            <enum name="GL_DEBUG_TYPE_POP_GROUP"/>
+            <enum name="GL_DEBUG_TYPE_OTHER"/>
+            <enum name="GL_DONT_CARE"/>
+        </group>
+
+        <group name="DebugSeverity">
+            <enum name="GL_DEBUG_SEVERITY_LOW"/>
+            <enum name="GL_DEBUG_SEVERITY_MEDIUM"/>
+            <enum name="GL_DEBUG_SEVERITY_HIGH"/>
+            <enum name="GL_DEBUG_SEVERITY_NOTIFICATION"/>
+            <enum name="GL_DONT_CARE"/>
+        </group>
+
+        <group name="SyncCondition">
+            <enum name="GL_SYNC_GPU_COMMANDS_COMPLETE"/>
+        </group>
+
+        <group name="FogPName">
+            <enum name="GL_FOG_MODE"/>
+            <enum name="GL_FOG_DENSITY"/>
+            <enum name="GL_FOG_START"/>
+            <enum name="GL_FOG_END"/>
+            <enum name="GL_FOG_INDEX"/>
+            <enum name="GL_FOG_COORD_SRC"/>
+        </group>
+
+        <group name="AtomicCounterBufferPName">
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_BINDING"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_DATA_SIZE"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_ACTIVE_ATOMIC_COUNTERS"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_ACTIVE_ATOMIC_COUNTER_INDICES"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_VERTEX_SHADER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TESS_CONTROL_SHADER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TESS_EVALUATION_SHADER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_GEOMETRY_SHADER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_FRAGMENT_SHADER"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_COMPUTE_SHADER"/>
+        </group>
+
+        <group name="UniformBlockPName">
+            <enum name="GL_UNIFORM_BLOCK_BINDING"/>
+            <enum name="GL_UNIFORM_BLOCK_DATA_SIZE"/>
+            <enum name="GL_UNIFORM_BLOCK_NAME_LENGTH"/>
+            <enum name="GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS"/>
+            <enum name="GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_TESS_CONTROL_SHADER"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_TESS_EVALUATION_SHADER"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_GEOMETRY_SHADER"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER"/>
+            <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_COMPUTE_SHADER"/>
+        </group>
+
+        <group name="UniformPName">
+            <enum name="GL_UNIFORM_TYPE"/>
+            <enum name="GL_UNIFORM_SIZE"/>
+            <enum name="GL_UNIFORM_NAME_LENGTH"/>
+            <enum name="GL_UNIFORM_BLOCK_INDEX"/>
+            <enum name="GL_UNIFORM_OFFSET"/>
+            <enum name="GL_UNIFORM_ARRAY_STRIDE"/>
+            <enum name="GL_UNIFORM_MATRIX_STRIDE"/>
+            <enum name="GL_UNIFORM_IS_ROW_MAJOR"/>
+            <enum name="GL_UNIFORM_ATOMIC_COUNTER_BUFFER_INDEX"/>
+        </group>
+
+        <group name="SamplerParameterI">
+            <enum name="GL_TEXTURE_WRAP_S"/>
+            <enum name="GL_TEXTURE_WRAP_T"/>
+            <enum name="GL_TEXTURE_WRAP_R"/>
+            <enum name="GL_TEXTURE_MIN_FILTER"/>
+            <enum name="GL_TEXTURE_MAG_FILTER"/>
+            <enum name="GL_TEXTURE_COMPARE_MODE"/>
+            <enum name="GL_TEXTURE_COMPARE_FUNC"/>
+        </group>
+
+        <group name="SamplerParameterF">
+            <enum name="GL_TEXTURE_BORDER_COLOR"/>
+            <enum name="GL_TEXTURE_MIN_LOD"/>
+            <enum name="GL_TEXTURE_MAX_LOD"/>
+            <enum name="GL_TEXTURE_MAX_ANISOTROPY"/>
+        </group>
+
+        <group name="VertexProvokingMode">
+            <enum name="GL_FIRST_VERTEX_CONVENTION"/>
+            <enum name="GL_LAST_VERTEX_CONVENTION"/>
+        </group>
+
+        <group name="PatchParameterName">
+            <enum name="GL_PATCH_VERTICES"/>
+            <enum name="GL_PATCH_DEFAULT_OUTER_LEVEL"/>
+            <enum name="GL_PATCH_DEFAULT_INNER_LEVEL"/>
+        </group>
+
+        <group name="ObjectIdentifier">
+            <enum name="GL_BUFFER"/>
+            <enum name="GL_SHADER"/>
+            <enum name="GL_PROGRAM"/>
+            <enum name="GL_VERTEX_ARRAY"/>
+            <enum name="GL_QUERY"/>
+            <enum name="GL_PROGRAM_PIPELINE"/>
+            <enum name="GL_TRANSFORM_FEEDBACK"/>
+            <enum name="GL_SAMPLER"/>
+            <enum name="GL_TEXTURE"/>
+            <enum name="GL_RENDERBUFFER"/>
+            <enum name="GL_FRAMEBUFFER"/>
+        </group>
+
+        <group name="ColorBuffer">
+            <enum name="GL_NONE"/>
+            <enum name="GL_FRONT_LEFT"/>
+            <enum name="GL_FRONT_RIGHT"/>
+            <enum name="GL_BACK_LEFT"/>
+            <enum name="GL_BACK_RIGHT"/>
+            <enum name="GL_FRONT"/>
+            <enum name="GL_BACK"/>
+            <enum name="GL_LEFT"/>
+            <enum name="GL_RIGHT"/>
+            <enum name="GL_FRONT_AND_BACK"/>
+            <enum name="GL_COLOR_ATTACHMENT0"/>
+            <enum name="GL_COLOR_ATTACHMENT1"/>
+            <enum name="GL_COLOR_ATTACHMENT2"/>
+            <enum name="GL_COLOR_ATTACHMENT3"/>
+            <enum name="GL_COLOR_ATTACHMENT4"/>
+            <enum name="GL_COLOR_ATTACHMENT5"/>
+            <enum name="GL_COLOR_ATTACHMENT6"/>
+            <enum name="GL_COLOR_ATTACHMENT7"/>
+            <enum name="GL_COLOR_ATTACHMENT8"/>
+            <enum name="GL_COLOR_ATTACHMENT9"/>
+            <enum name="GL_COLOR_ATTACHMENT10"/>
+            <enum name="GL_COLOR_ATTACHMENT11"/>
+            <enum name="GL_COLOR_ATTACHMENT12"/>
+            <enum name="GL_COLOR_ATTACHMENT13"/>
+            <enum name="GL_COLOR_ATTACHMENT14"/>
+            <enum name="GL_COLOR_ATTACHMENT15"/>
+            <enum name="GL_COLOR_ATTACHMENT16"/>
+            <enum name="GL_COLOR_ATTACHMENT17"/>
+            <enum name="GL_COLOR_ATTACHMENT18"/>
+            <enum name="GL_COLOR_ATTACHMENT19"/>
+            <enum name="GL_COLOR_ATTACHMENT20"/>
+            <enum name="GL_COLOR_ATTACHMENT21"/>
+            <enum name="GL_COLOR_ATTACHMENT22"/>
+            <enum name="GL_COLOR_ATTACHMENT23"/>
+            <enum name="GL_COLOR_ATTACHMENT24"/>
+            <enum name="GL_COLOR_ATTACHMENT25"/>
+            <enum name="GL_COLOR_ATTACHMENT26"/>
+            <enum name="GL_COLOR_ATTACHMENT27"/>
+            <enum name="GL_COLOR_ATTACHMENT28"/>
+            <enum name="GL_COLOR_ATTACHMENT29"/>
+            <enum name="GL_COLOR_ATTACHMENT30"/>
+            <enum name="GL_COLOR_ATTACHMENT31"/>
+        </group>
+
+        <group name="MapQuery">
+            <enum name="GL_COEFF"/>
+            <enum name="GL_ORDER"/>
+            <enum name="GL_DOMAIN"/>
+        </group>
+
+        <group name="VertexArrayPName">
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_ENABLED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_SIZE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_STRIDE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_TYPE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_NORMALIZED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_LONG"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR"/>
+            <enum name="GL_VERTEX_ATTRIB_RELATIVE_OFFSET"/>
+        </group>
+
+        <group name="TransformFeedbackPName">
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_BINDING"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_START"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_SIZE"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_PAUSED"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_ACTIVE"/>
+        </group>
+
+        <group name="SyncParameterName">
+            <enum name="GL_OBJECT_TYPE"/>
+            <enum name="GL_SYNC_STATUS"/>
+            <enum name="GL_SYNC_CONDITION"/>
+            <enum name="GL_SYNC_FLAGS"/>
+        </group>
+
+        <group name="ShaderParameterName">
+            <enum name="GL_SHADER_TYPE"/>
+            <enum name="GL_DELETE_STATUS"/>
+            <enum name="GL_COMPILE_STATUS"/>
+            <enum name="GL_INFO_LOG_LENGTH"/>
+            <enum name="GL_SHADER_SOURCE_LENGTH"/>
+        </group>
+
+        <group name="QueryObjectParameterName">
+            <enum name="GL_QUERY_RESULT_AVAILABLE"/>
+            <enum name="GL_QUERY_RESULT"/>
+            <enum name="GL_QUERY_RESULT_NO_WAIT"/>
+            <enum name="GL_QUERY_TARGET"/>
+        </group>
+
+        <group name="QueryParameterName">
+            <enum name="GL_CURRENT_QUERY"/>
+            <enum name="GL_QUERY_COUNTER_BITS"/>
+        </group>
+
+        <group name="ProgramStagePName">
+            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORMS"/>
+            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORM_LOCATIONS"/>
+            <enum name="GL_ACTIVE_SUBROUTINES"/>
+            <enum name="GL_ACTIVE_SUBROUTINE_UNIFORM_MAX_LENGTH"/>
+            <enum name="GL_ACTIVE_SUBROUTINE_MAX_LENGTH"/>
+        </group>
+
+        <group name="PipelineParameterName">
+            <enum name="GL_ACTIVE_PROGRAM"/>
+            <enum name="GL_VERTEX_SHADER"/>
+            <enum name="GL_TESS_CONTROL_SHADER"/>
+            <enum name="GL_TESS_EVALUATION_SHADER"/>
+            <enum name="GL_GEOMETRY_SHADER"/>
+            <enum name="GL_FRAGMENT_SHADER"/>
+            <enum name="GL_INFO_LOG_LENGTH"/>
+        </group>
+
+        <group name="ProgramInterface">
+            <enum name="GL_UNIFORM"/>
+            <enum name="GL_UNIFORM_BLOCK"/>
+            <enum name="GL_PROGRAM_INPUT"/>
+            <enum name="GL_PROGRAM_OUTPUT"/>
+            <enum name="GL_VERTEX_SUBROUTINE"/>
+            <enum name="GL_TESS_CONTROL_SUBROUTINE"/>
+            <enum name="GL_TESS_EVALUATION_SUBROUTINE"/>
+            <enum name="GL_GEOMETRY_SUBROUTINE"/>
+            <enum name="GL_FRAGMENT_SUBROUTINE"/>
+            <enum name="GL_COMPUTE_SUBROUTINE"/>
+            <enum name="GL_VERTEX_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_TESS_CONTROL_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_TESS_EVALUATION_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_GEOMETRY_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_FRAGMENT_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_COMPUTE_SUBROUTINE_UNIFORM"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_VARYING"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER"/>
+            <enum name="GL_BUFFER_VARIABLE"/>
+            <enum name="GL_SHADER_STORAGE_BLOCK"/>
+        </group>
+
+        <group name="VertexAttribEnum">
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_BUFFER_BINDING"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_ENABLED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_SIZE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_STRIDE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_TYPE"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_NORMALIZED"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_INTEGER"/>
+            <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR"/>
+            <enum name="GL_CURRENT_VERTEX_ATTRIB"/>
+        </group>
+
+        <group name="VertexAttribType">
+            <enum name="GL_BYTE"/>
+            <enum name="GL_SHORT"/>
+            <enum name="GL_INT"/>
+            <enum name="GL_FIXED"/>
+            <enum name="GL_FLOAT"/>
+            <enum name="GL_HALF_FLOAT"/>
+            <enum name="GL_DOUBLE"/>
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+            <enum name="GL_INT_2_10_10_10_REV"/>
+            <enum name="GL_UNSIGNED_INT_2_10_10_10_REV"/>
+            <enum name="GL_UNSIGNED_INT_10F_11F_11F_REV"/>
+        </group>
+
+        <group name="AttributeType">
+            <enum name="GL_FLOAT_VEC2"/>
+            <enum name="GL_FLOAT_VEC2_ARB"/>
+            <enum name="GL_FLOAT_VEC3"/>
+            <enum name="GL_FLOAT_VEC3_ARB"/>
+            <enum name="GL_FLOAT_VEC4"/>
+            <enum name="GL_FLOAT_VEC4_ARB"/>
+            <enum name="GL_INT_VEC2"/>
+            <enum name="GL_INT_VEC2_ARB"/>
+            <enum name="GL_INT_VEC3"/>
+            <enum name="GL_INT_VEC3_ARB"/>
+            <enum name="GL_INT_VEC4"/>
+            <enum name="GL_INT_VEC4_ARB"/>
+            <enum name="GL_BOOL"/>
+            <enum name="GL_BOOL_ARB"/>
+            <enum name="GL_BOOL_VEC2"/>
+            <enum name="GL_BOOL_VEC2_ARB"/>
+            <enum name="GL_BOOL_VEC3"/>
+            <enum name="GL_BOOL_VEC3_ARB"/>
+            <enum name="GL_BOOL_VEC4"/>
+            <enum name="GL_BOOL_VEC4_ARB"/>
+            <enum name="GL_FLOAT_MAT2"/>
+            <enum name="GL_FLOAT_MAT2_ARB"/>
+            <enum name="GL_FLOAT_MAT3"/>
+            <enum name="GL_FLOAT_MAT3_ARB"/>
+            <enum name="GL_FLOAT_MAT4"/>
+            <enum name="GL_FLOAT_MAT4_ARB"/>
+            <enum name="GL_FLOAT_MAT2x3"/>
+            <enum name="GL_FLOAT_MAT2x3_NV"/>
+            <enum name="GL_FLOAT_MAT2x4"/>
+            <enum name="GL_FLOAT_MAT2x4_NV"/>
+            <enum name="GL_FLOAT_MAT3x2"/>
+            <enum name="GL_FLOAT_MAT3x2_NV"/>
+            <enum name="GL_FLOAT_MAT3x4"/>
+            <enum name="GL_FLOAT_MAT3x4_NV"/>
+            <enum name="GL_FLOAT_MAT4x2"/>
+            <enum name="GL_FLOAT_MAT4x2_NV"/>
+            <enum name="GL_FLOAT_MAT4x3"/>
+            <enum name="GL_FLOAT_MAT4x3_NV"/>
+        </group>
+
+        <group name="UniformType">
+            <enum name="GL_INT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+            <enum name="GL_FLOAT"/>
+            <enum name="GL_DOUBLE"/>
+            <enum name="GL_FLOAT_VEC2"/>
+            <enum name="GL_FLOAT_VEC3"/>
+            <enum name="GL_FLOAT_VEC4"/>
+            <enum name="GL_INT_VEC2"/>
+            <enum name="GL_INT_VEC3"/>
+            <enum name="GL_INT_VEC4"/>
+            <enum name="GL_BOOL"/>
+            <enum name="GL_BOOL_VEC2"/>
+            <enum name="GL_BOOL_VEC3"/>
+            <enum name="GL_BOOL_VEC4"/>
+            <enum name="GL_FLOAT_MAT2"/>
+            <enum name="GL_FLOAT_MAT3"/>
+            <enum name="GL_FLOAT_MAT4"/>
+            <enum name="GL_SAMPLER_1D"/>
+            <enum name="GL_SAMPLER_2D"/>
+            <enum name="GL_SAMPLER_3D"/>
+            <enum name="GL_SAMPLER_CUBE"/>
+            <enum name="GL_SAMPLER_1D_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_RECT"/>
+            <enum name="GL_SAMPLER_2D_RECT_SHADOW"/>
+            <enum name="GL_FLOAT_MAT2X3"/>
+            <enum name="GL_FLOAT_MAT2X4"/>
+            <enum name="GL_FLOAT_MAT3X2"/>
+            <enum name="GL_FLOAT_MAT3X4"/>
+            <enum name="GL_FLOAT_MAT4X2"/>
+            <enum name="GL_FLOAT_MAT4X3"/>
+            <enum name="GL_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_SAMPLER_BUFFER"/>
+            <enum name="GL_SAMPLER_1D_ARRAY_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_ARRAY_SHADOW"/>
+            <enum name="GL_SAMPLER_CUBE_SHADOW"/>
+            <enum name="GL_UNSIGNED_INT_VEC2"/>
+            <enum name="GL_UNSIGNED_INT_VEC3"/>
+            <enum name="GL_UNSIGNED_INT_VEC4"/>
+            <enum name="GL_INT_SAMPLER_1D"/>
+            <enum name="GL_INT_SAMPLER_2D"/>
+            <enum name="GL_INT_SAMPLER_3D"/>
+            <enum name="GL_INT_SAMPLER_CUBE"/>
+            <enum name="GL_INT_SAMPLER_2D_RECT"/>
+            <enum name="GL_INT_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_BUFFER"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_1D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_3D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_CUBE"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_RECT"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_BUFFER"/>
+            <enum name="GL_DOUBLE_MAT2"/>
+            <enum name="GL_DOUBLE_MAT3"/>
+            <enum name="GL_DOUBLE_MAT4"/>
+            <enum name="GL_DOUBLE_MAT2x3"/>
+            <enum name="GL_DOUBLE_MAT2x4"/>
+            <enum name="GL_DOUBLE_MAT3x2"/>
+            <enum name="GL_DOUBLE_MAT3x4"/>
+            <enum name="GL_DOUBLE_MAT4x2"/>
+            <enum name="GL_DOUBLE_MAT4x3"/>
+            <enum name="GL_DOUBLE_VEC2"/>
+            <enum name="GL_DOUBLE_VEC3"/>
+            <enum name="GL_DOUBLE_VEC4"/>
+            <enum name="GL_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW"/>
+            <enum name="GL_INT_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_INT_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+        </group>
+
+        <group name="InternalFormatPName">
+            <enum name="GL_NUM_SAMPLE_COUNTS"/>
+            <enum name="GL_SAMPLES"/>
+            <enum name="GL_INTERNALFORMAT_SUPPORTED"/>
+            <enum name="GL_INTERNALFORMAT_PREFERRED"/>
+            <enum name="GL_INTERNALFORMAT_RED_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_GREEN_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_BLUE_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_ALPHA_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_DEPTH_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_STENCIL_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_SHARED_SIZE"/>
+            <enum name="GL_INTERNALFORMAT_RED_TYPE"/>
+            <enum name="GL_INTERNALFORMAT_GREEN_TYPE"/>
+            <enum name="GL_INTERNALFORMAT_BLUE_TYPE"/>
+            <enum name="GL_INTERNALFORMAT_ALPHA_TYPE"/>
+            <enum name="GL_INTERNALFORMAT_DEPTH_TYPE"/>
+            <enum name="GL_INTERNALFORMAT_STENCIL_TYPE"/>
+            <enum name="GL_MAX_WIDTH"/>
+            <enum name="GL_MAX_HEIGHT"/>
+            <enum name="GL_MAX_DEPTH"/>
+            <enum name="GL_MAX_LAYERS"/>
+            <enum name="GL_COLOR_COMPONENTS"/>
+            <enum name="GL_COLOR_RENDERABLE"/>
+            <enum name="GL_DEPTH_RENDERABLE"/>
+            <enum name="GL_STENCIL_RENDERABLE"/>
+            <enum name="GL_FRAMEBUFFER_RENDERABLE"/>
+            <enum name="GL_FRAMEBUFFER_RENDERABLE_LAYERED"/>
+            <enum name="GL_FRAMEBUFFER_BLEND"/>
+            <enum name="GL_READ_PIXELS"/>
+            <enum name="GL_READ_PIXELS_FORMAT"/>
+            <enum name="GL_READ_PIXELS_TYPE"/>
+            <enum name="GL_TEXTURE_IMAGE_FORMAT"/>
+            <enum name="GL_TEXTURE_IMAGE_TYPE"/>
+            <enum name="GL_GET_TEXTURE_IMAGE_FORMAT"/>
+            <enum name="GL_GET_TEXTURE_IMAGE_TYPE"/>
+            <enum name="GL_MIPMAP"/>
+            <enum name="GL_GENERATE_MIPMAP"/>
+            <enum name="GL_AUTO_GENERATE_MIPMAP"/>
+            <enum name="GL_COLOR_ENCODING"/>
+            <enum name="GL_SRGB_READ"/>
+            <enum name="GL_SRGB_WRITE"/>
+            <enum name="GL_FILTER"/>
+            <enum name="GL_VERTEX_TEXTURE"/>
+            <enum name="GL_TESS_CONTROL_TEXTURE"/>
+            <enum name="GL_TESS_EVALUATION_TEXTURE"/>
+            <enum name="GL_GEOMETRY_TEXTURE"/>
+            <enum name="GL_FRAGMENT_TEXTURE"/>
+            <enum name="GL_COMPUTE_TEXTURE"/>
+            <enum name="GL_TEXTURE_SHADOW"/>
+            <enum name="GL_TEXTURE_GATHER"/>
+            <enum name="GL_TEXTURE_GATHER_SHADOW"/>
+            <enum name="GL_SHADER_IMAGE_LOAD"/>
+            <enum name="GL_SHADER_IMAGE_STORE"/>
+            <enum name="GL_SHADER_IMAGE_ATOMIC"/>
+            <enum name="GL_IMAGE_TEXEL_SIZE"/>
+            <enum name="GL_IMAGE_COMPATIBILITY_CLASS"/>
+            <enum name="GL_IMAGE_PIXEL_FORMAT"/>
+            <enum name="GL_IMAGE_PIXEL_TYPE"/>
+            <enum name="GL_IMAGE_FORMAT_COMPATIBILITY_TYPE"/>
+            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_TEST"/>
+            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_TEST"/>
+            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_DEPTH_WRITE"/>
+            <enum name="GL_SIMULTANEOUS_TEXTURE_AND_STENCIL_WRITE"/>
+            <enum name="GL_TEXTURE_COMPRESSED"/>
+            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_WIDTH"/>
+            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_HEIGHT"/>
+            <enum name="GL_TEXTURE_COMPRESSED_BLOCK_SIZE"/>
+            <enum name="GL_CLEAR_BUFFER"/>
+            <enum name="GL_TEXTURE_VIEW"/>
+            <enum name="GL_VIEW_COMPATIBILITY_CLASS"/>
+            <enum name="GL_CLEAR_TEXTURE"/>
+        </group>
+
+        <group name="FramebufferAttachmentParameterName">
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_GREEN_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_BLUE_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_LAYERED"/>
+            <enum name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER"/>
+        </group>
+
+        <group name="ProgramInterfacePName">
+            <enum name="GL_ACTIVE_RESOURCES"/>
+            <enum name="GL_MAX_NAME_LENGTH"/>
+            <enum name="GL_MAX_NUM_ACTIVE_VARIABLES"/>
+            <enum name="GL_MAX_NUM_COMPATIBLE_SUBROUTINES"/>
+        </group>
+
+        <group name="PrecisionType">
+            <enum name="GL_LOW_FLOAT"/>
+            <enum name="GL_MEDIUM_FLOAT"/>
+            <enum name="GL_HIGH_FLOAT"/>
+            <enum name="GL_LOW_INT"/>
+            <enum name="GL_MEDIUM_INT"/>
+            <enum name="GL_HIGH_INT"/>
+        </group>
+
+        <group name="VertexAttribPointerType">
+            <enum name="GL_BYTE"/>
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_SHORT"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_INT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+            <enum name="GL_FLOAT"/>
+            <enum name="GL_DOUBLE"/>
+            <enum name="GL_HALF_FLOAT"/>
+            <enum name="GL_FIXED"/>
+            <enum name="GL_INT_2_10_10_10_REV"/>
+            <enum name="GL_UNSIGNED_INT_2_10_10_10_REV"/>
+            <enum name="GL_UNSIGNED_INT_10F_11F_11F_REV"/>
+        </group>
+
+        <group name="SubroutineParameterName">
+            <enum name="GL_NUM_COMPATIBLE_SUBROUTINES"/>
+            <enum name="GL_COMPATIBLE_SUBROUTINES"/>
+            <enum name="GL_UNIFORM_SIZE"/>
+            <enum name="GL_UNIFORM_NAME_LENGTH"/>
+        </group>
+
+        <group name="GetFramebufferParameter">
+            <enum name="GL_FRAMEBUFFER_DEFAULT_WIDTH"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_HEIGHT"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_LAYERS"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_SAMPLES"/>
+            <enum name="GL_FRAMEBUFFER_DEFAULT_FIXED_SAMPLE_LOCATIONS"/>
+            <enum name="GL_DOUBLEBUFFER"/>
+            <enum name="GL_IMPLEMENTATION_COLOR_READ_FORMAT"/>
+            <enum name="GL_IMPLEMENTATION_COLOR_READ_TYPE"/>
+            <enum name="GL_SAMPLES"/>
+            <enum name="GL_SAMPLE_BUFFERS"/>
+            <enum name="GL_STEREO"/>
+        </group>
+
+        <group name="PathStringFormat">
+            <enum name="GL_PATH_FORMAT_SVG_NV" />
+            <enum name="GL_PATH_FORMAT_PS_NV" />
+        </group>
+
+        <group name="PathFontTarget">
+            <enum name="GL_STANDARD_FONT_NAME_NV" />
+            <enum name="GL_SYSTEM_FONT_NAME_NV" />
+            <enum name="GL_FILE_NAME_NV" />
+        </group>
+
+        <group name="PathHandleMissingGlyphs">
+            <enum name="GL_SKIP_MISSING_GLYPH_NV" />
+            <enum name="GL_USE_MISSING_GLYPH_NV" />
+        </group>
+
+        <group name="PathParameter">
+            <enum name="GL_PATH_STROKE_WIDTH_NV" />
+            <enum name="GL_PATH_INITIAL_END_CAP_NV" />
+            <enum name="GL_PATH_TERMINAL_END_CAP_NV" />
+            <enum name="GL_PATH_JOIN_STYLE_NV" />
+            <enum name="GL_PATH_MITER_LIMIT_NV" />
+            <enum name="GL_PATH_INITIAL_DASH_CAP_NV" />
+            <enum name="GL_PATH_TERMINAL_DASH_CAP_NV" />
+            <enum name="GL_PATH_DASH_OFFSET_NV" />
+            <enum name="GL_PATH_CLIENT_LENGTH_NV" />
+            <enum name="GL_PATH_DASH_OFFSET_RESET_NV" />
+            <enum name="GL_PATH_FILL_MODE_NV" />
+            <enum name="GL_PATH_FILL_MASK_NV" />
+            <enum name="GL_PATH_FILL_COVER_MODE_NV" />
+            <enum name="GL_PATH_STROKE_COVER_MODE_NV" />
+            <enum name="GL_PATH_STROKE_MASK_NV" />
+            <!-- <enum name="GL_PATH_STROKE_BOUND_NV" comment="Removed from extension"/> -->
+            <enum name="GL_PATH_END_CAPS_NV" />
+            <enum name="GL_PATH_DASH_CAPS_NV" />
+            <enum name="GL_PATH_COMMAND_COUNT_NV" />
+            <enum name="GL_PATH_COORD_COUNT_NV" />
+            <enum name="GL_PATH_DASH_ARRAY_COUNT_NV" />
+            <enum name="GL_PATH_COMPUTED_LENGTH_NV" />
+            <enum name="GL_PATH_OBJECT_BOUNDING_BOX_NV" />
+            <enum name="GL_PATH_FILL_BOUNDING_BOX_NV" />
+            <enum name="GL_PATH_STROKE_BOUNDING_BOX_NV" />
+        </group>
+
+        <group name="PathColor">
+            <enum name="GL_PRIMARY_COLOR" />
+            <enum name="GL_PRIMARY_COLOR_NV" />
+            <enum name="GL_SECONDARY_COLOR_NV" />
+        </group>
+
+        <group name="PathGenMode">
+            <enum name="GL_NONE" />
+            <enum name="GL_EYE_LINEAR" />
+            <enum name="GL_OBJECT_LINEAR" />
+            <enum name="GL_PATH_OBJECT_BOUNDING_BOX_NV" />
+            <enum name="GL_CONSTANT" />
+        </group>
+
+        <group name="TextureLayout">
+            <enum name="GL_LAYOUT_GENERAL_EXT"/>
+            <enum name="GL_LAYOUT_COLOR_ATTACHMENT_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT"/>
+            <enum name="GL_LAYOUT_SHADER_READ_ONLY_EXT"/>
+            <enum name="GL_LAYOUT_TRANSFER_SRC_EXT"/>
+            <enum name="GL_LAYOUT_TRANSFER_DST_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+            <enum name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
+        </group>
+
+        <group name="PathTransformType">
+            <enum name="GL_NONE" />
+            <enum name="GL_TRANSLATE_X_NV" />
+            <enum name="GL_TRANSLATE_Y_NV" />
+            <enum name="GL_TRANSLATE_2D_NV" />
+            <enum name="GL_TRANSLATE_3D_NV" />
+            <enum name="GL_AFFINE_2D_NV" />
+            <enum name="GL_AFFINE_3D_NV" />
+            <enum name="GL_TRANSPOSE_AFFINE_2D_NV" />
+            <enum name="GL_TRANSPOSE_AFFINE_3D_NV" />
+        </group>
+
+        <group name="PathElementType">
+            <enum name="GL_UTF8_NV" />
+            <enum name="GL_UTF16_NV" />
+        </group>
+
+        <group name="PathCoverMode">
+            <enum name="GL_CONVEX_HULL_NV" />
+            <enum name="GL_BOUNDING_BOX_NV" />
+            <enum name="GL_BOUNDING_BOX_OF_BOUNDING_BOXES_NV" />
+            <enum name="GL_PATH_FILL_COVER_MODE_NV" />
+        </group>
+
+        <group name="PathFontStyle">
+            <enum name="GL_NONE" />
+            <enum name="GL_BOLD_BIT_NV" />
+            <enum name="GL_ITALIC_BIT_NV" />
+        </group>
+
+        <group name="PathMetricMask">
+            <enum name="GL_GLYPH_WIDTH_BIT_NV" />
+            <enum name="GL_GLYPH_HEIGHT_BIT_NV" />
+            <enum name="GL_GLYPH_HORIZONTAL_BEARING_X_BIT_NV" />
+            <enum name="GL_GLYPH_HORIZONTAL_BEARING_Y_BIT_NV" />
+            <enum name="GL_GLYPH_HORIZONTAL_BEARING_ADVANCE_BIT_NV" />
+            <enum name="GL_GLYPH_VERTICAL_BEARING_X_BIT_NV" />
+            <enum name="GL_GLYPH_VERTICAL_BEARING_Y_BIT_NV" />
+            <enum name="GL_GLYPH_VERTICAL_BEARING_ADVANCE_BIT_NV" />
+            <enum name="GL_GLYPH_HAS_KERNING_BIT_NV" />
+            <enum name="GL_FONT_X_MIN_BOUNDS_BIT_NV" />
+            <enum name="GL_FONT_Y_MIN_BOUNDS_BIT_NV" />
+            <enum name="GL_FONT_X_MAX_BOUNDS_BIT_NV" />
+            <enum name="GL_FONT_Y_MAX_BOUNDS_BIT_NV" />
+            <enum name="GL_FONT_UNITS_PER_EM_BIT_NV" />
+            <enum name="GL_FONT_ASCENDER_BIT_NV" />
+            <enum name="GL_FONT_DESCENDER_BIT_NV" />
+            <enum name="GL_FONT_HEIGHT_BIT_NV" />
+            <enum name="GL_FONT_MAX_ADVANCE_WIDTH_BIT_NV" />
+            <enum name="GL_FONT_MAX_ADVANCE_HEIGHT_BIT_NV" />
+            <enum name="GL_FONT_UNDERLINE_POSITION_BIT_NV" />
+            <enum name="GL_FONT_UNDERLINE_THICKNESS_BIT_NV" />
+            <enum name="GL_FONT_HAS_KERNING_BIT_NV" />
+            <enum name="GL_FONT_NUM_GLYPH_INDICES_BIT_NV" />
+        </group>
+
+        <group name="PathListMode">
+            <enum name="GL_ACCUM_ADJACENT_PAIRS_NV" />
+            <enum name="GL_ADJACENT_PAIRS_NV" />
+            <enum name="GL_FIRST_TO_REST_NV" />
+        </group>
+
+        <group name="ProgramPropertyARB">
+            <enum name="GL_DELETE_STATUS" />
+            <enum name="GL_LINK_STATUS" />
+            <enum name="GL_VALIDATE_STATUS" />
+            <enum name="GL_INFO_LOG_LENGTH" />
+            <enum name="GL_ATTACHED_SHADERS" />
+            <enum name="GL_ACTIVE_ATOMIC_COUNTER_BUFFERS" />
+            <enum name="GL_ACTIVE_ATTRIBUTES" />
+            <enum name="GL_ACTIVE_ATTRIBUTE_MAX_LENGTH" />
+            <enum name="GL_ACTIVE_UNIFORMS" />
+            <enum name="GL_ACTIVE_UNIFORM_BLOCKS" />
+            <enum name="GL_ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH" />
+            <enum name="GL_ACTIVE_UNIFORM_MAX_LENGTH" />
+            <enum name="GL_COMPUTE_WORK_GROUP_SIZE" />
+            <enum name="GL_PROGRAM_BINARY_LENGTH" />
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_MODE" />
+            <enum name="GL_TRANSFORM_FEEDBACK_VARYINGS" />
+            <enum name="GL_TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH" />
+            <enum name="GL_GEOMETRY_VERTICES_OUT" />
+            <enum name="GL_GEOMETRY_INPUT_TYPE" />
+            <enum name="GL_GEOMETRY_OUTPUT_TYPE" />
+        </group>
+
+        <group name="GlslTypeToken" comment="OpenGL 4.6 Table 7.3: OpenGL Shading Language type tokens">
+            <enum name="GL_FLOAT"/>
+            <enum name="GL_FLOAT_VEC2"/>
+            <enum name="GL_FLOAT_VEC3"/>
+            <enum name="GL_FLOAT_VEC4"/>
+            <enum name="GL_DOUBLE"/>
+            <enum name="GL_DOUBLE_VEC2"/>
+            <enum name="GL_DOUBLE_VEC3"/>
+            <enum name="GL_DOUBLE_VEC4"/>
+            <enum name="GL_INT"/>
+            <enum name="GL_INT_VEC2"/>
+            <enum name="GL_INT_VEC3"/>
+            <enum name="GL_INT_VEC4"/>
+            <enum name="GL_UNSIGNED_INT"/>
+            <enum name="GL_UNSIGNED_INT_VEC2"/>
+            <enum name="GL_UNSIGNED_INT_VEC3"/>
+            <enum name="GL_UNSIGNED_INT_VEC4"/>
+            <enum name="GL_BOOL"/>
+            <enum name="GL_BOOL_VEC2"/>
+            <enum name="GL_BOOL_VEC3"/>
+            <enum name="GL_BOOL_VEC4"/>
+            <enum name="GL_FLOAT_MAT2"/>
+            <enum name="GL_FLOAT_MAT3"/>
+            <enum name="GL_FLOAT_MAT4"/>
+            <enum name="GL_FLOAT_MAT2x3"/>
+            <enum name="GL_FLOAT_MAT2x4"/>
+            <enum name="GL_FLOAT_MAT3x2"/>
+            <enum name="GL_FLOAT_MAT3x4"/>
+            <enum name="GL_FLOAT_MAT4x2"/>
+            <enum name="GL_FLOAT_MAT4x3"/>
+            <enum name="GL_DOUBLE_MAT2"/>
+            <enum name="GL_DOUBLE_MAT3"/>
+            <enum name="GL_DOUBLE_MAT4"/>
+            <enum name="GL_SAMPLER_1D"/>
+            <enum name="GL_SAMPLER_2D"/>
+            <enum name="GL_SAMPLER_3D"/>
+            <enum name="GL_SAMPLER_CUBE"/>
+            <enum name="GL_SAMPLER_1D_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_SHADOW"/>
+            <enum name="GL_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_SAMPLER_1D_ARRAY_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_ARRAY_SHADOW"/>
+            <enum name="GL_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_SAMPLER_CUBE_SHADOW"/>
+            <enum name="GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW"/>
+            <enum name="GL_SAMPLER_BUFFER"/>
+            <enum name="GL_SAMPLER_2D_RECT"/>
+            <enum name="GL_SAMPLER_2D_RECT_SHADOW"/>
+            <enum name="GL_INT_SAMPLER_1D"/>
+            <enum name="GL_INT_SAMPLER_2D"/>
+            <enum name="GL_INT_SAMPLER_3D"/>
+            <enum name="GL_INT_SAMPLER_CUBE"/>
+            <enum name="GL_INT_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_INT_SAMPLER_BUFFER"/>
+            <enum name="GL_INT_SAMPLER_2D_RECT"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_1D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_3D"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_CUBE"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_1D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_BUFFER"/>
+            <enum name="GL_UNSIGNED_INT_SAMPLER_2D_RECT"/>
+            <enum name="GL_IMAGE_1D"/>
+            <enum name="GL_IMAGE_2D"/>
+            <enum name="GL_IMAGE_3D"/>
+            <enum name="GL_IMAGE_2D_RECT"/>
+            <enum name="GL_IMAGE_CUBE"/>
+            <enum name="GL_IMAGE_BUFFER"/>
+            <enum name="GL_IMAGE_1D_ARRAY"/>
+            <enum name="GL_IMAGE_2D_ARRAY"/>
+            <enum name="GL_IMAGE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_IMAGE_2D_MULTISAMPLE"/>
+            <enum name="GL_IMAGE_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_INT_IMAGE_1D"/>
+            <enum name="GL_INT_IMAGE_2D"/>
+            <enum name="GL_INT_IMAGE_3D"/>
+            <enum name="GL_INT_IMAGE_2D_RECT"/>
+            <enum name="GL_INT_IMAGE_CUBE"/>
+            <enum name="GL_INT_IMAGE_BUFFER"/>
+            <enum name="GL_INT_IMAGE_1D_ARRAY"/>
+            <enum name="GL_INT_IMAGE_2D_ARRAY"/>
+            <enum name="GL_INT_IMAGE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_INT_IMAGE_2D_MULTISAMPLE"/>
+            <enum name="GL_INT_IMAGE_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_1D"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_2D"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_3D"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_2D_RECT"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_CUBE"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_BUFFER"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_1D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_2D_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_2D_MULTISAMPLE"/>
+            <enum name="GL_UNSIGNED_INT_IMAGE_2D_MULTISAMPLE_ARRAY"/>
+            <enum name="GL_UNSIGNED_INT_ATOMIC_COUNTER"/>
+        </group>
+
+        <group name="TransformFeedbackBufferMode" comment="See glTransformFeedbackVaryings()">
+            <enum name="GL_INTERLEAVED_ATTRIBS"/>
+            <enum name="GL_SEPARATE_ATTRIBS"/>
+        </group>
+
+        <group name="VertexAttribIType">
+            <enum name="GL_BYTE"/>
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_SHORT"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_INT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+        </group>
+
+        <group name="VertexAttribLType">
+            <enum name="GL_DOUBLE"/>
+        </group>
+
+        <group name="ProgramResourceProperty">
+            <enum name="GL_ACTIVE_VARIABLES"/>
+            <enum name="GL_BUFFER_BINDING"/>
+            <enum name="GL_NUM_ACTIVE_VARIABLES"/>
+            <enum name="GL_ARRAY_SIZE"/>
+            <enum name="GL_ARRAY_STRIDE"/>
+            <enum name="GL_BLOCK_INDEX"/>
+            <enum name="GL_IS_ROW_MAJOR"/>
+            <enum name="GL_MATRIX_STRIDE"/>
+            <enum name="GL_ATOMIC_COUNTER_BUFFER_INDEX"/>
+            <enum name="GL_BUFFER_DATA_SIZE"/>
+            <enum name="GL_NUM_COMPATIBLE_SUBROUTINES"/>
+            <enum name="GL_COMPATIBLE_SUBROUTINES"/>
+            <enum name="GL_IS_PER_PATCH"/>
+            <enum name="GL_LOCATION"/>
+            <enum name="GL_UNIFORM"/>
+            <enum name="GL_LOCATION_COMPONENT"/>
+            <enum name="GL_LOCATION_INDEX"/>
+            <enum name="GL_NAME_LENGTH"/>
+            <enum name="GL_OFFSET"/>
+            <enum name="GL_REFERENCED_BY_VERTEX_SHADER"/>
+            <enum name="GL_REFERENCED_BY_TESS_CONTROL_SHADER"/>
+            <enum name="GL_REFERENCED_BY_TESS_EVALUATION_SHADER"/>
+            <enum name="GL_REFERENCED_BY_GEOMETRY_SHADER"/>
+            <enum name="GL_REFERENCED_BY_FRAGMENT_SHADER"/>
+            <enum name="GL_REFERENCED_BY_COMPUTE_SHADER"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_INDEX"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_BUFFER_STRIDE"/>
+            <enum name="GL_TOP_LEVEL_ARRAY_SIZE"/>
+            <enum name="GL_TOP_LEVEL_ARRAY_STRIDE"/>
+            <enum name="GL_TYPE"/>
+        </group>
+
+        <group name="TextureCompareMode">
+            <enum name="GL_NONE"/>
+            <enum name="GL_COMPARE_REF_TO_TEXTURE"/>
+            <enum name="GL_COMPARE_R_TO_TEXTURE"/>
+        </group>
+
+        <group name="TextureSwizzle">
+            <enum name="GL_RED"/>
+            <enum name="GL_GREEN"/>
+            <enum name="GL_BLUE"/>
+            <enum name="GL_ALPHA"/>
+            <enum name="GL_ZERO"/>
+            <enum name="GL_ONE"/>
+        </group>
+
     </groups>
 
     <!-- SECTION: GL enumerant (token) definitions. -->
@@ -2049,6 +4596,19 @@ typedef unsigned int GLhandleARB;
         <enum value="0xFFFFFFFF" name="GL_ALL_ATTRIB_BITS" comment="Guaranteed to mark all attribute groups at once"/>
     </enums>
 
+    <enums namespace="GL" group="BufferStorageMask" type="bitmask" comment="GL_MAP_{COHERENT,PERSISTENT,READ,WRITE}_{BIT,BIT_EXT} also lie in this namespace">
+        <enum value="0x0100" name="GL_DYNAMIC_STORAGE_BIT"/>
+        <enum value="0x0100" name="GL_DYNAMIC_STORAGE_BIT_EXT"/>
+        <enum value="0x0200" name="GL_CLIENT_STORAGE_BIT"/>
+        <enum value="0x0200" name="GL_CLIENT_STORAGE_BIT_EXT"/>
+        <enum value="0x0400" name="GL_SPARSE_STORAGE_BIT_ARB"/>
+        <enum value="0x0800" name="GL_LGPU_SEPARATE_STORAGE_BIT_NVX"/>
+        <enum value="0x0800" name="GL_PER_GPU_STORAGE_BIT_NV"/>
+            <unused start="0x1000" end="0x1000" comment="Reserved for NVIDIA"/>
+        <enum value="0x2000" name="GL_EXTERNAL_STORAGE_BIT_NVX"/>
+            <!-- Also used: 0x000000ff for bits reused from MapBufferAccessMask below -->
+    </enums>
+
     <enums namespace="GL" group="ClearBufferMask" type="bitmask" comment="GL_{DEPTH,ACCUM,STENCIL,COLOR}_BUFFER_BIT also lie in this namespace">
         <enum value="0x00008000" name="GL_COVERAGE_BUFFER_BIT_NV" comment="Collides with AttribMask bit GL_HINT_BIT. OK since this token is for OpenGL ES 2, which doesn't have attribute groups."/>
             <!-- Also used: 0x00004700 for bits reused from AttribMask above -->
@@ -2066,7 +4626,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x00000002" name="GL_CONTEXT_FLAG_DEBUG_BIT_KHR"/>
         <enum value="0x00000004" name="GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT"/>
         <enum value="0x00000004" name="GL_CONTEXT_FLAG_ROBUST_ACCESS_BIT_ARB"/>
-        <enum value="0x00000008" name="GL_CONTEXT_FLAG_NO_ERROR_BIT_KHR"/>
+        <enum value="0x00000008" name="GL_CONTEXT_FLAG_NO_ERROR_BIT"/>
+        <enum value="0x00000008" name="GL_CONTEXT_FLAG_NO_ERROR_BIT_KHR" alias="GL_CONTEXT_FLAG_NO_ERROR_BIT"/>
         <enum value="0x00000010" name="GL_CONTEXT_FLAG_PROTECTED_CONTENT_BIT_EXT"/>
     </enums>
 
@@ -2075,7 +4636,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x00000002" name="GL_CONTEXT_COMPATIBILITY_PROFILE_BIT"/>
     </enums>
 
-    <enums namespace="GL" group="MapBufferUsageMask" type="bitmask">
+    <enums namespace="GL" group="MapBufferAccessMask" type="bitmask">
         <enum value="0x0001" name="GL_MAP_READ_BIT"/>
         <enum value="0x0001" name="GL_MAP_READ_BIT_EXT"/>
         <enum value="0x0002" name="GL_MAP_WRITE_BIT"/>
@@ -2092,12 +4653,6 @@ typedef unsigned int GLhandleARB;
         <enum value="0x0040" name="GL_MAP_PERSISTENT_BIT_EXT"/>
         <enum value="0x0080" name="GL_MAP_COHERENT_BIT"/>
         <enum value="0x0080" name="GL_MAP_COHERENT_BIT_EXT"/>
-        <enum value="0x0100" name="GL_DYNAMIC_STORAGE_BIT"/>
-        <enum value="0x0100" name="GL_DYNAMIC_STORAGE_BIT_EXT"/>
-        <enum value="0x0200" name="GL_CLIENT_STORAGE_BIT"/>
-        <enum value="0x0200" name="GL_CLIENT_STORAGE_BIT_EXT"/>
-        <enum value="0x0400" name="GL_SPARSE_STORAGE_BIT_ARB"/>
-            <!-- Bits 0x1000 and 0x0800 reserved for Joshua Schnarr, jschnarr@nvidia.com -->
     </enums>
 
     <enums namespace="GL" group="MemoryBarrierMask" type="bitmask">
@@ -2134,7 +4689,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0xFFFFFFFF" name="GL_ALL_BARRIER_BITS_EXT"/>
     </enums>
 
-    <enums namespace="OcclusionQueryEventMaskAMD">
+    <enums namespace="GL" group="OcclusionQueryEventMaskAMD" type="bitmask">
         <enum value="0x00000001" name="GL_QUERY_DEPTH_PASS_EVENT_BIT_AMD"/>
         <enum value="0x00000002" name="GL_QUERY_DEPTH_FAIL_EVENT_BIT_AMD"/>
         <enum value="0x00000004" name="GL_QUERY_STENCIL_FAIL_EVENT_BIT_AMD"/>
@@ -2162,8 +4717,22 @@ typedef unsigned int GLhandleARB;
         <enum value="0x00000010" name="GL_TESS_EVALUATION_SHADER_BIT_EXT"/>
         <enum value="0x00000010" name="GL_TESS_EVALUATION_SHADER_BIT_OES"/>
         <enum value="0x00000020" name="GL_COMPUTE_SHADER_BIT"/>
+        <enum value="0x00000040" name="GL_MESH_SHADER_BIT_NV"/>
+        <enum value="0x00000080" name="GL_TASK_SHADER_BIT_NV"/>
         <enum value="0xFFFFFFFF" name="GL_ALL_SHADER_BITS"/>
         <enum value="0xFFFFFFFF" name="GL_ALL_SHADER_BITS_EXT"/>
+    </enums>
+
+    <enums namespace="GL" group="SubgroupSupportedFeatures" type="bitmask">
+        <enum value="0x00000001" name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+        <enum value="0x00000002" name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+        <enum value="0x00000004" name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+        <enum value="0x00000008" name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+        <enum value="0x00000010" name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+        <enum value="0x00000020" name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+        <enum value="0x00000040" name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+        <enum value="0x00000080" name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+        <enum value="0x00000100" name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
     </enums>
 
     <!-- Bitmasks defined by vendor extensions -->
@@ -2294,10 +4863,17 @@ typedef unsigned int GLhandleARB;
         <enum value="0x80000000" name="GL_MULTISAMPLE_BUFFER_BIT7_QCOM"/>
     </enums>
 
+    <enums namespace="GL" group="FoveationConfigBitQCOM" type="bitmask">
+        <enum value="0x00000001" name="GL_FOVEATION_ENABLE_BIT_QCOM"/>
+        <enum value="0x00000002" name="GL_FOVEATION_SCALED_BIN_METHOD_BIT_QCOM"/>
+        <enum value="0x00000004" name="GL_FOVEATION_SUBSAMPLED_LAYOUT_METHOD_BIT_QCOM"/>
+    </enums>
+
     <enums namespace="GL" group="FfdMaskSGIX" type="bitmask">
         <enum value="0x00000001" name="GL_TEXTURE_DEFORMATION_BIT_SGIX"/>
         <enum value="0x00000002" name="GL_GEOMETRY_DEFORMATION_BIT_SGIX"/>
     </enums>
+
 
     <!-- Non-bitmask enums with their own namespace. Generally small numbers
          used for indexed access. -->
@@ -2418,6 +4994,8 @@ typedef unsigned int GLhandleARB;
         <enum value="1" name="GL_VERSION_ES_CL_1_0" comment="Not an API enum. API definition macro for ES 1.0/1.1 headers"/>
         <enum value="1" name="GL_VERSION_ES_CM_1_1" comment="Not an API enum. API definition macro for ES 1.0/1.1 headers"/>
         <enum value="1" name="GL_VERSION_ES_CL_1_1" comment="Not an API enum. API definition macro for ES 1.0/1.1 headers"/>
+        <enum value="16" name="GL_UUID_SIZE_EXT"/>
+        <enum value="8" name="GL_LUID_SIZE_EXT"/>
     </enums>
 
     <enums namespace="GL" start="0x0000" end="0x7FFF" vendor="ARB" comment="Mostly OpenGL 1.0/1.1 enum assignments. Unused ranges should generally remain unused.">
@@ -3524,8 +6102,10 @@ typedef unsigned int GLhandleARB;
         <enum value="0x80EB" name="GL_PHONG_HINT_WIN"/>
         <enum value="0x80EC" name="GL_FOG_SPECULAR_TEXTURE_WIN"/>
         <enum value="0x80ED" name="GL_TEXTURE_INDEX_SIZE_EXT"/>
-        <enum value="0x80EE" name="GL_PARAMETER_BUFFER_ARB"/>
-        <enum value="0x80EF" name="GL_PARAMETER_BUFFER_BINDING_ARB"/>
+        <enum value="0x80EE" name="GL_PARAMETER_BUFFER"/>
+        <enum value="0x80EE" name="GL_PARAMETER_BUFFER_ARB" alias="GL_PARAMETER_BUFFER"/>
+        <enum value="0x80EF" name="GL_PARAMETER_BUFFER_BINDING"/>
+        <enum value="0x80EF" name="GL_PARAMETER_BUFFER_BINDING_ARB" alias="GL_PARAMETER_BUFFER_BINDING"/>
         <enum value="0x80F0" name="GL_CLIP_VOLUME_CLIPPING_HINT_EXT"/>
             <unused start="0x80F1" end="0x810F" vendor="MS"/>
     </enums>
@@ -4161,18 +6741,30 @@ typedef unsigned int GLhandleARB;
              ARB_direct_state_access in February 2015 after determining it
              was not well defined or implementable. -->
             <unused start="0x82EB" vendor="ARB" comment="Reserved. Formerly used for GL_TEXTURE_BINDING."/>
-        <enum value="0x82EC" name="GL_TRANSFORM_FEEDBACK_OVERFLOW_ARB"/>
-        <enum value="0x82ED" name="GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB"/>
-        <enum value="0x82EE" name="GL_VERTICES_SUBMITTED_ARB"/>
-        <enum value="0x82EF" name="GL_PRIMITIVES_SUBMITTED_ARB"/>
-        <enum value="0x82F0" name="GL_VERTEX_SHADER_INVOCATIONS_ARB"/>
-        <enum value="0x82F1" name="GL_TESS_CONTROL_SHADER_PATCHES_ARB"/>
-        <enum value="0x82F2" name="GL_TESS_EVALUATION_SHADER_INVOCATIONS_ARB"/>
-        <enum value="0x82F3" name="GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB"/>
-        <enum value="0x82F4" name="GL_FRAGMENT_SHADER_INVOCATIONS_ARB"/>
-        <enum value="0x82F5" name="GL_COMPUTE_SHADER_INVOCATIONS_ARB"/>
-        <enum value="0x82F6" name="GL_CLIPPING_INPUT_PRIMITIVES_ARB"/>
-        <enum value="0x82F7" name="GL_CLIPPING_OUTPUT_PRIMITIVES_ARB"/>
+        <enum value="0x82EC" name="GL_TRANSFORM_FEEDBACK_OVERFLOW"/>
+        <enum value="0x82EC" name="GL_TRANSFORM_FEEDBACK_OVERFLOW_ARB" alias="GL_TRANSFORM_FEEDBACK_OVERFLOW"/>
+        <enum value="0x82ED" name="GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW"/>
+        <enum value="0x82ED" name="GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW_ARB" alias="GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW"/>
+        <enum value="0x82EE" name="GL_VERTICES_SUBMITTED"/>
+        <enum value="0x82EE" name="GL_VERTICES_SUBMITTED_ARB" alias="GL_VERTICES_SUBMITTED"/>
+        <enum value="0x82EF" name="GL_PRIMITIVES_SUBMITTED"/>
+        <enum value="0x82EF" name="GL_PRIMITIVES_SUBMITTED_ARB" alias="GL_PRIMITIVES_SUBMITTED"/>
+        <enum value="0x82F0" name="GL_VERTEX_SHADER_INVOCATIONS"/>
+        <enum value="0x82F0" name="GL_VERTEX_SHADER_INVOCATIONS_ARB" alias="GL_VERTEX_SHADER_INVOCATIONS"/>
+        <enum value="0x82F1" name="GL_TESS_CONTROL_SHADER_PATCHES"/>
+        <enum value="0x82F1" name="GL_TESS_CONTROL_SHADER_PATCHES_ARB" alias="GL_TESS_CONTROL_SHADER_PATCHES"/>
+        <enum value="0x82F2" name="GL_TESS_EVALUATION_SHADER_INVOCATIONS"/>
+        <enum value="0x82F2" name="GL_TESS_EVALUATION_SHADER_INVOCATIONS_ARB" alias="GL_TESS_EVALUATION_SHADER_INVOCATIONS"/>
+        <enum value="0x82F3" name="GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED"/>
+        <enum value="0x82F3" name="GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED_ARB" alias="GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED"/>
+        <enum value="0x82F4" name="GL_FRAGMENT_SHADER_INVOCATIONS"/>
+        <enum value="0x82F4" name="GL_FRAGMENT_SHADER_INVOCATIONS_ARB" alias="GL_FRAGMENT_SHADER_INVOCATIONS"/>
+        <enum value="0x82F5" name="GL_COMPUTE_SHADER_INVOCATIONS"/>
+        <enum value="0x82F5" name="GL_COMPUTE_SHADER_INVOCATIONS_ARB" alias="GL_COMPUTE_SHADER_INVOCATIONS"/>
+        <enum value="0x82F6" name="GL_CLIPPING_INPUT_PRIMITIVES"/>
+        <enum value="0x82F6" name="GL_CLIPPING_INPUT_PRIMITIVES_ARB" alias="GL_CLIPPING_INPUT_PRIMITIVES"/>
+        <enum value="0x82F7" name="GL_CLIPPING_OUTPUT_PRIMITIVES"/>
+        <enum value="0x82F7" name="GL_CLIPPING_OUTPUT_PRIMITIVES_ARB" alias="GL_CLIPPING_OUTPUT_PRIMITIVES"/>
         <enum value="0x82F8" name="GL_SPARSE_BUFFER_PAGE_SIZE_ARB"/>
         <enum value="0x82F9" name="GL_MAX_CULL_DISTANCES"/>
         <enum value="0x82F9" name="GL_MAX_CULL_DISTANCES_EXT" alias="GL_MAX_CULL_DISTANCES"/>
@@ -4182,7 +6774,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x82FB" name="GL_CONTEXT_RELEASE_BEHAVIOR_KHR"/>
         <enum value="0x82FC" name="GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH"/>
         <enum value="0x82FC" name="GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR"/>
-            <unused start="0x82FD" end="0x830F" vendor="ARB"/>
+        <enum value="0x82FD" name="GL_ROBUST_GPU_TIMEOUT_MS_KHR" comment="Reserved for future"/>
+            <unused start="0x82FE" end="0x830F" vendor="ARB"/>
     </enums>
 
     <enums namespace="GL" start="0x8310" end="0x832F" vendor="SGI">
@@ -4378,7 +6971,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x83F9" name="GL_PERFQUERY_DONOT_FLUSH_INTEL"/>
         <enum value="0x83FA" name="GL_PERFQUERY_FLUSH_INTEL"/>
         <enum value="0x83FB" name="GL_PERFQUERY_WAIT_INTEL"/>
-            <unused start="0x83FC" end="0x83FD" vendor="INTEL"/>
+        <enum value="0x83FC" name="GL_BLACKHOLE_RENDER_INTEL"/>
+            <unused start="0x83FD" vendor="INTEL"/>
         <enum value="0x83FE" name="GL_CONSERVATIVE_RASTERIZATION_INTEL"/>
         <enum value="0x83FF" name="GL_TEXTURE_MEMORY_LAYOUT_INTEL"/>
     </enums>
@@ -4660,8 +7254,10 @@ typedef unsigned int GLhandleARB;
             <unused start="0x84FB" end="0x84FC" vendor="NV"/>
         <enum value="0x84FD" name="GL_MAX_TEXTURE_LOD_BIAS"/>
         <enum value="0x84FD" name="GL_MAX_TEXTURE_LOD_BIAS_EXT"/>
-        <enum value="0x84FE" name="GL_TEXTURE_MAX_ANISOTROPY_EXT"/>
-        <enum value="0x84FF" name="GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT"/>
+        <enum value="0x84FE" name="GL_TEXTURE_MAX_ANISOTROPY"/>
+        <enum value="0x84FE" name="GL_TEXTURE_MAX_ANISOTROPY_EXT" alias="GL_TEXTURE_MAX_ANISOTROPY"/>
+        <enum value="0x84FF" name="GL_MAX_TEXTURE_MAX_ANISOTROPY"/>
+        <enum value="0x84FF" name="GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT" alias="GL_MAX_TEXTURE_MAX_ANISOTROPY"/>
         <enum value="0x8500" name="GL_TEXTURE_FILTER_CONTROL"/>
         <enum value="0x8500" name="GL_TEXTURE_FILTER_CONTROL_EXT"/>
         <enum value="0x8501" name="GL_TEXTURE_LOD_BIAS"/>
@@ -5089,6 +7685,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x864E" name="GL_DOT_PRODUCT_TEXTURE_RECTANGLE_NV"/>
         <enum value="0x864F" name="GL_DEPTH_CLAMP"/>
         <enum value="0x864F" name="GL_DEPTH_CLAMP_NV"/>
+        <enum value="0x864F" name="GL_DEPTH_CLAMP_EXT"/>
         <enum value="0x8650" name="GL_VERTEX_ATTRIB_ARRAY0_NV"/>
         <enum value="0x8651" name="GL_VERTEX_ATTRIB_ARRAY1_NV"/>
         <enum value="0x8652" name="GL_VERTEX_ATTRIB_ARRAY2_NV"/>
@@ -5363,7 +7960,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x875C" name="GL_PROXY_TEXTURE_2D_STACK_MESAX"/>
         <enum value="0x875D" name="GL_TEXTURE_1D_STACK_BINDING_MESAX"/>
         <enum value="0x875E" name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
-            <unused start="0x875F" vendor="MESA"/>
+        <enum value="0x875F" name="GL_PROGRAM_BINARY_FORMAT_MESA"/>
     </enums>
 
     <enums namespace="GL" start="0x8760" end="0x883F" vendor="AMD">
@@ -5966,16 +8563,20 @@ typedef unsigned int GLhandleARB;
         <enum value="0x88EB" name="GL_PIXEL_PACK_BUFFER"/>
         <enum value="0x88EB" name="GL_PIXEL_PACK_BUFFER_ARB"/>
         <enum value="0x88EB" name="GL_PIXEL_PACK_BUFFER_EXT"/>
+        <enum value="0x88EB" name="GL_PIXEL_PACK_BUFFER_NV"/>
         <enum value="0x88EC" name="GL_PIXEL_UNPACK_BUFFER"/>
         <enum value="0x88EC" name="GL_PIXEL_UNPACK_BUFFER_ARB"/>
         <enum value="0x88EC" name="GL_PIXEL_UNPACK_BUFFER_EXT"/>
+        <enum value="0x88EC" name="GL_PIXEL_UNPACK_BUFFER_NV"/>
         <enum value="0x88ED" name="GL_PIXEL_PACK_BUFFER_BINDING"/>
         <enum value="0x88ED" name="GL_PIXEL_PACK_BUFFER_BINDING_ARB"/>
         <enum value="0x88ED" name="GL_PIXEL_PACK_BUFFER_BINDING_EXT"/>
+        <enum value="0x88ED" name="GL_PIXEL_PACK_BUFFER_BINDING_NV"/>
         <enum value="0x88EE" name="GL_ETC1_SRGB8_NV"/>
         <enum value="0x88EF" name="GL_PIXEL_UNPACK_BUFFER_BINDING"/>
         <enum value="0x88EF" name="GL_PIXEL_UNPACK_BUFFER_BINDING_ARB"/>
         <enum value="0x88EF" name="GL_PIXEL_UNPACK_BUFFER_BINDING_EXT"/>
+        <enum value="0x88EF" name="GL_PIXEL_UNPACK_BUFFER_BINDING_NV"/>
         <enum value="0x88F0" name="GL_DEPTH24_STENCIL8"/>
         <enum value="0x88F0" name="GL_DEPTH24_STENCIL8_EXT"/>
         <enum value="0x88F0" name="GL_DEPTH24_STENCIL8_OES"/>
@@ -6422,6 +9023,10 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8BB5" name="GL_VERTEX_PROGRAM_CALLBACK_MESA"/>
         <enum value="0x8BB6" name="GL_VERTEX_PROGRAM_CALLBACK_FUNC_MESA"/>
         <enum value="0x8BB7" name="GL_VERTEX_PROGRAM_CALLBACK_DATA_MESA"/>
+        <enum value="0x8BB8" name="GL_TILE_RASTER_ORDER_FIXED_MESA"/>
+        <enum value="0x8BB9" name="GL_TILE_RASTER_ORDER_INCREASING_X_MESA"/>
+        <enum value="0x8BBA" name="GL_TILE_RASTER_ORDER_INCREASING_Y_MESA"/>
+        <enum value="0x8BBB" name="GL_FRAMEBUFFER_FLIP_Y_MESA" />
     </enums>
 
     <enums namespace="GL" start="0x8BC0" end="0x8BFF" vendor="QCOM" comment="Reassigned from AMD to QCOM">
@@ -6448,7 +9053,11 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8BE7" name="GL_SAMPLER_EXTERNAL_2D_Y2Y_EXT"/>
             <unused start="0x8BE8" end="0x8BEF" vendor="QCOM"/>
         <enum value="0x8BFA" name="GL_TEXTURE_PROTECTED_EXT"/>
-            <unused start="0x8BFB" end="0x8BFF" vendor="QCOM"/>
+        <enum value="0x8BFB" name="GL_TEXTURE_FOVEATED_FEATURE_BITS_QCOM"/>
+        <enum value="0x8BFC" name="GL_TEXTURE_FOVEATED_MIN_PIXEL_DENSITY_QCOM"/>
+        <enum value="0x8BFD" name="GL_TEXTURE_FOVEATED_FEATURE_QUERY_QCOM"/>
+        <enum value="0x8BFE" name="GL_TEXTURE_FOVEATED_NUM_FOCAL_POINTS_QUERY_QCOM"/>
+        <enum value="0x8BFF" name="GL_FRAMEBUFFER_INCOMPLETE_FOVEATION_QCOM"/>
     </enums>
 
     <enums namespace="GL" start="0x8C00" end="0x8C0F" vendor="IMG">
@@ -6658,11 +9267,12 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8C93" name="GL_ATC_RGBA_EXPLICIT_ALPHA_AMD"/>
             <unused start="0x8C94" end="0x8C9F" vendor="QCOM"/>
     </enums>
-
     <enums namespace="GL" start="0x8CA0" end="0x8CAF" vendor="ARB">
         <enum value="0x8CA0" name="GL_POINT_SPRITE_COORD_ORIGIN"/>
         <enum value="0x8CA1" name="GL_LOWER_LEFT"/>
+        <enum value="0x8CA1" name="GL_LOWER_LEFT_EXT" alias="GL_LOWER_LEFT"/>
         <enum value="0x8CA2" name="GL_UPPER_LEFT"/>
+        <enum value="0x8CA2" name="GL_UPPER_LEFT_EXT" alias="GL_UPPER_LEFT"/>
         <enum value="0x8CA3" name="GL_STENCIL_BACK_REF"/>
         <enum value="0x8CA4" name="GL_STENCIL_BACK_VALUE_MASK"/>
         <enum value="0x8CA5" name="GL_STENCIL_BACK_WRITEMASK"/>
@@ -7143,7 +9753,8 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8E18" name="GL_QUERY_NO_WAIT_INVERTED"/>
         <enum value="0x8E19" name="GL_QUERY_BY_REGION_WAIT_INVERTED"/>
         <enum value="0x8E1A" name="GL_QUERY_BY_REGION_NO_WAIT_INVERTED"/>
-        <enum value="0x8E1B" name="GL_POLYGON_OFFSET_CLAMP_EXT"/>
+        <enum value="0x8E1B" name="GL_POLYGON_OFFSET_CLAMP"/>
+        <enum value="0x8E1B" name="GL_POLYGON_OFFSET_CLAMP_EXT" alias="GL_POLYGON_OFFSET_CLAMP"/>
             <unused start="0x8E1C" end="0x8E1D" vendor="NV"/>
         <enum value="0x8E1E" name="GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS"/>
         <enum value="0x8E1E" name="GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS_EXT"/>
@@ -7236,7 +9847,22 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8E5F" name="GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET"/>
         <enum value="0x8E5F" name="GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET_ARB"/>
         <enum value="0x8E5F" name="GL_MAX_PROGRAM_TEXTURE_GATHER_OFFSET_NV"/>
-            <unused start="0x8E60" end="0x8E6F" vendor="NV"/>
+        <enum value="0x8E60" name="GL_MAX_MESH_UNIFORM_BLOCKS_NV"/>
+        <enum value="0x8E61" name="GL_MAX_MESH_TEXTURE_IMAGE_UNITS_NV"/>
+        <enum value="0x8E62" name="GL_MAX_MESH_IMAGE_UNIFORMS_NV"/>
+        <enum value="0x8E63" name="GL_MAX_MESH_UNIFORM_COMPONENTS_NV"/>
+        <enum value="0x8E64" name="GL_MAX_MESH_ATOMIC_COUNTER_BUFFERS_NV"/>
+        <enum value="0x8E65" name="GL_MAX_MESH_ATOMIC_COUNTERS_NV"/>
+        <enum value="0x8E66" name="GL_MAX_MESH_SHADER_STORAGE_BLOCKS_NV"/>
+        <enum value="0x8E67" name="GL_MAX_COMBINED_MESH_UNIFORM_COMPONENTS_NV"/>
+        <enum value="0x8E68" name="GL_MAX_TASK_UNIFORM_BLOCKS_NV"/>
+        <enum value="0x8E69" name="GL_MAX_TASK_TEXTURE_IMAGE_UNITS_NV"/>
+        <enum value="0x8E6A" name="GL_MAX_TASK_IMAGE_UNIFORMS_NV"/>
+        <enum value="0x8E6B" name="GL_MAX_TASK_UNIFORM_COMPONENTS_NV"/>
+        <enum value="0x8E6C" name="GL_MAX_TASK_ATOMIC_COUNTER_BUFFERS_NV"/>
+        <enum value="0x8E6D" name="GL_MAX_TASK_ATOMIC_COUNTERS_NV"/>
+        <enum value="0x8E6E" name="GL_MAX_TASK_SHADER_STORAGE_BLOCKS_NV"/>
+        <enum value="0x8E6F" name="GL_MAX_COMBINED_TASK_UNIFORM_COMPONENTS_NV"/>
         <enum value="0x8E70" name="GL_MAX_TRANSFORM_FEEDBACK_BUFFERS"/>
         <enum value="0x8E71" name="GL_MAX_VERTEX_STREAMS"/>
         <enum value="0x8E72" name="GL_PATCH_VERTICES"/>
@@ -7315,12 +9941,16 @@ typedef unsigned int GLhandleARB;
             <unused start="0x8E8B" vendor="NV"/>
         <enum value="0x8E8C" name="GL_COMPRESSED_RGBA_BPTC_UNORM"/>
         <enum value="0x8E8C" name="GL_COMPRESSED_RGBA_BPTC_UNORM_ARB"/>
+        <enum value="0x8E8C" name="GL_COMPRESSED_RGBA_BPTC_UNORM_EXT"/>
         <enum value="0x8E8D" name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM"/>
         <enum value="0x8E8D" name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB"/>
+        <enum value="0x8E8D" name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT"/>
         <enum value="0x8E8E" name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT"/>
         <enum value="0x8E8E" name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB"/>
+        <enum value="0x8E8E" name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT"/>
         <enum value="0x8E8F" name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT"/>
         <enum value="0x8E8F" name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB"/>
+        <enum value="0x8E8F" name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT"/>
     </enums>
 
     <enums namespace="GL" start="0x8E90" end="0x8E9F" vendor="QNX" comment="For QNX_texture_tiling, QNX_complex_polygon, QNX_stippled_lines (Khronos bug 696)">
@@ -7443,7 +10073,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x8F65" name="GL_FETCH_PER_SAMPLE_ARM"/>
         <enum value="0x8F66" name="GL_FRAGMENT_SHADER_FRAMEBUFFER_FETCH_MRT_ARM"/>
         <enum value="0x8F67" name="GL_MAX_SHADER_PIXEL_LOCAL_STORAGE_SIZE_EXT"/>
-            <unused start="0x8F68" end="0x8F6F" vendor="ARM"/>
+            <unused start="0x8F68" vendor="ARM"/>
+        <enum value="0x8F69" name="GL_TEXTURE_ASTC_DECODE_PRECISION_EXT"/>
+            <unused start="0x8F6A" end="0x8F6F" vendor="ARM"/>
     </enums>
 
     <enums namespace="GL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with EGL.">
@@ -7479,7 +10111,8 @@ typedef unsigned int GLhandleARB;
 
     <enums namespace="GL" start="0x8FA0" end="0x8FBF" vendor="QCOM" comment="For Maurice Ribble, bug 4512">
         <enum value="0x8FA0" name="GL_PERFMON_GLOBAL_MODE_QCOM"/>
-            <unused start="0x8FA1" end="0x8FAF" vendor="QCOM"/>
+        <enum value="0x8FA1" name="GL_MAX_SHADER_SUBSAMPLED_IMAGE_UNITS_QCOM"/>
+            <unused start="0x8FA2" end="0x8FAF" vendor="QCOM"/>
         <enum value="0x8FB0" name="GL_BINNING_CONTROL_HINT_QCOM"/>
         <enum value="0x8FB1" name="GL_CPU_OPTIMIZED_QCOM"/>
         <enum value="0x8FB2" name="GL_GPU_OPTIMIZED_QCOM"/>
@@ -7489,7 +10122,7 @@ typedef unsigned int GLhandleARB;
             <unused start="0x8FBC" vendor="QCOM"/>
         <enum value="0x8FBD" name="GL_SR8_EXT"/>
         <enum value="0x8FBE" name="GL_SRG8_EXT"/>
-            <unused start="0x8FBF" vendor="QCOM"/>
+        <enum value="0x8FBF" name="GL_TEXTURE_FORMAT_SRGB_OVERRIDE_EXT"/>
     </enums>
 
     <enums namespace="GL" start="0x8FC0" end="0x8FDF" vendor="VIV" comment="For Frido Garritsen, bug 4526">
@@ -8034,9 +10667,17 @@ typedef unsigned int GLhandleARB;
             <unused start="0x91AB" end="0x91AD" vendor="AMD"/>
         <enum value="0x91AE" name="GL_PIXELS_PER_SAMPLE_PATTERN_X_AMD"/>
         <enum value="0x91AF" name="GL_PIXELS_PER_SAMPLE_PATTERN_Y_AMD"/>
-        <enum value="0x91B0" name="GL_MAX_SHADER_COMPILER_THREADS_ARB"/>
-        <enum value="0x91B1" name="GL_COMPLETION_STATUS_ARB"/>
-            <unused start="0x91B2" end="0x91B8" vendor="AMD"/>
+        <enum value="0x91B0" name="GL_MAX_SHADER_COMPILER_THREADS_KHR"/>
+        <enum value="0x91B0" name="GL_MAX_SHADER_COMPILER_THREADS_ARB" alias="GL_MAX_SHADER_COMPILER_THREADS_KHR"/>
+        <enum value="0x91B1" name="GL_COMPLETION_STATUS_KHR"/>
+        <enum value="0x91B1" name="GL_COMPLETION_STATUS_ARB" alias="GL_COMPLETION_STATUS_KHR"/>
+        <enum value="0x91B2" name="GL_RENDERBUFFER_STORAGE_SAMPLES_AMD"/>
+        <enum value="0x91B3" name="GL_MAX_COLOR_FRAMEBUFFER_SAMPLES_AMD"/>
+        <enum value="0x91B4" name="GL_MAX_COLOR_FRAMEBUFFER_STORAGE_SAMPLES_AMD"/>
+        <enum value="0x91B5" name="GL_MAX_DEPTH_STENCIL_FRAMEBUFFER_SAMPLES_AMD"/>
+        <enum value="0x91B6" name="GL_NUM_SUPPORTED_MULTISAMPLE_MODES_AMD"/>
+        <enum value="0x91B7" name="GL_SUPPORTED_MULTISAMPLE_MODES_AMD"/>
+            <unused start="0x91B8" end="0x91B8" vendor="AMD"/>
         <enum value="0x91B9" name="GL_COMPUTE_SHADER"/>
             <unused start="0x91BA" vendor="AMD"/>
         <enum value="0x91BB" name="GL_MAX_COMPUTE_UNIFORM_BLOCKS"/>
@@ -8187,14 +10828,16 @@ typedef unsigned int GLhandleARB;
         <enum value="0x92B2" name="GL_PLUS_CLAMPED_ALPHA_NV"/>
         <enum value="0x92B3" name="GL_MINUS_CLAMPED_NV"/>
         <enum value="0x92B4" name="GL_INVERT_OVG_NV"/>
-            <unused start="0x92B5" end="0x92BA" vendor="NV"/>
+            <unused start="0x92B5" end="0x92B9" vendor="NV"/>
+        <enum value="0x92BA" name="GL_MAX_LGPU_GPUS_NVX"/>
+        <enum value="0x92BA" name="GL_MULTICAST_GPUS_NV"/>
         <enum value="0x92BB" name="GL_PURGED_CONTEXT_RESET_NV"/>
             <unused start="0x92BC" end="0x92BD" vendor="NV"/>
         <enum value="0x92BE" name="GL_PRIMITIVE_BOUNDING_BOX_ARB"/>
         <enum value="0x92BE" name="GL_PRIMITIVE_BOUNDING_BOX"/>
         <enum value="0x92BE" name="GL_PRIMITIVE_BOUNDING_BOX_EXT"/>
         <enum value="0x92BE" name="GL_PRIMITIVE_BOUNDING_BOX_OES"/>
-            <unused start="0x92BF" vendor="NV"/>
+        <enum value="0x92BF" name="GL_ALPHA_TO_COVERAGE_DITHER_MODE_NV"/>
         <enum value="0x92C0" name="GL_ATOMIC_COUNTER_BUFFER"/>
         <enum value="0x92C1" name="GL_ATOMIC_COUNTER_BUFFER_BINDING"/>
         <enum value="0x92C2" name="GL_ATOMIC_COUNTER_BUFFER_START"/>
@@ -8238,7 +10881,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x92DC" name="GL_MAX_ATOMIC_COUNTER_BUFFER_BINDINGS"/>
         <enum value="0x92DD" name="GL_FRAGMENT_COVERAGE_TO_COLOR_NV"/>
         <enum value="0x92DE" name="GL_FRAGMENT_COVERAGE_COLOR_NV"/>
-            <unused start="0x92DF" end="0x92DF" vendor="NV"/>
+        <enum value="0x92DF" name="GL_MESH_OUTPUT_PER_VERTEX_GRANULARITY_NV"/>
         <enum value="0x92E0" name="GL_DEBUG_OUTPUT"/>
         <enum value="0x92E0" name="GL_DEBUG_OUTPUT_KHR"/>
         <enum value="0x92E1" name="GL_UNIFORM"/>
@@ -8352,7 +10995,9 @@ typedef unsigned int GLhandleARB;
         <enum value="0x934A" name="GL_LOCATION_COMPONENT"/>
         <enum value="0x934B" name="GL_TRANSFORM_FEEDBACK_BUFFER_INDEX"/>
         <enum value="0x934C" name="GL_TRANSFORM_FEEDBACK_BUFFER_STRIDE"/>
-            <unused start="0x934D" end="0x934F" vendor="NV"/>
+        <enum value="0x934D" name="GL_ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV"/>
+        <enum value="0x934E" name="GL_ALPHA_TO_COVERAGE_DITHER_ENABLE_NV"/>
+        <enum value="0x934F" name="GL_ALPHA_TO_COVERAGE_DITHER_DISABLE_NV"/>
         <enum value="0x9350" name="GL_VIEWPORT_SWIZZLE_POSITIVE_X_NV"/>
         <enum value="0x9351" name="GL_VIEWPORT_SWIZZLE_NEGATIVE_X_NV"/>
         <enum value="0x9352" name="GL_VIEWPORT_SWIZZLE_POSITIVE_Y_NV"/>
@@ -8366,13 +11011,19 @@ typedef unsigned int GLhandleARB;
         <enum value="0x935A" name="GL_VIEWPORT_SWIZZLE_Z_NV"/>
         <enum value="0x935B" name="GL_VIEWPORT_SWIZZLE_W_NV"/>
         <enum value="0x935C" name="GL_CLIP_ORIGIN"/>
+        <enum value="0x935C" name="GL_CLIP_ORIGIN_EXT" alias="GL_CLIP_ORIGIN"/>
         <enum value="0x935D" name="GL_CLIP_DEPTH_MODE"/>
+        <enum value="0x935D" name="GL_CLIP_DEPTH_MODE_EXT" alias="GL_CLIP_DEPTH_MODE"/>
         <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE"/>
+        <enum value="0x935E" name="GL_NEGATIVE_ONE_TO_ONE_EXT" alias="GL_NEGATIVE_ONE_TO_ONE"/>
         <enum value="0x935F" name="GL_ZERO_TO_ONE"/>
+        <enum value="0x935F" name="GL_ZERO_TO_ONE_EXT" alias="GL_ZERO_TO_ONE"/>
             <unused start="0x9360" end="0x9364" vendor="NV"/>
         <enum value="0x9365" name="GL_CLEAR_TEXTURE"/>
         <enum value="0x9366" name="GL_TEXTURE_REDUCTION_MODE_ARB"/>
+        <enum value="0x9366" name="GL_TEXTURE_REDUCTION_MODE_EXT" alias="GL_TEXTURE_REDUCTION_MODE_ARB"/>
         <enum value="0x9367" name="GL_WEIGHTED_AVERAGE_ARB"/>
+        <enum value="0x9367" name="GL_WEIGHTED_AVERAGE_EXT" alias="GL_WEIGHTED_AVERAGE_ARB"/>
         <enum value="0x9368" name="GL_FONT_GLYPHS_AVAILABLE_NV"/>
         <enum value="0x9369" name="GL_FONT_TARGET_UNAVAILABLE_NV"/>
         <enum value="0x936A" name="GL_FONT_UNAVAILABLE_NV"/>
@@ -8393,7 +11044,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x937C" name="GL_VIEWPORT_POSITION_W_SCALE_NV"/>
         <enum value="0x937D" name="GL_VIEWPORT_POSITION_W_SCALE_X_COEFF_NV"/>
         <enum value="0x937E" name="GL_VIEWPORT_POSITION_W_SCALE_Y_COEFF_NV"/>
-            <unused start="0x937F" vendor="NV"/>
+        <enum value="0x937F" name="GL_REPRESENTATIVE_FRAGMENT_TEST_NV"/>
     </enums>
 
     <enums namespace="GL" start="0x9380" end="0x939F" vendor="ARB">
@@ -8402,7 +11053,36 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9381" name="GL_MULTISAMPLE_LINE_WIDTH_RANGE"/>
         <enum value="0x9382" name="GL_MULTISAMPLE_LINE_WIDTH_GRANULARITY_ARB"/>
         <enum value="0x9382" name="GL_MULTISAMPLE_LINE_WIDTH_GRANULARITY"/>
-            <unused start="0x9383" end="0x939F" vendor="ARB"/>
+        <enum value="0x9383" name="GL_VIEW_CLASS_EAC_R11"/>
+        <enum value="0x9384" name="GL_VIEW_CLASS_EAC_RG11"/>
+        <enum value="0x9385" name="GL_VIEW_CLASS_ETC2_RGB"/>
+        <enum value="0x9386" name="GL_VIEW_CLASS_ETC2_RGBA"/>
+        <enum value="0x9387" name="GL_VIEW_CLASS_ETC2_EAC_RGBA"/>
+        <enum value="0x9388" name="GL_VIEW_CLASS_ASTC_4x4_RGBA"/>
+        <enum value="0x9389" name="GL_VIEW_CLASS_ASTC_5x4_RGBA"/>
+        <enum value="0x938A" name="GL_VIEW_CLASS_ASTC_5x5_RGBA"/>
+        <enum value="0x938B" name="GL_VIEW_CLASS_ASTC_6x5_RGBA"/>
+        <enum value="0x938C" name="GL_VIEW_CLASS_ASTC_6x6_RGBA"/>
+        <enum value="0x938D" name="GL_VIEW_CLASS_ASTC_8x5_RGBA"/>
+        <enum value="0x938E" name="GL_VIEW_CLASS_ASTC_8x6_RGBA"/>
+        <enum value="0x938F" name="GL_VIEW_CLASS_ASTC_8x8_RGBA"/>
+        <enum value="0x9390" name="GL_VIEW_CLASS_ASTC_10x5_RGBA"/>
+        <enum value="0x9391" name="GL_VIEW_CLASS_ASTC_10x6_RGBA"/>
+        <enum value="0x9392" name="GL_VIEW_CLASS_ASTC_10x8_RGBA"/>
+        <enum value="0x9393" name="GL_VIEW_CLASS_ASTC_10x10_RGBA"/>
+        <enum value="0x9394" name="GL_VIEW_CLASS_ASTC_12x10_RGBA"/>
+        <enum value="0x9395" name="GL_VIEW_CLASS_ASTC_12x12_RGBA"/>
+            <unused start="0x9396" end="0x939F" vendor="ARB" comment="reserved for ASTC 3D interactions with ARB_ifq2"/>
+            <!-- <enum value="0x9396" name="GL_VIEW_CLASS_ASTC_3x3x3_RGBA"/> -->
+            <!-- <enum value="0x9397" name="GL_VIEW_CLASS_ASTC_4x3x3_RGBA"/> -->
+            <!-- <enum value="0x9398" name="GL_VIEW_CLASS_ASTC_4x4x3_RGBA"/> -->
+            <!-- <enum value="0x9399" name="GL_VIEW_CLASS_ASTC_4x4x4_RGBA"/> -->
+            <!-- <enum value="0x939A" name="GL_VIEW_CLASS_ASTC_5x4x4_RGBA"/> -->
+            <!-- <enum value="0x939B" name="GL_VIEW_CLASS_ASTC_5x5x4_RGBA"/> -->
+            <!-- <enum value="0x939C" name="GL_VIEW_CLASS_ASTC_5x5x5_RGBA"/> -->
+            <!-- <enum value="0x939D" name="GL_VIEW_CLASS_ASTC_6x5x5_RGBA"/> -->
+            <!-- <enum value="0x939E" name="GL_VIEW_CLASS_ASTC_6x6x5_RGBA"/> -->
+            <!-- <enum value="0x939F" name="GL_VIEW_CLASS_ASTC_6x6x6_RGBA"/> -->
     </enums>
 
     <enums namespace="GL" start="0x93A0" end="0x93AF" vendor="ANGLE" comment="Khronos bug 8100">
@@ -8530,11 +11210,127 @@ typedef unsigned int GLhandleARB;
     </enums>
 
     <enums namespace="GL" start="0x9530" end="0x962F" vendor="NV" comment="Khronos bug 12977">
-            <unused start="0x9530" end="0x954C" vendor="NV"/>
+        <enum value="0x9530" name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+        <enum value="0x9531" name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
+        <enum value="0x9532" name="GL_SUBGROUP_SIZE_KHR"/>
+        <enum value="0x9533" name="GL_SUBGROUP_SUPPORTED_STAGES_KHR"/>
+        <enum value="0x9534" name="GL_SUBGROUP_SUPPORTED_FEATURES_KHR"/>
+        <enum value="0x9535" name="GL_SUBGROUP_QUAD_ALL_STAGES_KHR"/>
+        <enum value="0x9536" name="GL_MAX_MESH_TOTAL_MEMORY_SIZE_NV"/>
+        <enum value="0x9537" name="GL_MAX_TASK_TOTAL_MEMORY_SIZE_NV"/>
+        <enum value="0x9538" name="GL_MAX_MESH_OUTPUT_VERTICES_NV"/>
+        <enum value="0x9539" name="GL_MAX_MESH_OUTPUT_PRIMITIVES_NV"/>
+        <enum value="0x953A" name="GL_MAX_TASK_OUTPUT_COUNT_NV"/>
+        <enum value="0x953B" name="GL_MAX_MESH_WORK_GROUP_SIZE_NV"/>
+        <enum value="0x953C" name="GL_MAX_TASK_WORK_GROUP_SIZE_NV"/>
+        <enum value="0x953D" name="GL_MAX_DRAW_MESH_TASKS_COUNT_NV"/>
+        <enum value="0x953E" name="GL_MESH_WORK_GROUP_SIZE_NV"/>
+        <enum value="0x953F" name="GL_TASK_WORK_GROUP_SIZE_NV"/>
+        <enum value="0x9540" name="GL_QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV"/>
+            <unused start="0x9541" vendor="NV"/>
+        <enum value="0x9542" name="GL_QUERY_RESOURCE_MEMTYPE_VIDMEM_NV"/>
+        <enum value="0x9543" name="GL_MESH_OUTPUT_PER_PRIMITIVE_GRANULARITY_NV"/>
+        <enum value="0x9544" name="GL_QUERY_RESOURCE_SYS_RESERVED_NV"/>
+        <enum value="0x9545" name="GL_QUERY_RESOURCE_TEXTURE_NV"/>
+        <enum value="0x9546" name="GL_QUERY_RESOURCE_RENDERBUFFER_NV"/>
+        <enum value="0x9547" name="GL_QUERY_RESOURCE_BUFFEROBJECT_NV"/>
+        <enum value="0x9548" name="GL_PER_GPU_STORAGE_NV"/>
+        <enum value="0x9549" name="GL_MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV"/>
+        <enum value="0x954A" name="GL_UPLOAD_GPU_MASK_NVX"/>
+            <unused start="0x954B" end="0x954C" vendor="NV"/>
         <enum value="0x954D" name="GL_CONSERVATIVE_RASTER_MODE_NV"/>
         <enum value="0x954E" name="GL_CONSERVATIVE_RASTER_MODE_POST_SNAP_NV"/>
         <enum value="0x954F" name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_TRIANGLES_NV"/>
-            <unused start="0x9550" end="0x962F" vendor="NV"/>
+        <enum value="0x9550" name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV"/>
+        <enum value="0x9551" name="GL_SHADER_BINARY_FORMAT_SPIR_V"/>
+        <enum value="0x9551" name="GL_SHADER_BINARY_FORMAT_SPIR_V_ARB" alias="GL_SHADER_BINARY_FORMAT_SPIR_V"/>
+        <enum value="0x9552" name="GL_SPIR_V_BINARY"/>
+        <enum value="0x9552" name="GL_SPIR_V_BINARY_ARB" alias="GL_SPIR_V_BINARY"/>
+        <enum value="0x9553" name="GL_SPIR_V_EXTENSIONS"/>
+        <enum value="0x9554" name="GL_NUM_SPIR_V_EXTENSIONS"/>
+        <enum value="0x9555" name="GL_SCISSOR_TEST_EXCLUSIVE_NV"/>
+        <enum value="0x9556" name="GL_SCISSOR_BOX_EXCLUSIVE_NV"/>
+        <enum value="0x9557" name="GL_MAX_MESH_VIEWS_NV"/>
+        <enum value="0x9558" name="GL_RENDER_GPU_MASK_NV"/>
+        <enum value="0x9559" name="GL_MESH_SHADER_NV"/>
+        <enum value="0x955A" name="GL_TASK_SHADER_NV"/>
+        <enum value="0x955B" name="GL_SHADING_RATE_IMAGE_BINDING_NV"/>
+        <enum value="0x955C" name="GL_SHADING_RATE_IMAGE_TEXEL_WIDTH_NV"/>
+        <enum value="0x955D" name="GL_SHADING_RATE_IMAGE_TEXEL_HEIGHT_NV"/>
+        <enum value="0x955E" name="GL_SHADING_RATE_IMAGE_PALETTE_SIZE_NV"/>
+        <enum value="0x955F" name="GL_MAX_COARSE_FRAGMENT_SAMPLES_NV"/>
+            <unused start="0x9560" end="0x9562" vendor="NV"/>
+        <enum value="0x9563" name="GL_SHADING_RATE_IMAGE_NV"/>
+        <enum value="0x9564" name="GL_SHADING_RATE_NO_INVOCATIONS_NV"/>
+        <enum value="0x9565" name="GL_SHADING_RATE_1_INVOCATION_PER_PIXEL_NV"/>
+        <enum value="0x9566" name="GL_SHADING_RATE_1_INVOCATION_PER_1X2_PIXELS_NV"/>
+        <enum value="0x9567" name="GL_SHADING_RATE_1_INVOCATION_PER_2X1_PIXELS_NV"/>
+        <enum value="0x9568" name="GL_SHADING_RATE_1_INVOCATION_PER_2X2_PIXELS_NV"/>
+        <enum value="0x9569" name="GL_SHADING_RATE_1_INVOCATION_PER_2X4_PIXELS_NV"/>
+        <enum value="0x956A" name="GL_SHADING_RATE_1_INVOCATION_PER_4X2_PIXELS_NV"/>
+        <enum value="0x956B" name="GL_SHADING_RATE_1_INVOCATION_PER_4X4_PIXELS_NV"/>
+        <enum value="0x956C" name="GL_SHADING_RATE_2_INVOCATIONS_PER_PIXEL_NV"/>
+        <enum value="0x956D" name="GL_SHADING_RATE_4_INVOCATIONS_PER_PIXEL_NV"/>
+        <enum value="0x956E" name="GL_SHADING_RATE_8_INVOCATIONS_PER_PIXEL_NV"/>
+        <enum value="0x956F" name="GL_SHADING_RATE_16_INVOCATIONS_PER_PIXEL_NV"/>
+            <unused start="0x9570" end="0x9578" vendor="NV"/>
+        <enum value="0x9579" name="GL_MESH_VERTICES_OUT_NV"/>
+        <enum value="0x957A" name="GL_MESH_PRIMITIVES_OUT_NV"/>
+        <enum value="0x957B" name="GL_MESH_OUTPUT_TYPE_NV"/>
+        <enum value="0x957C" name="GL_MESH_SUBROUTINE_NV"/>
+        <enum value="0x957D" name="GL_TASK_SUBROUTINE_NV"/>
+        <enum value="0x957E" name="GL_MESH_SUBROUTINE_UNIFORM_NV"/>
+        <enum value="0x957F" name="GL_TASK_SUBROUTINE_UNIFORM_NV"/>
+        <enum value="0x9580" name="GL_TEXTURE_TILING_EXT"/>
+        <enum value="0x9581" name="GL_DEDICATED_MEMORY_OBJECT_EXT"/>
+        <enum value="0x9582" name="GL_NUM_TILING_TYPES_EXT"/>
+        <enum value="0x9583" name="GL_TILING_TYPES_EXT"/>
+        <enum value="0x9584" name="GL_OPTIMAL_TILING_EXT"/>
+        <enum value="0x9585" name="GL_LINEAR_TILING_EXT"/>
+        <enum value="0x9586" name="GL_HANDLE_TYPE_OPAQUE_FD_EXT"/>
+        <enum value="0x9587" name="GL_HANDLE_TYPE_OPAQUE_WIN32_EXT"/>
+        <enum value="0x9588" name="GL_HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT"/>
+        <enum value="0x9589" name="GL_HANDLE_TYPE_D3D12_TILEPOOL_EXT"/>
+        <enum value="0x958A" name="GL_HANDLE_TYPE_D3D12_RESOURCE_EXT"/>
+        <enum value="0x958B" name="GL_HANDLE_TYPE_D3D11_IMAGE_EXT"/>
+        <enum value="0x958C" name="GL_HANDLE_TYPE_D3D11_IMAGE_KMT_EXT"/>
+        <enum value="0x958D" name="GL_LAYOUT_GENERAL_EXT"/>
+        <enum value="0x958E" name="GL_LAYOUT_COLOR_ATTACHMENT_EXT"/>
+        <enum value="0x958F" name="GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT"/>
+        <enum value="0x9590" name="GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT"/>
+        <enum value="0x9591" name="GL_LAYOUT_SHADER_READ_ONLY_EXT"/>
+        <enum value="0x9592" name="GL_LAYOUT_TRANSFER_SRC_EXT"/>
+        <enum value="0x9593" name="GL_LAYOUT_TRANSFER_DST_EXT"/>
+        <enum value="0x9594" name="GL_HANDLE_TYPE_D3D12_FENCE_EXT"/>
+        <enum value="0x9595" name="GL_D3D12_FENCE_VALUE_EXT"/>
+        <enum value="0x9596" name="GL_NUM_DEVICE_UUIDS_EXT"/>
+        <enum value="0x9597" name="GL_DEVICE_UUID_EXT"/>
+        <enum value="0x9598" name="GL_DRIVER_UUID_EXT"/>
+        <enum value="0x9599" name="GL_DEVICE_LUID_EXT"/>
+        <enum value="0x959A" name="GL_DEVICE_NODE_MASK_EXT"/>
+        <enum value="0x959B" name="GL_PROTECTED_MEMORY_OBJECT_EXT"/>
+        <enum value="0x959C" name="GL_UNIFORM_BLOCK_REFERENCED_BY_MESH_SHADER_NV"/>
+        <enum value="0x959D" name="GL_UNIFORM_BLOCK_REFERENCED_BY_TASK_SHADER_NV"/>
+        <enum value="0x959E" name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_MESH_SHADER_NV"/>
+        <enum value="0x959F" name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TASK_SHADER_NV"/>
+        <enum value="0x95A0" name="GL_REFERENCED_BY_MESH_SHADER_NV"/>
+        <enum value="0x95A1" name="GL_REFERENCED_BY_TASK_SHADER_NV"/>
+        <enum value="0x95A2" name="GL_MAX_MESH_WORK_GROUP_INVOCATIONS_NV"/>
+        <enum value="0x95A3" name="GL_MAX_TASK_WORK_GROUP_INVOCATIONS_NV"/>
+        <enum value="0x95A4" name="GL_ATTACHED_MEMORY_OBJECT_NV"/>
+        <enum value="0x95A5" name="GL_ATTACHED_MEMORY_OFFSET_NV"/>
+        <enum value="0x95A6" name="GL_MEMORY_ATTACHABLE_ALIGNMENT_NV"/>
+        <enum value="0x95A7" name="GL_MEMORY_ATTACHABLE_SIZE_NV"/>
+        <enum value="0x95A8" name="GL_MEMORY_ATTACHABLE_NV"/>
+        <enum value="0x95A9" name="GL_DETACHED_MEMORY_INCARNATION_NV"/>
+        <enum value="0x95AA" name="GL_DETACHED_TEXTURES_NV"/>
+        <enum value="0x95AB" name="GL_DETACHED_BUFFERS_NV"/>
+        <enum value="0x95AC" name="GL_MAX_DETACHED_TEXTURES_NV"/>
+        <enum value="0x95AD" name="GL_MAX_DETACHED_BUFFERS_NV"/>
+        <enum value="0x95AE" name="GL_SHADING_RATE_SAMPLE_ORDER_DEFAULT_NV"/>
+        <enum value="0x95AF" name="GL_SHADING_RATE_SAMPLE_ORDER_PIXEL_MAJOR_NV"/>
+        <enum value="0x95B0" name="GL_SHADING_RATE_SAMPLE_ORDER_SAMPLE_MAJOR_NV"/>
+        <unused start="0x9581" end="0x962F" vendor="NV"/>
     </enums>
 
     <enums namespace="GL" start="0x9630" end="0x963F" vendor="Oculus" comment="Email from Cass Everitt">
@@ -8542,7 +11338,7 @@ typedef unsigned int GLhandleARB;
         <enum value="0x9631" name="GL_MAX_VIEWS_OVR"/>
         <enum value="0x9632" name="GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR"/>
         <enum value="0x9633" name="GL_FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR"/>
-            <unused start="0x9633" end="0x963F" vendor="Oculus"/>
+            <unused start="0x9634" end="0x963F" vendor="Oculus"/>
     </enums>
 
     <enums namespace="GL" start="0x9640" end="0x964F" vendor="Mediatek" comment="Khronos bug 14294">
@@ -8563,7 +11359,10 @@ typedef unsigned int GLhandleARB;
     </enums>
 
     <enums namespace="GL" start="0x96A0" end="0x96AF" vendor="Qualcomm" comment="contact Maurice Ribble">
-            <unused start="0x96A0" end="0x96AF" vendor="Qualcomm"/>
+            <unused start="0x96A0" end="0x96A1" vendor="Qualcomm"/>
+        <enum value="0x96A2" name="GL_FRAMEBUFFER_FETCH_NONCOHERENT_QCOM"/>
+        <enum value="0x96A3" name="GL_VALIDATE_SHADER_BINARY_QCOM"/>
+            <unused start="0x96A4" end="0x96AF" vendor="Qualcomm"/>
     </enums>
 
 <!-- Enums reservable for future use. To reserve a new range, allocate one
@@ -8737,13 +11536,17 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glAlphaFuncx</name></proto>
-            <param><ptype>GLenum</ptype> <name>func</name></param>
+            <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param><ptype>GLfixed</ptype> <name>ref</name></param>
         </command>
         <command>
             <proto>void <name>glAlphaFuncxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>func</name></param>
+            <param group="AlphaFunction"><ptype>GLenum</ptype> <name>func</name></param>
             <param group="ClampedFixed"><ptype>GLfixed</ptype> <name>ref</name></param>
+        </command>
+        <command>
+            <proto>void <name>glAlphaToCoverageDitherControlNV</name></proto>
+            <param><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glApplyFramebufferAttachmentCMAAINTEL</name></proto>
@@ -8751,6 +11554,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glApplyTextureEXT</name></proto>
             <param group="LightTextureModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLboolean</ptype> <name>glAcquireKeyedMutexWin32EXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>key</name></param>
+            <param><ptype>GLuint</ptype> <name>timeout</name></param>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glAreProgramsResidentNV</name></proto>
@@ -8792,6 +11601,48 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>offset</name></param>
         </command>
         <command>
+            <proto><ptype>GLuint</ptype> <name>glAsyncCopyBufferSubDataNVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>waitSemaphoreCount</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint</ptype> *<name>waitSemaphoreArray</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
+            <param><ptype>GLuint</ptype> <name>readGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>writeGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>readBuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>writeBuffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>readOffset</name></param>
+            <param><ptype>GLintptr</ptype> <name>writeOffset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLsizei</ptype> <name>signalSemaphoreCount</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint</ptype> *<name>signalSemaphoreArray</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint64</ptype> *<name>signalValueArray</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLuint</ptype> <name>glAsyncCopyImageSubDataNVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>waitSemaphoreCount</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint</ptype> *<name>waitSemaphoreArray</name></param>
+            <param len="waitSemaphoreCount">const <ptype>GLuint64</ptype> *<name>waitValueArray</name></param>
+            <param><ptype>GLuint</ptype> <name>srcGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>dstGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>srcName</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLint</ptype> <name>srcLevel</name></param>
+            <param><ptype>GLint</ptype> <name>srcX</name></param>
+            <param><ptype>GLint</ptype> <name>srcY</name></param>
+            <param><ptype>GLint</ptype> <name>srcZ</name></param>
+            <param><ptype>GLuint</ptype> <name>dstName</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLint</ptype> <name>dstLevel</name></param>
+            <param><ptype>GLint</ptype> <name>dstX</name></param>
+            <param><ptype>GLint</ptype> <name>dstY</name></param>
+            <param><ptype>GLint</ptype> <name>dstZ</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcWidth</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcHeight</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcDepth</name></param>
+            <param><ptype>GLsizei</ptype> <name>signalSemaphoreCount</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint</ptype> *<name>signalSemaphoreArray</name></param>
+            <param len="signalSemaphoreCount">const <ptype>GLuint64</ptype> *<name>signalValueArray</name></param>
+        </command>
+        <command>
             <proto>void <name>glAsyncMarkerSGIX</name></proto>
             <param><ptype>GLuint</ptype> <name>marker</name></param>
         </command>
@@ -8814,12 +11665,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBeginConditionalRender</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="ConditionalRenderMode"><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glBeginConditionalRenderNV</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="ConditionalRenderMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBeginConditionalRender"/>
             <glx type="render" opcode="348"/>
         </command>
@@ -8844,7 +11695,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBeginQuery</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <glx type="render" opcode="231"/>
         </command>
@@ -8856,27 +11707,28 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBeginQueryEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
             <proto>void <name>glBeginQueryIndexed</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedback</name></proto>
-            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <glx type="render" opcode="357"/>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedbackEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
             <alias name="glBeginTransformFeedback"/>
         </command>
         <command>
             <proto>void <name>glBeginTransformFeedbackNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>primitiveMode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>primitiveMode</name></param>
             <alias name="glBeginTransformFeedback"/>
         </command>
         <command>
@@ -8912,34 +11764,35 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferBase</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <glx type="render" opcode="356"/>
         </command>
         <command>
             <proto>void <name>glBindBufferBaseEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glBindBufferBase"/>
         </command>
         <command>
             <proto>void <name>glBindBufferBaseNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glBindBufferBase"/>
         </command>
         <command>
             <proto>void <name>glBindBufferOffsetEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBindBufferOffsetNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -8947,15 +11800,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferRange</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <glx type="render" opcode="355"/>
         </command>
         <command>
             <proto>void <name>glBindBufferRangeEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -8964,7 +11818,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBufferRangeNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
@@ -8973,14 +11827,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindBuffersBase</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>buffers</name></param>
         </command>
         <command>
             <proto>void <name>glBindBuffersRange</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>buffers</name></param>
@@ -9033,7 +11887,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindFramebufferOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
         </command>
         <command>
@@ -9043,8 +11897,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param><ptype>GLenum</ptype> <name>access</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>format</name></param>
         </command>
         <command>
             <proto>void <name>glBindImageTextureEXT</name></proto>
@@ -9053,7 +11907,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
             <param><ptype>GLint</ptype> <name>format</name></param>
         </command>
         <command>
@@ -9117,7 +11971,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindRenderbufferOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
@@ -9130,6 +11984,10 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>samplers</name></param>
+        </command>
+        <command>
+            <proto>void <name>glBindShadingRateImageNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glBindTexGenParameterEXT</name></proto>
@@ -9168,7 +12026,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBindTransformFeedback</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BindTransformFeedbackTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
         </command>
         <command>
@@ -9344,7 +12202,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendEquation</name></proto>
-            <param group="BlendEquationMode"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
             <glx type="render" opcode="4097"/>
         </command>
         <command>
@@ -9356,12 +12214,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBlendEquationIndexedAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparate</name></proto>
@@ -9379,69 +12237,69 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glBlendEquationSeparateIndexedAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparatei</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationSeparateiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>modeRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>modeAlpha</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeRGB</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>modeAlpha</name></param>
             <alias name="glBlendEquationSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationi</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glBlendEquationiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendEquationiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="BlendEquationModeEXT"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glBlendEquationi"/>
         </command>
         <command>
             <proto>void <name>glBlendFunc</name></proto>
-            <param group="BlendingFactorSrc"><ptype>GLenum</ptype> <name>sfactor</name></param>
-            <param group="BlendingFactorDest"><ptype>GLenum</ptype> <name>dfactor</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactor</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactor</name></param>
             <glx type="render" opcode="160"/>
         </command>
         <command>
@@ -9453,106 +12311,106 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparate</name></proto>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
             <glx type="render" opcode="4134"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateEXT</name></proto>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
             <alias name="glBlendFuncSeparate"/>
             <glx type="render" opcode="4134"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateINGR</name></proto>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
-            <param group="BlendFuncSeparateParameterEXT"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>sfactorAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dfactorAlpha</name></param>
             <alias name="glBlendFuncSeparate"/>
             <glx type="render" opcode="4134"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateIndexedAMD</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparatei</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFuncSeparateiOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>srcRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>dstRGB</name></param>
-            <param><ptype>GLenum</ptype> <name>srcAlpha</name></param>
-            <param><ptype>GLenum</ptype> <name>dstAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstRGB</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>srcAlpha</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dstAlpha</name></param>
             <alias name="glBlendFuncSeparatei"/>
         </command>
         <command>
             <proto>void <name>glBlendFunci</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
-            <param><ptype>GLenum</ptype> <name>dst</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dst</name></param>
         </command>
         <command>
             <proto>void <name>glBlendFunciARB</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
-            <param><ptype>GLenum</ptype> <name>dst</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
             <proto>void <name>glBlendFunciEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
-            <param><ptype>GLenum</ptype> <name>dst</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
             <proto>void <name>glBlendFunciOES</name></proto>
             <param><ptype>GLuint</ptype> <name>buf</name></param>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
-            <param><ptype>GLenum</ptype> <name>dst</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="BlendingFactor"><ptype>GLenum</ptype> <name>dst</name></param>
             <alias name="glBlendFunci"/>
         </command>
         <command>
@@ -9571,7 +12429,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>filter</name></param>
+            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
             <glx type="render" opcode="4330"/>
         </command>
         <command>
@@ -9584,8 +12442,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstY0</name></param>
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
-            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>filter</name></param>
+            <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
         </command>
         <command>
             <proto>void <name>glBlitFramebufferEXT</name></proto>
@@ -9598,7 +12456,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
             <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>filter</name></param>
+            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
             <alias name="glBlitFramebuffer"/>
             <glx type="render" opcode="4330"/>
         </command>
@@ -9612,8 +12470,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstY0</name></param>
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
-            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>filter</name></param>
+            <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
             <alias name="glBlitFramebuffer"/>
         </command>
         <command>
@@ -9628,8 +12486,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>dstY0</name></param>
             <param><ptype>GLint</ptype> <name>dstX1</name></param>
             <param><ptype>GLint</ptype> <name>dstY1</name></param>
-            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
-            <param><ptype>GLenum</ptype> <name>filter</name></param>
+            <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param group="BlitFramebufferFilter"><ptype>GLenum</ptype> <name>filter</name></param>
         </command>
         <command>
             <proto>void <name>glBufferAddressRangeNV</name></proto>
@@ -9637,6 +12495,12 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLuint64EXT</ptype> <name>address</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>length</name></param>
+        </command>
+        <command>
+            <proto>void <name>glBufferAttachMemoryNV</name></proto>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBufferData</name></proto>
@@ -9668,18 +12532,33 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glBufferStorage</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glBufferStorageEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
             <alias name="glBufferStorage"/>
+        </command>
+        <command>
+            <proto>void <name>glBufferStorageExternalEXT</name></proto>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLeglClientBufferEXT</ptype> <name>clientBuffer</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
+        </command>
+        <command>
+            <proto>void <name>glBufferStorageMemEXT</name></proto>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glBufferSubData</name></proto>
@@ -9713,24 +12592,24 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="2"/>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatus</name></proto>
+            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatus</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="vendor" opcode="1427"/>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatusEXT</name></proto>
+            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatusEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glCheckFramebufferStatus"/>
             <glx type="vendor" opcode="1427"/>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glCheckFramebufferStatusOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckFramebufferStatusOES</name></proto>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatus</name></proto>
+            <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatus</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto group="FramebufferStatus"><ptype>GLenum</ptype> <name>glCheckNamedFramebufferStatusEXT</name></proto>
@@ -9772,46 +12651,50 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClearBufferData</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="BufferStorageTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferSubData</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearBufferfi</name></proto>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
+            <glx type="render" opcode="360"/>
         </command>
         <command>
             <proto>void <name>glClearBufferfv</name></proto>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLfloat</ptype> *<name>value</name></param>
+            <glx type="render" opcode="361"/>
         </command>
         <command>
             <proto>void <name>glClearBufferiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLint</ptype> *<name>value</name></param>
+            <glx type="render" opcode="362"/>
         </command>
         <command>
             <proto>void <name>glClearBufferuiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param group="DrawBufferName"><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param len="COMPSIZE(buffer)">const <ptype>GLuint</ptype> *<name>value</name></param>
+            <glx type="render" opcode="363"/>
         </command>
         <command>
             <proto>void <name>glClearColor</name></proto>
@@ -9887,15 +12770,15 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedBufferData</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedBufferDataEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
@@ -9903,11 +12786,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedBufferSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>data</name></param>
         </command>
         <command>
@@ -9923,7 +12806,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedFramebufferfi</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param><ptype>GLfloat</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>stencil</name></param>
@@ -9931,21 +12814,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glClearNamedFramebufferfv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferiv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glClearNamedFramebufferuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>buffer</name></param>
+            <param group="Buffer"><ptype>GLenum</ptype> <name>buffer</name></param>
             <param><ptype>GLint</ptype> <name>drawbuffer</name></param>
             <param>const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
@@ -9953,7 +12836,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearPixelLocalStorageuiEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>offset</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>values</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glClearStencil</name></proto>
@@ -9964,16 +12847,16 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glClearTexImage</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glClearTexImageEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
             <alias name="glClearTexImage"/>
         </command>
@@ -9987,8 +12870,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
         </command>
         <command>
@@ -10001,8 +12884,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type)">const void *<name>data</name></param>
             <alias name="glClearTexSubImage"/>
         </command>
@@ -10024,22 +12907,34 @@ typedef unsigned int GLhandleARB;
             <param group="ClientAttribMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glClientWaitSync</name></proto>
+            <proto>void <name>glClientWaitSemaphoreui64NVX</name></proto>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
+        </command>
+        <command>
+            <proto group="SyncStatus"><ptype>GLenum</ptype> <name>glClientWaitSync</name></proto>
             <param group="sync"><ptype>GLsync</ptype> <name>sync</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="SyncObjectMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
             <param><ptype>GLuint64</ptype> <name>timeout</name></param>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glClientWaitSyncAPPLE</name></proto>
+            <proto group="SyncStatus"><ptype>GLenum</ptype> <name>glClientWaitSyncAPPLE</name></proto>
             <param><ptype>GLsync</ptype> <name>sync</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="SyncObjectMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
             <param><ptype>GLuint64</ptype> <name>timeout</name></param>
             <alias name="glClientWaitSync"/>
         </command>
         <command>
             <proto>void <name>glClipControl</name></proto>
+            <param group="ClipControlOrigin"><ptype>GLenum</ptype> <name>origin</name></param>
+            <param group="ClipControlDepth"><ptype>GLenum</ptype> <name>depth</name></param>
+        </command>
+        <command>
+            <proto>void <name>glClipControlEXT</name></proto>
             <param><ptype>GLenum</ptype> <name>origin</name></param>
             <param><ptype>GLenum</ptype> <name>depth</name></param>
+            <alias name="glClipControl"/>
         </command>
         <command>
             <proto>void <name>glClipPlane</name></proto>
@@ -10049,33 +12944,33 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glClipPlanef</name></proto>
-            <param><ptype>GLenum</ptype> <name>p</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanefIMG</name></proto>
-            <param><ptype>GLenum</ptype> <name>p</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanefOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfloat</ptype> *<name>equation</name></param>
             <glx type="render" opcode="4312"/>
         </command>
         <command>
             <proto>void <name>glClipPlanex</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanexIMG</name></proto>
-            <param><ptype>GLenum</ptype> <name>p</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>p</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>eqn</name></param>
         </command>
         <command>
             <proto>void <name>glClipPlanexOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
@@ -10454,6 +13349,7 @@ typedef unsigned int GLhandleARB;
             <param group="Boolean"><ptype>GLboolean</ptype> <name>b</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>a</name></param>
             <alias name="glColorMaski"/>
+            <glx type="render" opcode="352"/>
         </command>
         <command>
             <proto>void <name>glColorMaski</name></proto>
@@ -10489,22 +13385,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glColorP4uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
@@ -10560,7 +13456,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTable</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -10571,7 +13467,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -10581,7 +13477,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableParameterfv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="2054"/>
         </command>
@@ -10596,7 +13492,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableParameteriv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="2055"/>
         </command>
@@ -10611,7 +13507,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glColorTableSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -10703,7 +13599,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -10714,7 +13610,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -10726,7 +13622,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -10777,7 +13673,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -10789,7 +13685,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage1DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -10801,7 +13697,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -10814,7 +13710,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage2DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -10827,7 +13723,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -10841,7 +13737,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCompressedTexImage3DARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -10853,16 +13749,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCompressedTexImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
-            <alias name="glCompressedTexImage3D"/>
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage1D</name></proto>
@@ -10950,7 +13845,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCompressedTexSubImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
@@ -10958,17 +13853,16 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param len="imageSize">const void *<name>data</name></param>
-            <alias name="glCompressedTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glCompressedTextureImage1DEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
@@ -10979,7 +13873,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -10991,7 +13885,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -11005,7 +13899,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -11028,7 +13922,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -11055,7 +13949,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param><ptype>GLsizei</ptype> <name>imageSize</name></param>
             <param>const void *<name>data</name></param>
         </command>
@@ -11087,7 +13981,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter1D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -11098,7 +13992,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter1DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -11109,7 +14003,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter2D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -11121,7 +14015,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionFilter2DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -11133,7 +14027,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionParameterf</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>params</name></param>
             <glx type="render" opcode="4103"/>
         </command>
@@ -11148,7 +14042,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionParameterfv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedFloat32" len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="render" opcode="4104"/>
         </command>
@@ -11163,7 +14057,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionParameteri</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>params</name></param>
             <glx type="render" opcode="4105"/>
         </command>
@@ -11178,7 +14072,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glConvolutionParameteriv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ConvolutionParameter"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="CheckedInt32" len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
             <glx type="render" opcode="4106"/>
         </command>
@@ -11192,28 +14086,29 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glConvolutionParameterxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glConvolutionParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glCopyBufferSubData</name></proto>
-            <param><ptype>GLenum</ptype> <name>readTarget</name></param>
-            <param><ptype>GLenum</ptype> <name>writeTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>readTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>writeTarget</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>readOffset</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>writeOffset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <glx type="single" opcode="221"/>
         </command>
         <command>
             <proto>void <name>glCopyBufferSubDataNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>readTarget</name></param>
-            <param><ptype>GLenum</ptype> <name>writeTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>readTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>writeTarget</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>readOffset</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>writeOffset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -11240,7 +14135,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyColorTable</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11249,7 +14144,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyColorTableSGI</name></proto>
             <param group="ColorTableTargetSGI"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11259,7 +14154,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter1D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11268,7 +14163,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter1DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11278,7 +14173,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter2D</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11288,7 +14183,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyConvolutionFilter2DEXT</name></proto>
             <param group="ConvolutionTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11299,13 +14194,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param group="CopyImageSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param group="CopyImageSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -11317,13 +14212,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -11336,13 +14231,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataNV</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -11355,13 +14250,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCopyImageSubDataOES</name></proto>
             <param><ptype>GLuint</ptype> <name>srcName</name></param>
-            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>srcTarget</name></param>
             <param><ptype>GLint</ptype> <name>srcLevel</name></param>
             <param><ptype>GLint</ptype> <name>srcX</name></param>
             <param><ptype>GLint</ptype> <name>srcY</name></param>
             <param><ptype>GLint</ptype> <name>srcZ</name></param>
             <param><ptype>GLuint</ptype> <name>dstName</name></param>
-            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param group="CopyBufferSubDataTarget"><ptype>GLenum</ptype> <name>dstTarget</name></param>
             <param><ptype>GLint</ptype> <name>dstLevel</name></param>
             <param><ptype>GLint</ptype> <name>dstX</name></param>
             <param><ptype>GLint</ptype> <name>dstY</name></param>
@@ -11376,7 +14271,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11387,7 +14282,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11455,7 +14350,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11466,7 +14361,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage1DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11478,7 +14373,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11490,7 +14385,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glCopyTexImage2DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11583,14 +14478,13 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <alias name="glCopyTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glCopyTextureImage1DEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11601,7 +14495,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
             <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -11723,7 +14617,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCoverageModulationTableNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLfloat</ptype> *<name>v</name></param>
+            <param len="n">const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glCoverageOperationNV</name></proto>
@@ -11732,17 +14626,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCreateBuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>buffers</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>buffers</name></param>
         </command>
         <command>
             <proto>void <name>glCreateCommandListsNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>lists</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>lists</name></param>
         </command>
         <command>
             <proto>void <name>glCreateFramebuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>framebuffers</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>framebuffers</name></param>
+        </command>
+        <command>
+            <proto>void <name>glCreateMemoryObjectsEXT</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param><ptype>GLuint</ptype> *<name>memoryObjects</name></param>
         </command>
         <command>
             <proto>void <name>glCreatePerfQueryINTEL</name></proto>
@@ -11759,54 +14658,57 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glCreateProgramPipelines</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>pipelines</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>pipelines</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLuint</ptype> <name>glCreateProgressFenceNVX</name></proto>
         </command>
         <command>
             <proto>void <name>glCreateQueries</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>ids</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>ids</name></param>
         </command>
         <command>
             <proto>void <name>glCreateRenderbuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>renderbuffers</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>renderbuffers</name></param>
         </command>
         <command>
             <proto>void <name>glCreateSamplers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>samplers</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>samplers</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShader</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
         </command>
         <command>
             <proto group="handleARB"><ptype>GLhandleARB</ptype> <name>glCreateShaderObjectARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>shaderType</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shaderType</name></param>
             <alias name="glCreateShader"/>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const <ptype>GLchar</ptype> *<name>string</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLchar</ptype> *const*<name>strings</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glCreateShaderProgramvEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLchar</ptype> **<name>strings</name></param>
         </command>
         <command>
             <proto>void <name>glCreateStatesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>states</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>states</name></param>
         </command>
         <command>
             <proto group="sync"><ptype>GLsync</ptype> <name>glCreateSyncFromCLeventARB</name></proto>
@@ -11816,19 +14718,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glCreateTextures</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>textures</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>textures</name></param>
         </command>
         <command>
             <proto>void <name>glCreateTransformFeedbacks</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>ids</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>ids</name></param>
         </command>
         <command>
             <proto>void <name>glCreateVertexArrays</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param><ptype>GLuint</ptype> *<name>arrays</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>arrays</name></param>
         </command>
         <command>
             <proto>void <name>glCullFace</name></proto>
@@ -11878,18 +14780,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDebugMessageControl</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageControlARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
@@ -11897,9 +14799,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDebugMessageControlKHR</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param>const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param><ptype>GLboolean</ptype> <name>enabled</name></param>
@@ -11908,44 +14810,44 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDebugMessageEnableAMD</name></proto>
             <param><ptype>GLenum</ptype> <name>category</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>ids</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>enabled</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsert</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(buf,length)">const <ptype>GLchar</ptype> *<name>buf</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsertAMD</name></proto>
             <param><ptype>GLenum</ptype> <name>category</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="length">const <ptype>GLchar</ptype> *<name>buf</name></param>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsertARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="length">const <ptype>GLchar</ptype> *<name>buf</name></param>
             <alias name="glDebugMessageInsert"/>
         </command>
         <command>
             <proto>void <name>glDebugMessageInsertKHR</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>severity</name></param>
+            <param group="DebugSeverity"><ptype>GLenum</ptype> <name>severity</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>buf</name></param>
             <alias name="glDebugMessageInsert"/>
@@ -12010,7 +14912,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeleteCommandListsNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>lists</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>lists</name></param>
         </command>
         <command>
             <proto>void <name>glDeleteFencesAPPLE</name></proto>
@@ -12050,6 +14952,11 @@ typedef unsigned int GLhandleARB;
             <param group="List"><ptype>GLuint</ptype> <name>list</name></param>
             <param><ptype>GLsizei</ptype> <name>range</name></param>
             <glx type="single" opcode="103"/>
+        </command>
+        <command>
+            <proto>void <name>glDeleteMemoryObjectsEXT</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>memoryObjects</name></param>
         </command>
         <command>
             <proto>void <name>glDeleteNamedStringARB</name></proto>
@@ -12131,6 +15038,11 @@ typedef unsigned int GLhandleARB;
             <param len="n">const <ptype>GLuint</ptype> *<name>ids</name></param>
         </command>
         <command>
+            <proto>void <name>glDeleteQueryResourceTagNV</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param len="n">const <ptype>GLint</ptype> *<name>tagIds</name></param>
+        </command>
+        <command>
             <proto>void <name>glDeleteRenderbuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param len="n">const <ptype>GLuint</ptype> *<name>renderbuffers</name></param>
@@ -12154,6 +15066,11 @@ typedef unsigned int GLhandleARB;
             <param len="count">const <ptype>GLuint</ptype> *<name>samplers</name></param>
         </command>
         <command>
+            <proto>void <name>glDeleteSemaphoresEXT</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>semaphores</name></param>
+        </command>
+        <command>
             <proto>void <name>glDeleteShader</name></proto>
             <param><ptype>GLuint</ptype> <name>shader</name></param>
             <glx type="single" opcode="195"/>
@@ -12161,7 +15078,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDeleteStatesNV</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLuint</ptype> *<name>states</name></param>
+            <param len="n">const <ptype>GLuint</ptype> *<name>states</name></param>
         </command>
         <command>
             <proto>void <name>glDeleteSync</name></proto>
@@ -12241,8 +15158,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDepthRange</name></proto>
-            <param><ptype>GLdouble</ptype> <name>near</name></param>
-            <param><ptype>GLdouble</ptype> <name>far</name></param>
+            <param><ptype>GLdouble</ptype> <name>n</name></param>
+            <param><ptype>GLdouble</ptype> <name>f</name></param>
             <glx type="render" opcode="174"/>
         </command>
         <command>
@@ -12352,9 +15269,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDisableIndexedEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
+            <glx type="render" opcode="354"/>
         </command>
         <command>
             <proto>void <name>glDisableVariantClientStateEXT</name></proto>
@@ -12391,24 +15309,24 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glDisablei</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto>void <name>glDisableiEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
         <command>
             <proto>void <name>glDisableiNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
         <command>
             <proto>void <name>glDisableiOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glDisablei"/>
         </command>
@@ -12521,26 +15439,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDrawBuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param group="DrawBufferModeATI" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param group="DrawBufferMode" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
             <glx type="render" opcode="233"/>
         </command>
         <command>
             <proto>void <name>glDrawBuffersARB</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param group="DrawBufferModeATI" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param group="DrawBufferMode" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
             <alias name="glDrawBuffers"/>
         </command>
         <command>
             <proto>void <name>glDrawBuffersATI</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param group="DrawBufferModeATI" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param group="DrawBufferMode" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
             <alias name="glDrawBuffers"/>
             <glx type="render" opcode="233"/>
         </command>
         <command>
             <proto>void <name>glDrawBuffersEXT</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
             <alias name="glDrawBuffers"/>
         </command>
         <command>
@@ -12633,7 +15551,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glDrawElementsIndirect</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
         </command>
         <command>
@@ -12648,7 +15566,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedANGLE</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(count,type)">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glDrawElementsInstanced"/>
@@ -12666,7 +15584,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseInstance</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLuint</ptype> <name>baseinstance</name></param>
@@ -12675,7 +15593,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseInstanceEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLuint</ptype> <name>baseinstance</name></param>
@@ -12694,7 +15612,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseVertexBaseInstance</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLint</ptype> <name>basevertex</name></param>
@@ -12704,7 +15622,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedBaseVertexBaseInstanceEXT</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="count">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>instancecount</name></param>
             <param><ptype>GLint</ptype> <name>basevertex</name></param>
@@ -12744,7 +15662,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glDrawElementsInstancedNV</name></proto>
             <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(count,type)">const void *<name>indices</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <alias name="glDrawElementsInstanced"/>
@@ -12755,6 +15673,15 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>first</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
+        </command>
+        <command>
+            <proto>void <name>glDrawMeshTasksNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLuint</ptype> <name>count</name></param>
+        </command>
+        <command>
+            <proto>void <name>glDrawMeshTasksIndirectNV</name></proto>
+            <param><ptype>GLintptr</ptype> <name>indirect</name></param>
         </command>
         <command>
             <proto>void <name>glDrawPixels</name></proto>
@@ -12839,10 +15766,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfloat</ptype> <name>z</name></param>
             <param><ptype>GLfloat</ptype> <name>width</name></param>
             <param><ptype>GLfloat</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexfvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexfvOES</name></proto>
-            <param>const <ptype>GLfloat</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLfloat</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTexiOES</name></proto>
@@ -12851,10 +15779,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>z</name></param>
             <param><ptype>GLint</ptype> <name>width</name></param>
             <param><ptype>GLint</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexivOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexivOES</name></proto>
-            <param>const <ptype>GLint</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTexsOES</name></proto>
@@ -12863,10 +15792,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLshort</ptype> <name>z</name></param>
             <param><ptype>GLshort</ptype> <name>width</name></param>
             <param><ptype>GLshort</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexsvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexsvOES</name></proto>
-            <param>const <ptype>GLshort</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLshort</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTextureNV</name></proto>
@@ -12889,10 +15819,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfixed</ptype> <name>z</name></param>
             <param><ptype>GLfixed</ptype> <name>width</name></param>
             <param><ptype>GLfixed</ptype> <name>height</name></param>
+            <vecequiv name="glDrawTexxvOES"/>
         </command>
         <command>
             <proto>void <name>glDrawTexxvOES</name></proto>
-            <param>const <ptype>GLfixed</ptype> *<name>coords</name></param>
+            <param len="5">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glDrawTransformFeedback</name></proto>
@@ -12943,9 +15874,21 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
         </command>
         <command>
+            <proto>void <name>glEGLImageTargetTexStorageEXT</name></proto>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
+            <param>const <ptype>GLint</ptype>* <name>attrib_list</name></param>
+        </command>
+        <command>
             <proto>void <name>glEGLImageTargetTexture2DOES</name></proto>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
+        </command>
+        <command>
+            <proto>void <name>glEGLImageTargetTextureStorageEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLeglImageOES</ptype> <name>image</name></param>
+            <param>const <ptype>GLint</ptype>* <name>attrib_list</name></param>
         </command>
         <command>
             <proto>void <name>glEdgeFlag</name></proto>
@@ -13013,9 +15956,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEnableIndexedEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
+            <glx type="render" opcode="353"/>
         </command>
         <command>
             <proto>void <name>glEnableVariantClientStateEXT</name></proto>
@@ -13052,24 +15996,24 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEnablei</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto>void <name>glEnableiEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
         <command>
             <proto>void <name>glEnableiNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
         <command>
             <proto>void <name>glEnableiOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glEnablei"/>
         </command>
@@ -13109,29 +16053,30 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glEndQuery</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="232"/>
         </command>
         <command>
             <proto>void <name>glEndQueryARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glEndQuery"/>
         </command>
         <command>
             <proto>void <name>glEndQueryEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glEndQueryIndexed</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto>void <name>glEndTilingQCOM</name></proto>
-            <param><ptype>GLbitfield</ptype> <name>preserveMask</name></param>
+            <param group="BufferBitQCOM"><ptype>GLbitfield</ptype> <name>preserveMask</name></param>
         </command>
         <command>
             <proto>void <name>glEndTransformFeedback</name></proto>
+            <glx type="render" opcode="358"/>
         </command>
         <command>
             <proto>void <name>glEndTransformFeedbackEXT</name></proto>
@@ -13269,7 +16214,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glExtGetProgramBinarySourceQCOM</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLchar</ptype> *<name>source</name></param>
             <param><ptype>GLint</ptype> *<name>length</name></param>
         </command>
@@ -13309,8 +16254,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>void *<name>texels</name></param>
         </command>
         <command>
@@ -13350,12 +16295,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="sync"><ptype>GLsync</ptype> <name>glFenceSync</name></proto>
-            <param><ptype>GLenum</ptype> <name>condition</name></param>
+            <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto><ptype>GLsync</ptype> <name>glFenceSyncAPPLE</name></proto>
-            <param><ptype>GLenum</ptype> <name>condition</name></param>
+            <param group="SyncCondition"><ptype>GLenum</ptype> <name>condition</name></param>
             <param><ptype>GLbitfield</ptype> <name>flags</name></param>
             <alias name="glFenceSync"/>
         </command>
@@ -13404,14 +16349,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFlushMappedBufferRangeAPPLE</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <alias name="glFlushMappedBufferRange"/>
         </command>
         <command>
             <proto>void <name>glFlushMappedBufferRangeEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>length</name></param>
             <alias name="glFlushMappedBufferRange"/>
@@ -13559,22 +16504,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFogx</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glFogxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FogPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -13674,9 +16619,34 @@ typedef unsigned int GLhandleARB;
             <param group="DrawBufferMode" len="n">const <ptype>GLenum</ptype> *<name>bufs</name></param>
         </command>
         <command>
+            <proto>void <name>glFramebufferFetchBarrierEXT</name></proto>
+        </command>
+        <command>
+            <proto>void <name>glFramebufferFetchBarrierQCOM</name></proto>
+        </command>
+        <command>
+            <proto>void <name>glFramebufferFoveationConfigQCOM</name></proto>
+            <param group="Framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>numLayers</name></param>
+            <param><ptype>GLuint</ptype> <name>focalPointsPerLayer</name></param>
+            <param><ptype>GLuint</ptype> <name>requestedFeatures</name></param>
+            <param len="1"><ptype>GLuint</ptype> *<name>providedFeatures</name></param>
+        </command>
+        <command>
+            <proto>void <name>glFramebufferFoveationParametersQCOM</name></proto>
+            <param group="Framebuffer"><ptype>GLuint</ptype> <name>framebuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>layer</name></param>
+            <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+        </command>
+        <command>
             <proto>void <name>glFramebufferParameteri</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -13708,36 +16678,36 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferRenderbufferOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferSampleLocationsfvARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>start</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferSampleLocationsfvNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>start</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferSamplePositionsfvAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>numsamples</name></param>
             <param><ptype>GLuint</ptype> <name>pixelindex</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -13745,7 +16715,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture1D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <glx type="render" opcode="4321"/>
@@ -13754,7 +16724,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture1DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture1D"/>
@@ -13764,7 +16734,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture2D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <glx type="render" opcode="4322"/>
@@ -13773,7 +16743,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture2DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <alias name="glFramebufferTexture2D"/>
@@ -13781,9 +16751,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DDownsampleIMG</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xscale</name></param>
@@ -13791,27 +16761,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DMultisampleIMG</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
         </command>
         <command>
             <proto>void <name>glFramebufferTexture2DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -13819,7 +16789,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture3D</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -13829,7 +16799,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glFramebufferTexture3DEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
@@ -13838,13 +16808,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glFramebufferTexture3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>textarget</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>textarget</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>zoffset</name></param>
-            <alias name="glFramebufferTexture3D"/>
         </command>
         <command>
             <proto>void <name>glFramebufferTextureARB</name></proto>
@@ -14113,6 +17082,11 @@ typedef unsigned int GLhandleARB;
             <param len="n"><ptype>GLuint</ptype> *<name>ids</name></param>
         </command>
         <command>
+            <proto>void <name>glGenQueryResourceTagNV</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param len="n"><ptype>GLint</ptype> *<name>tagIds</name></param>
+        </command>
+        <command>
             <proto>void <name>glGenRenderbuffers</name></proto>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param len="n"><ptype>GLuint</ptype> *<name>renderbuffers</name></param>
@@ -14134,6 +17108,11 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGenSamplers</name></proto>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>samplers</name></param>
+        </command>
+        <command>
+            <proto>void <name>glGenSemaphoresEXT</name></proto>
+            <param><ptype>GLsizei</ptype> <name>n</name></param>
+            <param len="n"><ptype>GLuint</ptype> *<name>semaphores</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGenSymbolsEXT</name></proto>
@@ -14189,18 +17168,18 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGenerateMipmap</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="4325"/>
         </command>
         <command>
             <proto>void <name>glGenerateMipmapEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glGenerateMipmap"/>
             <glx type="render" opcode="4325"/>
         </command>
         <command>
             <proto>void <name>glGenerateMipmapOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glGenerateMultiTexMipmapEXT</name></proto>
@@ -14220,7 +17199,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetActiveAtomicCounterBufferiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLuint</ptype> <name>bufferIndex</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="AtomicCounterBufferPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -14230,7 +17209,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param group="AttributeType" len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
@@ -14240,14 +17219,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>maxLength</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1" group="AttributeType"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="maxLength"><ptype>GLcharARB</ptype> *<name>name</name></param>
             <alias name="glGetActiveAttrib"/>
         </command>
         <command>
             <proto>void <name>glGetActiveSubroutineName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -14256,7 +17235,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetActiveSubroutineUniformName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -14265,9 +17244,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetActiveSubroutineUniformiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SubroutineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>values</name></param>
         </command>
         <command>
@@ -14277,7 +17256,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1" group="UniformType"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
@@ -14287,7 +17266,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>maxLength</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param len="1" group="UniformType"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="maxLength"><ptype>GLcharARB</ptype> *<name>name</name></param>
             <alias name="glGetActiveUniform"/>
         </command>
@@ -14298,13 +17277,15 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>uniformBlockName</name></param>
+            <glx type="single" opcode="220"/>
         </command>
         <command>
             <proto>void <name>glGetActiveUniformBlockiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLuint</ptype> <name>uniformBlockIndex</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="UniformBlockPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(program,uniformBlockIndex,pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <glx type="single" opcode="219"/>
         </command>
         <command>
             <proto>void <name>glGetActiveUniformName</name></proto>
@@ -14313,14 +17294,16 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>uniformName</name></param>
+            <glx type="single" opcode="217"/>
         </command>
         <command>
             <proto>void <name>glGetActiveUniformsiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLsizei</ptype> <name>uniformCount</name></param>
             <param len="uniformCount">const <ptype>GLuint</ptype> *<name>uniformIndices</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="UniformPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(uniformCount,pname)"><ptype>GLint</ptype> *<name>params</name></param>
+            <glx type="single" opcode="216"/>
         </command>
         <command>
             <proto>void <name>glGetActiveVaryingNV</name></proto>
@@ -14371,14 +17354,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBooleanIndexedvEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
             <alias name="glGetBooleani_v"/>
+            <glx type="single" opcode="210"/>
         </command>
         <command>
             <proto>void <name>glGetBooleani_v</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param group="Boolean" len="COMPSIZE(target)"><ptype>GLboolean</ptype> *<name>data</name></param>
         </command>
@@ -14409,7 +17393,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBufferParameterui64vNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
@@ -14428,8 +17412,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetBufferPointervOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferPointerNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>params</name></param>
             <alias name="glGetBufferPointerv"/>
         </command>
@@ -14456,23 +17440,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetClipPlanef</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfloat</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glGetClipPlanefOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfloat</ptype> *<name>equation</name></param>
             <glx type="vendor" opcode="1421"/>
         </command>
         <command>
             <proto>void <name>glGetClipPlanex</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
             <proto>void <name>glGetClipPlanexOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>plane</name></param>
+            <param group="ClipPlaneName"><ptype>GLenum</ptype> <name>plane</name></param>
             <param len="4"><ptype>GLfixed</ptype> *<name>equation</name></param>
         </command>
         <command>
@@ -14495,14 +17479,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetColorTableParameterfv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="148"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterfvEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glGetColorTableParameterfv"/>
         </command>
@@ -14516,14 +17500,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetColorTableParameteriv</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="149"/>
         </command>
         <command>
             <proto>void <name>glGetColorTableParameterivEXT</name></proto>
             <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetColorTableParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetColorTableParameterPNameSGI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetColorTableParameteriv"/>
         </command>
@@ -14657,7 +17641,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetConvolutionParameterfv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetConvolutionParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="151"/>
         </command>
@@ -14671,7 +17655,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetConvolutionParameteriv</name></proto>
             <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetConvolutionParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ConvolutionParameterEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="152"/>
         </command>
@@ -14697,10 +17681,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLog</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
         </command>
@@ -14709,7 +17693,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufsize</name></param>
             <param len="count"><ptype>GLenum</ptype> *<name>categories</name></param>
-            <param len="count"><ptype>GLuint</ptype> *<name>severities</name></param>
+            <param len="count" group="DebugSeverity"><ptype>GLuint</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufsize"><ptype>GLchar</ptype> *<name>message</name></param>
@@ -14718,10 +17702,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLogARB</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
             <alias name="glGetDebugMessageLog"/>
@@ -14730,10 +17714,10 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetDebugMessageLogKHR</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>sources</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>types</name></param>
+            <param len="count" group="DebugSource"><ptype>GLenum</ptype> *<name>sources</name></param>
+            <param len="count" group="DebugType"><ptype>GLenum</ptype> *<name>types</name></param>
             <param len="count"><ptype>GLuint</ptype> *<name>ids</name></param>
-            <param len="count"><ptype>GLenum</ptype> *<name>severities</name></param>
+            <param len="count" group="DebugSeverity"><ptype>GLenum</ptype> *<name>severities</name></param>
             <param len="count"><ptype>GLsizei</ptype> *<name>lengths</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>messageLog</name></param>
             <alias name="glGetDebugMessageLog"/>
@@ -14746,7 +17730,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetDoubleIndexedvEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLdouble</ptype> *<name>data</name></param>
             <alias name="glGetDoublei_v"/>
@@ -14759,7 +17743,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetDoublei_vEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLdouble</ptype> *<name>params</name></param>
             <alias name="glGetDoublei_v"/>
@@ -14814,44 +17798,44 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetFixedv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFixedvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFloatIndexedvEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLfloat</ptype> *<name>data</name></param>
             <alias name="glGetFloati_v"/>
         </command>
         <command>
             <proto>void <name>glGetFloati_v</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLfloat</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetFloati_vEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glGetFloati_v"/>
         </command>
         <command>
             <proto>void <name>glGetFloati_vNV</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLfloat</ptype> *<name>data</name></param>
             <alias name="glGetFloati_v"/>
         </command>
         <command>
             <proto>void <name>glGetFloati_vOES</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLfloat</ptype> *<name>data</name></param>
             <alias name="glGetFloati_v"/>
@@ -14916,7 +17900,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetFramebufferAttachmentParameteriv</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1428"/>
         </command>
@@ -14924,22 +17908,22 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetFramebufferAttachmentParameterivEXT</name></proto>
             <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetFramebufferAttachmentParameteriv"/>
             <glx type="vendor" opcode="1428"/>
         </command>
         <command>
             <proto>void <name>glGetFramebufferAttachmentParameterivOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetFramebufferParameterfvAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>numsamples</name></param>
             <param><ptype>GLuint</ptype> <name>pixelindex</name></param>
             <param><ptype>GLsizei</ptype> <name>size</name></param>
@@ -14947,8 +17931,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetFramebufferParameteriv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -14959,19 +17943,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLsizei</ptype> <name>glGetFramebufferPixelLocalStorageSizeEXT</name></proto>
-            <param><ptype>GLuint</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLuint</ptype> <name>target</name></param>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatus</name></proto>
+            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatus</name></proto>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusARB</name></proto>
+            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusARB</name></proto>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusEXT</name></proto>
+            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusEXT</name></proto>
+            <alias name="glGetGraphicsResetStatus"/>
         </command>
         <command>
-            <proto><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusKHR</name></proto>
+            <proto group="GraphicsResetStatus"><ptype>GLenum</ptype> <name>glGetGraphicsResetStatusKHR</name></proto>
             <alias name="glGetGraphicsResetStatus"/>
         </command>
         <command>
@@ -14980,7 +17965,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetHistogram</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -14999,8 +17984,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetHistogramParameterfv</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetHistogramParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetHistogramParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="155"/>
         </command>
@@ -15013,8 +17998,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetHistogramParameteriv</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetHistogramParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetHistogramParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="156"/>
         </command>
@@ -15027,8 +18012,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetHistogramParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetHistogramParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15037,7 +18022,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
         </command>
         <command>
             <proto><ptype>GLuint64</ptype> <name>glGetImageHandleNV</name></proto>
@@ -15045,7 +18030,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>layered</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
         </command>
         <command>
             <proto>void <name>glGetImageTransformParameterfvHP</name></proto>
@@ -15078,12 +18063,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetInteger64v</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetInteger64vAPPLE</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>params</name></param>
             <alias name="glGetInteger64v"/>
         </command>
@@ -15093,6 +18078,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(target)"><ptype>GLint</ptype> *<name>data</name></param>
             <alias name="glGetIntegeri_v"/>
+            <glx type="single" opcode="211"/>
         </command>
         <command>
             <proto>void <name>glGetIntegeri_v</name></proto>
@@ -15125,26 +18111,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetInternalformatSampleivNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetInternalformati64v</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetInternalformativ</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormatPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
@@ -15182,20 +18168,20 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetLightxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLightxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetLightxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15287,8 +18273,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMapxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetMapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param len="COMPSIZE(query)"><ptype>GLfixed</ptype> *<name>v</name></param>
         </command>
         <command>
@@ -15307,25 +18293,39 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMaterialxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetMaterialxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetMaterialxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
+            <proto>void <name>glGetMemoryObjectDetachedResourcesuivNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param><ptype>GLuint</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glGetMemoryObjectParameterivEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memoryObject</name></param>
+            <param group="MemoryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLint</ptype> *<name>params</name></param>
+        </command>
+        <command>
             <proto>void <name>glGetMinmax</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
@@ -15344,8 +18344,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMinmaxParameterfv</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetMinmaxParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetMinmaxParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
             <glx type="single" opcode="158"/>
         </command>
@@ -15358,8 +18358,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMinmaxParameteriv</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="GetMinmaxParameterPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetMinmaxParameterPNameEXT"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="159"/>
         </command>
@@ -15460,7 +18460,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetMultisamplefv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetMultisamplePNameNV"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>val</name></param>
         </command>
@@ -15474,13 +18474,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedBufferParameteri64v</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedBufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15498,7 +18498,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedBufferPointerv</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexBufferObjectParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>params</name></param>
         </command>
         <command>
@@ -15523,7 +18523,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetNamedFramebufferParameterfvAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>framebuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>numsamples</name></param>
             <param><ptype>GLuint</ptype> <name>pixelindex</name></param>
@@ -15533,8 +18533,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedFramebufferAttachmentParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15547,7 +18547,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetNamedFramebufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetFramebufferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -15595,13 +18595,13 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetNamedProgramivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param group="ProgramTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="ProgramProperty"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ProgramPropertyARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetNamedRenderbufferParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -15644,7 +18644,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetObjectLabel</name></proto>
-            <param><ptype>GLenum</ptype> <name>identifier</name></param>
+            <param group="ObjectIdentifier"><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -15863,7 +18863,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>queryHandle</name></param>
             <param><ptype>GLuint</ptype> <name>flags</name></param>
             <param><ptype>GLsizei</ptype> <name>dataSize</name></param>
-            <param><ptype>GLvoid</ptype> *<name>data</name></param>
+            <param>void *<name>data</name></param>
             <param><ptype>GLuint</ptype> *<name>bytesWritten</name></param>
         </command>
         <command>
@@ -15904,7 +18904,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetPixelMapxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param len="size"><ptype>GLfixed</ptype> *<name>values</name></param>
         </command>
@@ -15934,13 +18934,13 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetPointerIndexedvEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="1">void **<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glGetPointeri_vEXT</name></proto>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param len="1">void **<name>params</name></param>
         </command>
@@ -16020,8 +19020,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramInterfaceiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterfacePName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16097,43 +19097,43 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramPipelineiv</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PipelineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetProgramPipelineivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PipelineParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetProgramResourceIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocation</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocationIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetProgramResourceLocationIndexEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetProgramResourceName</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
@@ -16142,7 +19142,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramResourcefvNV</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>propCount</name></param>
             <param>const <ptype>GLenum</ptype> *<name>props</name></param>
@@ -16153,10 +19153,10 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramResourceiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>programInterface</name></param>
+            <param group="ProgramInterface"><ptype>GLenum</ptype> <name>programInterface</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLsizei</ptype> <name>propCount</name></param>
-            <param len="propCount">const <ptype>GLenum</ptype> *<name>props</name></param>
+            <param group="ProgramResourceProperty" len="propCount">const <ptype>GLenum</ptype> *<name>props</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
@@ -16164,8 +19164,8 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramStageiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ProgramStagePName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="1"><ptype>GLint</ptype> *<name>values</name></param>
         </command>
         <command>
@@ -16190,7 +19190,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetProgramiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ProgramPropertyARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="199"/>
         </command>
@@ -16211,47 +19211,47 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetQueryBufferObjecti64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectui64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryBufferObjectuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryIndexediv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjecti64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjecti64vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1328"/>
             <alias name="glGetQueryObjecti64v"/>
@@ -16259,34 +19259,34 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetQueryObjectiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="165"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectivARB</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
-            <param><ptype>GLint</ptype> *<name>params</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectui64v</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectui64vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1329"/>
             <alias name="glGetQueryObjectui64v"/>
@@ -16294,119 +19294,125 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetQueryObjectuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <glx type="single" opcode="166"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectuivARB</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetQueryObjectuiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryObjectuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
-            <param><ptype>GLuint</ptype> *<name>params</name></param>
+            <param group="QueryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetQueryiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="164"/>
         </command>
         <command>
             <proto>void <name>glGetQueryivARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetQueryiv"/>
         </command>
         <command>
             <proto>void <name>glGetQueryivEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
-            <param><ptype>GLint</ptype> *<name>params</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetRenderbufferParameteriv</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="vendor" opcode="1424"/>
         </command>
         <command>
             <proto>void <name>glGetRenderbufferParameterivEXT</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetRenderbufferParameteriv"/>
             <glx type="vendor" opcode="1424"/>
         </command>
         <command>
             <proto>void <name>glGetRenderbufferParameterivOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterIuivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterF"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetSamplerParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
+            <proto>void <name>glGetSemaphoreParameterui64vEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param group="SemaphoreParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLuint64</ptype> *<name>params</name></param>
+        </command>
+        <command>
             <proto>void <name>glGetSeparableFilter</name></proto>
-            <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
             <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(target,format,type)">void *<name>row</name></param>
@@ -16435,10 +19441,10 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetShaderPrecisionFormat</name></proto>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
-            <param><ptype>GLenum</ptype> <name>precisiontype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="PrecisionType"><ptype>GLenum</ptype> <name>precisiontype</name></param>
             <param len="2"><ptype>GLint</ptype> *<name>range</name></param>
-            <param len="2"><ptype>GLint</ptype> *<name>precision</name></param>
+            <param len="1"><ptype>GLint</ptype> *<name>precision</name></param>
         </command>
         <command>
             <proto>void <name>glGetShaderSource</name></proto>
@@ -16458,9 +19464,22 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetShaderiv</name></proto>
             <param><ptype>GLuint</ptype> <name>shader</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="ShaderParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
             <glx type="single" opcode="198"/>
+        </command>
+        <command>
+            <proto>void <name>glGetShadingRateImagePaletteNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>viewport</name></param>
+            <param><ptype>GLuint</ptype> <name>entry</name></param>
+            <param len="1"><ptype>GLenum</ptype> *<name>rate</name></param>
+        </command>
+        <command>
+            <proto>void <name>glGetShadingRateSampleLocationivNV</name></proto>
+            <param><ptype>GLenum</ptype> <name>rate</name></param>
+            <param><ptype>GLuint</ptype> <name>samples</name></param>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <param len="3"><ptype>GLint</ptype> *<name>location</name></param>
         </command>
         <command>
             <proto>void <name>glGetSharpenTexFuncSGIS</name></proto>
@@ -16470,7 +19489,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto><ptype>GLushort</ptype> <name>glGetStageIndexNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
         </command>
         <command>
             <proto group="String">const <ptype>GLubyte</ptype> *<name>glGetString</name></proto>
@@ -16479,25 +19498,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="String">const <ptype>GLubyte</ptype> *<name>glGetStringi</name></proto>
-            <param><ptype>GLenum</ptype> <name>name</name></param>
+            <param group="StringName"><ptype>GLenum</ptype> <name>name</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
+            <glx type="single" opcode="214"/>
         </command>
         <command>
             <proto><ptype>GLuint</ptype> <name>glGetSubroutineIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param>const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetSubroutineUniformLocation</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param>const <ptype>GLchar</ptype> *<name>name</name></param>
         </command>
         <command>
             <proto>void <name>glGetSynciv</name></proto>
             <param group="sync"><ptype>GLsync</ptype> <name>sync</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SyncParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>values</name></param>
@@ -16505,7 +19525,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetSyncivAPPLE</name></proto>
             <param><ptype>GLsync</ptype> <name>sync</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SyncParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>values</name></param>
@@ -16537,14 +19557,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexEnvxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexEnvxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16570,8 +19590,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexGenfvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16583,14 +19603,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexGenivOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexGenxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16621,9 +19641,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexLevelParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16690,14 +19710,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetTexParameterxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetTexParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16717,8 +19737,8 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureImage</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
@@ -16735,7 +19755,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16750,7 +19770,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetTextureLevelParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16764,7 +19784,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTextureParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16777,7 +19797,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTextureParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16790,7 +19810,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTextureParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16803,7 +19823,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTextureParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -16839,8 +19859,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
@@ -16859,8 +19879,9 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param group="GlslTypeToken" len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
+            <glx type="single" opcode="213"/>
         </command>
         <command>
             <proto>void <name>glGetTransformFeedbackVaryingEXT</name></proto>
@@ -16869,7 +19890,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             <param len="1"><ptype>GLsizei</ptype> *<name>size</name></param>
-            <param len="1"><ptype>GLenum</ptype> *<name>type</name></param>
+            <param group="GlslTypeToken" len="1"><ptype>GLenum</ptype> *<name>type</name></param>
             <param len="bufSize"><ptype>GLchar</ptype> *<name>name</name></param>
             <alias name="glGetTransformFeedbackVarying"/>
         </command>
@@ -16882,21 +19903,21 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetTransformFeedbacki64_v</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint64</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetTransformFeedbacki_v</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetTransformFeedbackiv</name></proto>
             <param><ptype>GLuint</ptype> <name>xfb</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TransformFeedbackPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -16910,6 +19931,7 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLuint</ptype> <name>glGetUniformBlockIndex</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param len="COMPSIZE()">const <ptype>GLchar</ptype> *<name>uniformBlockName</name></param>
+            <glx type="single" opcode="218"/>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetUniformBufferSizeEXT</name></proto>
@@ -16922,6 +19944,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>uniformCount</name></param>
             <param len="COMPSIZE(uniformCount)">const <ptype>GLchar</ptype> *const*<name>uniformNames</name></param>
             <param len="COMPSIZE(uniformCount)"><ptype>GLuint</ptype> *<name>uniformIndices</name></param>
+            <glx type="single" opcode="215"/>
         </command>
         <command>
             <proto><ptype>GLint</ptype> <name>glGetUniformLocation</name></proto>
@@ -16941,7 +19964,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetUniformSubroutineuiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param len="1"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
@@ -17015,6 +20038,17 @@ typedef unsigned int GLhandleARB;
             <alias name="glGetUniformuiv"/>
         </command>
         <command>
+            <proto>void <name>glGetUnsignedBytevEXT</name></proto>
+            <param group="GetPName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLubyte</ptype> *<name>data</name></param>
+        </command>
+        <command>
+            <proto>void <name>glGetUnsignedBytei_vEXT</name></proto>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <param len="COMPSIZE(target)"><ptype>GLubyte</ptype> *<name>data</name></param>
+        </command>
+        <command>
             <proto>void <name>glGetVariantArrayObjectfvATI</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param group="ArrayObjectPNameATI"><ptype>GLenum</ptype> <name>pname</name></param>
@@ -17059,46 +20093,46 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glGetVertexArrayIndexed64iv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint64</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIndexediv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIntegeri_vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayIntegervEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayPointeri_vEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>void **<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayPointervEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="1">void **<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexArrayiv</name></proto>
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexArrayPName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -17142,32 +20176,32 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glGetVertexAttribLdv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLdouble</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLdvEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLdouble</ptype> *<name>params</name></param>
             <alias name="glGetVertexAttribLdv"/>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLi64vNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLui64vARB</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetVertexAttribLui64vNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)"><ptype>GLuint64EXT</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -17313,161 +20347,161 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnColorTable</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>table</name></param>
         </command>
         <command>
             <proto>void <name>glGetnColorTableARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorTableTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>table</name></param>
         </command>
         <command>
             <proto>void <name>glGetnCompressedTexImage</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>lod</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetnCompressedTexImageARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>lod</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>img</name></param>
         </command>
         <command>
             <proto>void <name>glGetnConvolutionFilter</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>image</name></param>
         </command>
         <command>
             <proto>void <name>glGetnConvolutionFilterARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ConvolutionTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>image</name></param>
         </command>
         <command>
             <proto>void <name>glGetnHistogram</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnHistogramARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapdv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapdvARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLdouble</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapfv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapfvARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLfloat</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMapivARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>query</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapQuery"><ptype>GLenum</ptype> <name>query</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>v</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMinmax</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param>void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnMinmaxARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>reset</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapfv</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapfvARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapuiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLuint</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapuivARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLuint</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapusv</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param><ptype>GLushort</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glGetnPixelMapusvARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLushort</ptype> *<name>values</name></param>
         </command>
@@ -17483,9 +20517,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnSeparableFilter</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>rowBufSize</name></param>
             <param>void *<name>row</name></param>
             <param><ptype>GLsizei</ptype> <name>columnBufSize</name></param>
@@ -17494,9 +20528,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnSeparableFilterARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>rowBufSize</name></param>
             <param len="rowBufSize">void *<name>row</name></param>
             <param><ptype>GLsizei</ptype> <name>columnBufSize</name></param>
@@ -17505,19 +20539,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glGetnTexImage</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>pixels</name></param>
+            <param len="bufSize">void *<name>pixels</name></param>
         </command>
         <command>
             <proto>void <name>glGetnTexImageARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>img</name></param>
         </command>
@@ -17526,7 +20560,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLdouble</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLdouble</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformdvARB</name></proto>
@@ -17540,7 +20574,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformfvARB</name></proto>
@@ -17555,13 +20589,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLfloat</ptype> *<name>params</name></param>
+            <alias name="glGetnUniformfv"/>
         </command>
         <command>
             <proto>void <name>glGetnUniformfvKHR</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLfloat</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLfloat</ptype> *<name>params</name></param>
             <alias name="glGetnUniformfv"/>
         </command>
         <command>
@@ -17569,14 +20604,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLint64</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformivARB</name></proto>
@@ -17591,13 +20626,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
+            <alias name="glGetnUniformiv"/>
         </command>
         <command>
             <proto>void <name>glGetnUniformivKHR</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLint</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLint</ptype> *<name>params</name></param>
             <alias name="glGetnUniformiv"/>
         </command>
         <command>
@@ -17605,14 +20641,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLuint64</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLuint64</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLuint</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glGetnUniformuivARB</name></proto>
@@ -17626,7 +20662,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLint</ptype> <name>location</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param><ptype>GLuint</ptype> *<name>params</name></param>
+            <param len="bufSize"><ptype>GLuint</ptype> *<name>params</name></param>
             <alias name="glGetnUniformuiv"/>
         </command>
         <command>
@@ -17674,9 +20710,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glHistogram</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4110"/>
         </command>
@@ -17684,7 +20720,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glHistogramEXT</name></proto>
             <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glHistogram"/>
             <glx type="render" opcode="4110"/>
@@ -17718,6 +20754,45 @@ typedef unsigned int GLhandleARB;
             <param group="ImageTransformTargetHP"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="ImageTransformPNameHP"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportMemoryFdEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>size</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param><ptype>GLint</ptype> <name>fd</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportMemoryWin32HandleEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>size</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param>void *<name>handle</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportMemoryWin32NameEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>size</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param>const void *<name>name</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportSemaphoreFdEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param><ptype>GLint</ptype> <name>fd</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportSemaphoreWin32HandleEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param>void *<name>handle</name></param>
+        </command>
+        <command>
+            <proto>void <name>glImportSemaphoreWin32NameEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param group="ExternalHandleType"><ptype>GLenum</ptype> <name>handleType</name></param>
+            <param>const void *<name>name</name></param>
         </command>
         <command>
             <proto group="sync"><ptype>GLsync</ptype> <name>glImportSyncEXT</name></proto>
@@ -17869,21 +20944,21 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glInvalidateFramebuffer</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param group="FramebufferAttachment" len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
         </command>
         <command>
             <proto>void <name>glInvalidateNamedFramebufferData</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param>const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
         </command>
         <command>
             <proto>void <name>glInvalidateNamedFramebufferSubData</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param>const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
             <param><ptype>GLint</ptype> <name>x</name></param>
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -17891,9 +20966,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glInvalidateSubFramebuffer</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numAttachments</name></param>
-            <param len="numAttachments">const <ptype>GLenum</ptype> *<name>attachments</name></param>
+            <param len="numAttachments" group="FramebufferAttachment">const <ptype>GLenum</ptype> *<name>attachments</name></param>
             <param><ptype>GLint</ptype> <name>x</name></param>
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -17943,30 +21018,31 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabledIndexedEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
+            <glx type="single" opcode="212"/>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnabledi</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsEnablediOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="EnableCap"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <alias name="glIsEnabledi"/>
         </command>
@@ -18006,6 +21082,10 @@ typedef unsigned int GLhandleARB;
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsList</name></proto>
             <param group="List"><ptype>GLuint</ptype> <name>list</name></param>
             <glx type="single" opcode="141"/>
+        </command>
+        <command>
+            <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsMemoryObjectEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memoryObject</name></param>
         </command>
         <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsNameAMD</name></proto>
@@ -18100,6 +21180,10 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
+            <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsSemaphoreEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+        </command>
+        <command>
             <proto group="Boolean"><ptype>GLboolean</ptype> <name>glIsSampler</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
         </command>
@@ -18174,6 +21258,37 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>pname</name></param>
         </command>
         <command>
+            <proto>void <name>glLGPUCopyImageSubDataNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>sourceGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>destinationGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>srcName</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLint</ptype> <name>srcLevel</name></param>
+            <param><ptype>GLint</ptype> <name>srcX</name></param>
+            <param><ptype>GLint</ptype> <name>srxY</name></param>
+            <param><ptype>GLint</ptype> <name>srcZ</name></param>
+            <param><ptype>GLuint</ptype> <name>dstName</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLint</ptype> <name>dstLevel</name></param>
+            <param><ptype>GLint</ptype> <name>dstX</name></param>
+            <param><ptype>GLint</ptype> <name>dstY</name></param>
+            <param><ptype>GLint</ptype> <name>dstZ</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLsizei</ptype> <name>depth</name></param>
+        </command>
+        <command>
+            <proto>void <name>glLGPUInterlockNVX</name></proto>
+        </command>
+        <command>
+            <proto>void <name>glLGPUNamedBufferSubDataNVX</name></proto>
+            <param><ptype>GLbitfield</ptype> <name>gpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param>const void *<name>data</name></param>
+        </command>
+        <command>
             <proto>void <name>glLabelObjectEXT</name></proto>
             <param><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>object</name></param>
@@ -18211,22 +21326,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLightModelx</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightModelxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightModelParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -18259,26 +21374,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glLightx</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glLightxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glLightxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>light</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="LightName"><ptype>GLenum</ptype> <name>light</name></param>
+            <param group="LightParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -18501,7 +21616,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMap1xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLfixed</ptype> <name>u1</name></param>
             <param><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>stride</name></param>
@@ -18538,7 +21653,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMap2xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MapTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLfixed</ptype> <name>u1</name></param>
             <param><ptype>GLfixed</ptype> <name>u2</name></param>
             <param><ptype>GLint</ptype> <name>ustride</name></param>
@@ -18562,8 +21677,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void *<name>glMapBufferOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
             <alias name="glMapBuffer"/>
         </command>
         <command>
@@ -18571,15 +21686,15 @@ typedef unsigned int GLhandleARB;
             <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>length</name></param>
-            <param group="BufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
+            <param group="MapBufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
             <glx type="single" opcode="205"/>
         </command>
         <command>
             <proto>void *<name>glMapBufferRangeEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="BufferTargetARB"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>length</name></param>
-            <param><ptype>GLbitfield</ptype> <name>access</name></param>
+            <param group="MapBufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
             <alias name="glMapBufferRange"/>
         </command>
         <command>
@@ -18645,26 +21760,26 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void *<name>glMapNamedBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapNamedBufferEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
-            <param group="VertexBufferObjectAccess"><ptype>GLenum</ptype> <name>access</name></param>
+            <param group="BufferAccessARB"><ptype>GLenum</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapNamedBufferRange</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>length</name></param>
-            <param><ptype>GLbitfield</ptype> <name>access</name></param>
+            <param group="MapBufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapNamedBufferRangeEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param><ptype>GLsizeiptr</ptype> <name>length</name></param>
-            <param group="BufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
+            <param group="MapBufferAccessMask"><ptype>GLbitfield</ptype> <name>access</name></param>
         </command>
         <command>
             <proto>void *<name>glMapObjectBufferATI</name></proto>
@@ -18768,26 +21883,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMaterialx</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glMaterialxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>face</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="MaterialFace"><ptype>GLenum</ptype> <name>face</name></param>
+            <param group="MaterialParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -18810,7 +21925,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glMatrixIndexPointerOES</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="MatrixIndexPointerTypeARB"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
         </command>
@@ -18974,21 +22089,32 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLfloat</ptype> <name>z</name></param>
         </command>
         <command>
-            <proto>void <name>glMaxShaderCompilerThreadsARB</name></proto>
+            <proto>void <name>glMaxShaderCompilerThreadsKHR</name></proto>
             <param><ptype>GLuint</ptype> <name>count</name></param>
         </command>
         <command>
+            <proto>void <name>glMaxShaderCompilerThreadsARB</name></proto>
+            <param><ptype>GLuint</ptype> <name>count</name></param>
+            <alias name="glMaxShaderCompilerThreadsKHR"/>
+        </command>
+        <command>
             <proto>void <name>glMemoryBarrier</name></proto>
-            <param><ptype>GLbitfield</ptype> <name>barriers</name></param>
+            <param group="MemoryBarrierMask"><ptype>GLbitfield</ptype> <name>barriers</name></param>
         </command>
         <command>
             <proto>void <name>glMemoryBarrierByRegion</name></proto>
-            <param><ptype>GLbitfield</ptype> <name>barriers</name></param>
+            <param group="MemoryBarrierMask"><ptype>GLbitfield</ptype> <name>barriers</name></param>
         </command>
         <command>
             <proto>void <name>glMemoryBarrierEXT</name></proto>
-            <param><ptype>GLbitfield</ptype> <name>barriers</name></param>
+            <param group="MemoryBarrierMask"><ptype>GLbitfield</ptype> <name>barriers</name></param>
             <alias name="glMemoryBarrier"/>
+        </command>
+        <command>
+            <proto>void <name>glMemoryObjectParameterivEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memoryObject</name></param>
+            <param group="MemoryObjectParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param>const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glMinSampleShading</name></proto>
@@ -19006,15 +22132,15 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMinmax</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <glx type="render" opcode="4111"/>
         </command>
         <command>
             <proto>void <name>glMinmaxEXT</name></proto>
             <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>sink</name></param>
             <alias name="glMinmax"/>
             <glx type="render" opcode="4111"/>
@@ -19076,14 +22202,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysIndirect</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysIndirectAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -19091,7 +22217,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysIndirectBindlessCountNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxDrawCount</name></param>
@@ -19100,23 +22226,32 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawArraysIndirectBindlessNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLint</ptype> <name>vertexBufferCount</name></param>
         </command>
         <command>
-            <proto>void <name>glMultiDrawArraysIndirectCountARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLintptr</ptype> <name>indirect</name></param>
+            <proto>void <name>glMultiDrawArraysIndirectCount</name></proto>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param>const void *<name>indirect</name></param>
             <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
+            <proto>void <name>glMultiDrawArraysIndirectCountARB</name></proto>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param>const void *<name>indirect</name></param>
+            <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>stride</name></param>
+            <alias name="glMultiDrawArraysIndirectCount"/>
+        </command>
+        <command>
             <proto>void <name>glMultiDrawArraysIndirectEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -19139,7 +22274,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertex</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
@@ -19148,17 +22283,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsBaseVertexEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
-            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
-            <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
-            <param><ptype>GLsizei</ptype> <name>primcount</name></param>
-            <param len="COMPSIZE(drawcount)">const <ptype>GLint</ptype> *<name>basevertex</name></param>
-            <alias name="glMultiDrawElementsBaseVertex"/>
-        </command>
-        <command>
-            <proto>void <name>glMultiDrawElementsBaseVertexOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
             <param len="COMPSIZE(drawcount)">const <ptype>GLsizei</ptype> *<name>count</name></param>
             <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount)">const void *const*<name>indices</name></param>
@@ -19177,16 +22302,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsIndirect</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsIndirectAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>primcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
@@ -19194,8 +22319,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsIndirectBindlessCountNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxDrawCount</name></param>
@@ -19204,30 +22329,53 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiDrawElementsIndirectBindlessNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawCount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLint</ptype> <name>vertexBufferCount</name></param>
         </command>
         <command>
-            <proto>void <name>glMultiDrawElementsIndirectCountARB</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
-            <param><ptype>GLintptr</ptype> <name>indirect</name></param>
+            <proto>void <name>glMultiDrawElementsIndirectCount</name></proto>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param>const void *<name>indirect</name></param>
             <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
+            <proto>void <name>glMultiDrawElementsIndirectCountARB</name></proto>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
+            <param>const void *<name>indirect</name></param>
+            <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>stride</name></param>
+            <alias name="glMultiDrawElementsIndirectCount"/>
+        </command>
+        <command>
             <proto>void <name>glMultiDrawElementsIndirectEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PrimitiveType"><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="DrawElementsType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(drawcount,stride)">const void *<name>indirect</name></param>
             <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <alias name="glMultiDrawElementsIndirect"/>
+        </command>
+        <command>
+            <proto>void <name>glMultiDrawMeshTasksIndirectNV</name></proto>
+            <param><ptype>GLintptr</ptype> <name>indirect</name></param>
+            <param><ptype>GLsizei</ptype> <name>drawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>stride</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMultiDrawMeshTasksIndirectCountNV</name></proto>
+            <param><ptype>GLintptr</ptype> <name>indirect</name></param>
+            <param><ptype>GLintptr</ptype> <name>drawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>maxdrawcount</name></param>
+            <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glMultiDrawRangeElementArrayAPPLE</name></proto>
@@ -19259,17 +22407,17 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glMultiTexBufferEXT</name></proto>
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TypeEnum"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1bOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1bvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="1">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -19390,23 +22538,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord1xvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="1">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2bOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2bvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="2">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -19536,25 +22684,25 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord2xvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="2">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3bOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
             <param><ptype>GLbyte</ptype> <name>r</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3bvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="3">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -19693,19 +22841,19 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord3xvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="3">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4bOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLbyte</ptype> <name>s</name></param>
             <param><ptype>GLbyte</ptype> <name>t</name></param>
             <param><ptype>GLbyte</ptype> <name>r</name></param>
@@ -19713,7 +22861,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4bvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="4">const <ptype>GLbyte</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -19861,7 +23009,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4x</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
@@ -19869,7 +23017,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4xOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param><ptype>GLfixed</ptype> <name>s</name></param>
             <param><ptype>GLfixed</ptype> <name>t</name></param>
             <param><ptype>GLfixed</ptype> <name>r</name></param>
@@ -19877,55 +23025,55 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glMultiTexCoord4xvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
             <param len="4">const <ptype>GLfixed</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP1ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP1uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP2ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP2uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glMultiTexCoordP4uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TextureUnit"><ptype>GLenum</ptype> <name>texture</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20016,7 +23164,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -20028,7 +23176,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -20041,7 +23189,7 @@ typedef unsigned int GLhandleARB;
             <param group="TextureUnit"><ptype>GLenum</ptype> <name>texunit</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -20140,11 +23288,135 @@ typedef unsigned int GLhandleARB;
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
         </command>
         <command>
+            <proto>void <name>glMulticastBarrierNV</name></proto>
+        </command>
+        <command>
+            <proto>void <name>glMulticastBlitFramebufferNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>srcGpu</name></param>
+            <param><ptype>GLuint</ptype> <name>dstGpu</name></param>
+            <param><ptype>GLint</ptype> <name>srcX0</name></param>
+            <param><ptype>GLint</ptype> <name>srcY0</name></param>
+            <param><ptype>GLint</ptype> <name>srcX1</name></param>
+            <param><ptype>GLint</ptype> <name>srcY1</name></param>
+            <param><ptype>GLint</ptype> <name>dstX0</name></param>
+            <param><ptype>GLint</ptype> <name>dstY0</name></param>
+            <param><ptype>GLint</ptype> <name>dstX1</name></param>
+            <param><ptype>GLint</ptype> <name>dstY1</name></param>
+            <param group="ClearBufferMask"><ptype>GLbitfield</ptype> <name>mask</name></param>
+            <param><ptype>GLenum</ptype> <name>filter</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastBufferSubDataNV</name></proto>
+            <param><ptype>GLbitfield</ptype> <name>gpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param>const void *<name>data</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastCopyBufferSubDataNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>readGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>writeGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>readBuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>writeBuffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>readOffset</name></param>
+            <param><ptype>GLintptr</ptype> <name>writeOffset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastCopyImageSubDataNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>srcGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>dstGpuMask</name></param>
+            <param><ptype>GLuint</ptype> <name>srcName</name></param>
+            <param><ptype>GLenum</ptype> <name>srcTarget</name></param>
+            <param><ptype>GLint</ptype> <name>srcLevel</name></param>
+            <param><ptype>GLint</ptype> <name>srcX</name></param>
+            <param><ptype>GLint</ptype> <name>srcY</name></param>
+            <param><ptype>GLint</ptype> <name>srcZ</name></param>
+            <param><ptype>GLuint</ptype> <name>dstName</name></param>
+            <param><ptype>GLenum</ptype> <name>dstTarget</name></param>
+            <param><ptype>GLint</ptype> <name>dstLevel</name></param>
+            <param><ptype>GLint</ptype> <name>dstX</name></param>
+            <param><ptype>GLint</ptype> <name>dstY</name></param>
+            <param><ptype>GLint</ptype> <name>dstZ</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcWidth</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcHeight</name></param>
+            <param><ptype>GLsizei</ptype> <name>srcDepth</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastFramebufferSampleLocationsfvNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
+            <param><ptype>GLuint</ptype> <name>start</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param>const <ptype>GLfloat</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastGetQueryObjecti64vNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>id</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLint64</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastGetQueryObjectivNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>id</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLint</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastGetQueryObjectui64vNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>id</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLuint64</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastGetQueryObjectuivNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>id</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLuint</ptype> *<name>params</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastScissorArrayvNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastViewportArrayvNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="COMPSIZE(count)">const <ptype>GLfloat</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastViewportPositionWScaleNVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>gpu</name></param>
+            <param><ptype>GLuint</ptype> <name>index</name></param>
+            <param><ptype>GLfloat</ptype> <name>xcoeff</name></param>
+            <param><ptype>GLfloat</ptype> <name>ycoeff</name></param>
+        </command>
+        <command>
+            <proto>void <name>glMulticastWaitSyncNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>signalGpu</name></param>
+            <param><ptype>GLbitfield</ptype> <name>waitGpuMask</name></param>
+        </command>
+        <command>
+            <proto>void <name>glNamedBufferAttachMemoryNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
             <proto>void <name>glNamedBufferData</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param>const void *<name>data</name></param>
-            <param><ptype>GLenum</ptype> <name>usage</name></param>
+            <param group="VertexBufferObjectUsage"><ptype>GLenum</ptype> <name>usage</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferDataEXT</name></proto>
@@ -20172,15 +23444,30 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
+        </command>
+        <command>
+            <proto>void <name>glNamedBufferStorageExternalEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <param><ptype>GLintptr</ptype> <name>offset</name></param>
+            <param><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLeglClientBufferEXT</ptype> <name>clientBuffer</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferStorageEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
             <param len="size">const void *<name>data</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="BufferStorageMask"><ptype>GLbitfield</ptype> <name>flags</name></param>
             <alias name="glNamedBufferStorage"/>
+        </command>
+        <command>
+            <proto>void <name>glNamedBufferStorageMemEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>buffer</name></param>
+            <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
         </command>
         <command>
             <proto>void <name>glNamedBufferSubData</name></proto>
@@ -20208,18 +23495,18 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferDrawBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>buf</name></param>
+            <param group="ColorBuffer"><ptype>GLenum</ptype> <name>buf</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferDrawBuffers</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
-            <param>const <ptype>GLenum</ptype> *<name>bufs</name></param>
+            <param group="ColorBuffer">const <ptype>GLenum</ptype> *<name>bufs</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -20231,13 +23518,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferReadBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="ColorBuffer"><ptype>GLenum</ptype> <name>src</name></param>
         </command>
         <command>
             <proto>void <name>glNamedFramebufferRenderbuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
-            <param><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>renderbuffertarget</name></param>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
         </command>
         <command>
@@ -20264,7 +23551,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferTexture</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
         </command>
@@ -20318,7 +23605,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedFramebufferTextureLayer</name></proto>
             <param><ptype>GLuint</ptype> <name>framebuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>attachment</name></param>
+            <param group="FramebufferAttachment"><ptype>GLenum</ptype> <name>attachment</name></param>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>layer</name></param>
@@ -20438,14 +23725,14 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glNamedRenderbufferStorage</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glNamedRenderbufferStorageEXT</name></proto>
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -20453,7 +23740,16 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedRenderbufferStorageMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+        </command>
+        <command>
+            <proto>void <name>glNamedRenderbufferStorageMultisampleAdvancedAMD</name></proto>
+            <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLsizei</ptype> <name>storageSamples</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -20462,7 +23758,7 @@ typedef unsigned int GLhandleARB;
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -20470,7 +23766,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glNamedRenderbufferStorageMultisampleEXT</name></proto>
             <param group="Renderbuffer"><ptype>GLuint</ptype> <name>renderbuffer</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -20603,12 +23899,12 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glNormalP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="NormalPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glNormalP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="NormalPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -20698,14 +23994,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glObjectLabel</name></proto>
-            <param><ptype>GLenum</ptype> <name>identifier</name></param>
+            <param group="ObjectIdentifier"><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(label,length)">const <ptype>GLchar</ptype> *<name>label</name></param>
         </command>
         <command>
             <proto>void <name>glObjectLabelKHR</name></proto>
-            <param><ptype>GLenum</ptype> <name>identifier</name></param>
+            <param group="ObjectIdentifier"><ptype>GLenum</ptype> <name>identifier</name></param>
             <param><ptype>GLuint</ptype> <name>name</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>label</name></param>
@@ -20810,23 +24106,23 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPatchParameterfv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>values</name></param>
         </command>
         <command>
             <proto>void <name>glPatchParameteri</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glPatchParameteriEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
             <alias name="glPatchParameteri"/>
         </command>
         <command>
             <proto>void <name>glPatchParameteriOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PatchParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>value</name></param>
             <alias name="glPatchParameteri"/>
         </command>
@@ -20872,7 +24168,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>firstPathName</name></param>
             <param><ptype>GLenum</ptype> <name>fontTarget</name></param>
             <param>const void *<name>fontName</name></param>
-            <param><ptype>GLbitfield</ptype> <name>fontStyle</name></param>
+            <param group="PathFontStyle"><ptype>GLbitfield</ptype> <name>fontStyle</name></param>
             <param><ptype>GLuint</ptype> <name>firstGlyphIndex</name></param>
             <param><ptype>GLsizei</ptype> <name>numGlyphs</name></param>
             <param><ptype>GLuint</ptype> <name>pathParameterTemplate</name></param>
@@ -20882,7 +24178,7 @@ typedef unsigned int GLhandleARB;
             <proto><ptype>GLenum</ptype> <name>glPathGlyphIndexRangeNV</name></proto>
             <param><ptype>GLenum</ptype> <name>fontTarget</name></param>
             <param>const void *<name>fontName</name></param>
-            <param><ptype>GLbitfield</ptype> <name>fontStyle</name></param>
+            <param group="PathFontStyle"><ptype>GLbitfield</ptype> <name>fontStyle</name></param>
             <param><ptype>GLuint</ptype> <name>pathParameterTemplate</name></param>
             <param><ptype>GLfloat</ptype> <name>emScale</name></param>
             <param><ptype>GLuint</ptype> <name>baseAndCount</name>[2]</param>
@@ -21031,7 +24327,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelMapx</name></proto>
-            <param><ptype>GLenum</ptype> <name>map</name></param>
+            <param group="PixelMap"><ptype>GLenum</ptype> <name>map</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
             <param len="size">const <ptype>GLfixed</ptype> *<name>values</name></param>
         </command>
@@ -21049,7 +24345,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelStorex</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PixelStoreParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
@@ -21091,7 +24387,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPixelTransferxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PixelTransferParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
@@ -21220,22 +24516,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPointParameterx</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glPointParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="PointParameterNameARB"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -21285,11 +24581,18 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="192"/>
         </command>
         <command>
-            <proto>void <name>glPolygonOffsetClampEXT</name></proto>
+            <proto>void <name>glPolygonOffsetClamp</name></proto>
             <param><ptype>GLfloat</ptype> <name>factor</name></param>
             <param><ptype>GLfloat</ptype> <name>units</name></param>
             <param><ptype>GLfloat</ptype> <name>clamp</name></param>
             <glx type="render" opcode="4225"/>
+        </command>
+        <command>
+            <proto>void <name>glPolygonOffsetClampEXT</name></proto>
+            <param><ptype>GLfloat</ptype> <name>factor</name></param>
+            <param><ptype>GLfloat</ptype> <name>units</name></param>
+            <param><ptype>GLfloat</ptype> <name>clamp</name></param>
+            <alias name="glPolygonOffsetClamp"/>
         </command>
         <command>
             <proto>void <name>glPolygonOffsetEXT</name></proto>
@@ -21422,9 +24725,11 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glPrimitiveRestartIndexNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
+            <glx type="render" opcode="365"/>
         </command>
         <command>
             <proto>void <name>glPrimitiveRestartNV</name></proto>
+            <glx type="render" opcode="364"/>
         </command>
         <command>
             <proto>void <name>glPrioritizeTextures</name></proto>
@@ -22865,11 +26170,11 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glProvokingVertex</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="VertexProvokingMode"><ptype>GLenum</ptype> <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glProvokingVertexEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>mode</name></param>
+            <param group="VertexProvokingMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <alias name="glProvokingVertex"/>
         </command>
         <command>
@@ -22887,14 +26192,14 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glPushDebugGroup</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param len="COMPSIZE(message,length)">const <ptype>GLchar</ptype> *<name>message</name></param>
         </command>
         <command>
             <proto>void <name>glPushDebugGroupKHR</name></proto>
-            <param><ptype>GLenum</ptype> <name>source</name></param>
+            <param group="DebugSource"><ptype>GLenum</ptype> <name>source</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLsizei</ptype> <name>length</name></param>
             <param>const <ptype>GLchar</ptype> *<name>message</name></param>
@@ -22917,12 +26222,12 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glQueryCounter</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryCounterTarget"><ptype>GLenum</ptype> <name>target</name></param>
         </command>
         <command>
             <proto>void <name>glQueryCounterEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>id</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryCounterTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <alias name="glQueryCounter"/>
         </command>
         <command>
@@ -22932,10 +26237,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glQueryObjectParameteruiAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="QueryTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>id</name></param>
             <param><ptype>GLenum</ptype> <name>pname</name></param>
             <param group="OcclusionQueryEventMaskAMD"><ptype>GLuint</ptype> <name>param</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLint</ptype> <name>glQueryResourceNV</name></proto>
+            <param><ptype>GLenum</ptype> <name>queryType</name></param>
+            <param><ptype>GLint</ptype> <name>tagId</name></param>
+            <param><ptype>GLuint</ptype> <name>bufSize</name></param>
+            <param><ptype>GLint</ptype> *<name>buffer</name></param>
+        </command>
+        <command>
+            <proto>void <name>glQueryResourceTagNV</name></proto>
+            <param><ptype>GLint</ptype> <name>tagId</name></param>
+            <param>const <ptype>GLchar</ptype> *<name>tagString</name></param>
         </command>
         <command>
             <proto>void <name>glRasterPos2d</name></proto>
@@ -23123,7 +26440,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glReadBufferIndexedEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>src</name></param>
+            <param group="ReadBufferMode"><ptype>GLenum</ptype> <name>src</name></param>
             <param><ptype>GLint</ptype> <name>index</name></param>
         </command>
         <command>
@@ -23153,10 +26470,10 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
-            <param>void *<name>data</name></param>
+            <param len="bufSize">void *<name>data</name></param>
         </command>
         <command>
             <proto>void <name>glReadnPixelsARB</name></proto>
@@ -23164,8 +26481,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>data</name></param>
             <alias name="glReadnPixels"/>
@@ -23176,8 +26493,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>y</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>data</name></param>
             <alias name="glReadnPixels"/>
@@ -23193,6 +26510,11 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>bufSize</name></param>
             <param len="bufSize">void *<name>data</name></param>
             <alias name="glReadnPixels"/>
+        </command>
+        <command>
+            <proto><ptype>GLboolean</ptype> <name>glReleaseKeyedMutexWin32EXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>key</name></param>
         </command>
         <command>
             <proto>void <name>glRectd</name></proto>
@@ -23271,6 +26593,10 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glReleaseShaderCompiler</name></proto>
         </command>
         <command>
+            <proto>void <name>glRenderGpuMaskNV</name></proto>
+            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
+        </command>
+        <command>
             <proto><ptype>GLint</ptype> <name>glRenderMode</name></proto>
             <param group="RenderingMode"><ptype>GLenum</ptype> <name>mode</name></param>
             <glx type="single" opcode="107"/>
@@ -23278,7 +26604,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glRenderbufferStorage</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <glx type="render" opcode="4318"/>
@@ -23286,7 +26612,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glRenderbufferStorageEXT</name></proto>
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorage"/>
@@ -23294,26 +26620,35 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisample</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <glx type="render" opcode="4331"/>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleANGLE</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleAPPLE</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+        </command>
+        <command>
+            <proto>void <name>glRenderbufferStorageMultisampleAdvancedAMD</name></proto>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLsizei</ptype> <name>storageSamples</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -23322,15 +26657,15 @@ typedef unsigned int GLhandleARB;
             <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorageMultisample"/>
@@ -23338,25 +26673,25 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleIMG</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageMultisampleNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glRenderbufferStorageMultisample"/>
         </command>
         <command>
             <proto>void <name>glRenderbufferStorageOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="RenderbufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -23538,7 +26873,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glResetHistogram</name></proto>
-            <param group="HistogramTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="HistogramTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="4112"/>
         </command>
         <command>
@@ -23548,8 +26883,13 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="4112"/>
         </command>
         <command>
+            <proto>void <name>glResetMemoryObjectParameterNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLenum</ptype> <name>pname</name></param>
+        </command>
+        <command>
             <proto>void <name>glResetMinmax</name></proto>
-            <param group="MinmaxTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="MinmaxTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
             <glx type="render" opcode="4113"/>
         </command>
         <command>
@@ -23667,65 +27007,65 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSamplerParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuivEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterIuivOES</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLuint</ptype> *<name>param</name></param>
             <alias name="glSamplerParameterIuiv"/>
         </command>
         <command>
             <proto>void <name>glSamplerParameterf</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterF"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterF"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glSamplerParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>sampler</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="SamplerParameterI"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -23781,6 +27121,19 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
             <alias name="glScissorArrayv"/>
+        </command>
+        <command>
+            <proto>void <name>glScissorExclusiveArrayvNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="COMPSIZE(count)">const <ptype>GLint</ptype> *<name>v</name></param>
+        </command>
+        <command>
+            <proto>void <name>glScissorExclusiveNV</name></proto>
+            <param group="WinCoord"><ptype>GLint</ptype> <name>x</name></param>
+            <param group="WinCoord"><ptype>GLint</ptype> <name>y</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glScissorIndexed</name></proto>
@@ -24048,17 +27401,17 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSecondaryColorFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>color</name></param>
         </command>
         <command>
             <proto>void <name>glSecondaryColorP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="ColorPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>color</name></param>
         </command>
         <command>
@@ -24099,9 +27452,15 @@ typedef unsigned int GLhandleARB;
             <param len="numCounters"><ptype>GLuint</ptype> *<name>counterList</name></param>
         </command>
         <command>
+            <proto>void <name>glSemaphoreParameterui64vEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param group="SemaphoreParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param>const <ptype>GLuint64</ptype> *<name>params</name></param>
+        </command>
+        <command>
             <proto>void <name>glSeparableFilter2D</name></proto>
-            <param group="SeparableTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24114,7 +27473,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glSeparableFilter2DEXT</name></proto>
             <param group="SeparableTargetEXT"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -24212,11 +27571,65 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>storageBlockBinding</name></param>
         </command>
         <command>
+            <proto>void <name>glShadingRateImageBarrierNV</name></proto>
+            <param><ptype>GLboolean</ptype> <name>synchronize</name></param>
+        </command>
+        <command>
+            <proto>void <name>glShadingRateImagePaletteNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>viewport</name></param>
+            <param><ptype>GLuint</ptype> <name>first</name></param>
+            <param><ptype>GLsizei</ptype> <name>count</name></param>
+            <param len="count">const <ptype>GLenum</ptype> *<name>rates</name></param>
+        </command>
+        <command>
+            <proto>void <name>glShadingRateSampleOrderNV</name></proto>
+            <param><ptype>GLenum</ptype> <name>order</name></param>
+        </command>
+        <command>
+            <proto>void <name>glShadingRateSampleOrderCustomNV</name></proto>
+            <param><ptype>GLenum</ptype> <name>rate</name></param>
+            <param><ptype>GLuint</ptype> <name>samples</name></param>
+            <param len="COMPSIZE(rate,samples)">const <ptype>GLint</ptype> *<name>locations</name></param>
+        </command>
+        <command>
             <proto>void <name>glSharpenTexFuncSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>n</name></param>
             <param len="n*2">const <ptype>GLfloat</ptype> *<name>points</name></param>
             <glx type="render" opcode="2052"/>
+        </command>
+        <command>
+            <proto>void <name>glSignalSemaphoreEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param><ptype>GLuint</ptype> <name>numBufferBarriers</name></param>
+            <param len="COMPSIZE(numBufferBarriers)">const <ptype>GLuint</ptype> *<name>buffers</name></param>
+            <param><ptype>GLuint</ptype> <name>numTextureBarriers</name></param>
+            <param len="COMPSIZE(numTextureBarriers)">const <ptype>GLuint</ptype> *<name>textures</name></param>
+            <param group="TextureLayout" len="COMPSIZE(numTextureBarriers)">const <ptype>GLenum</ptype> *<name>dstLayouts</name></param>
+        </command>
+        <command>
+            <proto>void <name>glSignalSemaphoreui64NVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>signalGpu</name></param>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
+        </command>
+        <command>
+            <proto>void <name>glSpecializeShader</name></proto>
+            <param><ptype>GLuint</ptype> <name>shader</name></param>
+            <param>const <ptype>GLchar</ptype> *<name>pEntryPoint</name></param>
+            <param><ptype>GLuint</ptype> <name>numSpecializationConstants</name></param>
+            <param>const <ptype>GLuint</ptype> *<name>pConstantIndex</name></param>
+            <param>const <ptype>GLuint</ptype> *<name>pConstantValue</name></param>
+        </command>
+        <command>
+            <proto>void <name>glSpecializeShaderARB</name></proto>
+            <param><ptype>GLuint</ptype> <name>shader</name></param>
+            <param>const <ptype>GLchar</ptype> *<name>pEntryPoint</name></param>
+            <param><ptype>GLuint</ptype> <name>numSpecializationConstants</name></param>
+            <param>const <ptype>GLuint</ptype> *<name>pConstantIndex</name></param>
+            <param>const <ptype>GLuint</ptype> *<name>pConstantValue</name></param>
+            <alias name="glSpecializeShader"/>
         </command>
         <command>
             <proto>void <name>glSpriteParameterfSGIX</name></proto>
@@ -24252,7 +27665,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>y</name></param>
             <param><ptype>GLuint</ptype> <name>width</name></param>
             <param><ptype>GLuint</ptype> <name>height</name></param>
-            <param><ptype>GLbitfield</ptype> <name>preserveMask</name></param>
+            <param group="BufferBitQCOM"><ptype>GLbitfield</ptype> <name>preserveMask</name></param>
         </command>
         <command>
             <proto>void <name>glStateCaptureNV</name></proto>
@@ -24515,44 +27928,51 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>name</name></param>
         </command>
         <command>
+            <proto>void <name>glTexAttachMemoryNV</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
             <proto>void <name>glTexBuffer</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTexBufferARB</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
+            <glx type="render" opcode="367"/>
         </command>
         <command>
             <proto>void <name>glTexBufferEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
         </command>
         <command>
             <proto>void <name>glTexBufferOES</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <alias name="glTexBuffer"/>
         </command>
         <command>
             <proto>void <name>glTexBufferRange</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
         </command>
         <command>
             <proto>void <name>glTexBufferRangeEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -24560,8 +27980,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexBufferRangeOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -25019,42 +28439,42 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexCoordP1ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP1uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP2ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP2uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>coords</name></param>
         </command>
         <command>
             <proto>void <name>glTexCoordP4uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="TexCoordPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>coords</name></param>
         </command>
         <command>
@@ -25116,26 +28536,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexEnvx</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexEnvxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureEnvTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureEnvParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -25169,8 +28589,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenfOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
@@ -25182,8 +28602,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenfvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfloat</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -25195,8 +28615,8 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGeniOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -25208,27 +28628,27 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexGenivOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexGenxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexGenxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>coord</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureCoordName"><ptype>GLenum</ptype> <name>coord</name></param>
+            <param group="TextureGenParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage1D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25241,7 +28661,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage2D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -25253,16 +28673,16 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage2DMultisample</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexImage2DMultisampleCoverageNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -25274,7 +28694,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage3D</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25289,7 +28709,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTexImage3DEXT</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25302,9 +28722,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DMultisample</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25312,7 +28732,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DMultisampleCoverageNV</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -25323,23 +28743,22 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLint</ptype> <name>border</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
-            <alias name="glTexImage3D"/>
         </command>
         <command>
             <proto>void <name>glTexImage4DSGIS</name></proto>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="PixelInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25447,26 +28866,26 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexParameterx</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfixed</ptype> <name>param</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxv</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
             <proto>void <name>glTexParameterxvOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="GetTextureParameter"><ptype>GLenum</ptype> <name>pname</name></param>
             <param len="COMPSIZE(pname)">const <ptype>GLfixed</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -25476,59 +28895,59 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage1D</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage1DEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <alias name="glTexStorage1D"/>
         </command>
         <command>
             <proto>void <name>glTexStorage2D</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage2DEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <alias name="glTexStorage2D"/>
         </command>
         <command>
             <proto>void <name>glTexStorage2DMultisample</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3D</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
         </command>
         <command>
             <proto>void <name>glTexStorage3DEXT</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25536,9 +28955,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage3DMultisample</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25546,9 +28965,9 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexStorage3DMultisampleOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25556,14 +28975,67 @@ typedef unsigned int GLhandleARB;
             <alias name="glTexStorage3DMultisample"/>
         </command>
         <command>
-            <proto>void <name>glTexStorageSparseAMD</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <proto>void <name>glTexStorageMem1DEXT</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTexStorageMem2DEXT</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTexStorageMem2DMultisampleEXT</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTexStorageMem3DEXT</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
             <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTexStorageMem3DMultisampleEXT</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLsizei</ptype> <name>depth</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTexStorageSparseAMD</name></proto>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLsizei</ptype> <name>layers</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="TextureStorageMaskAMD"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glTexSubImage1D</name></proto>
@@ -25651,7 +29123,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glTexSubImage3DOES</name></proto>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
@@ -25659,10 +29131,9 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="COMPSIZE(format,type,width,height,depth)">const void *<name>pixels</name></param>
-            <alias name="glTexSubImage3D"/>
         </command>
         <command>
             <proto>void <name>glTexSubImage4DSGIS</name></proto>
@@ -25682,6 +29153,12 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="2058"/>
         </command>
         <command>
+            <proto>void <name>glTextureAttachMemoryNV</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
             <proto>void <name>glTextureBarrier</name></proto>
         </command>
         <command>
@@ -25691,20 +29168,20 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureBuffer</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTextureBufferEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
         </command>
         <command>
             <proto>void <name>glTextureBufferRange</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -25713,7 +29190,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureBufferRangeEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
             <param group="BufferSize"><ptype>GLsizeiptr</ptype> <name>size</name></param>
@@ -25727,11 +29204,22 @@ typedef unsigned int GLhandleARB;
             <glx type="render" opcode="2082"/>
         </command>
         <command>
+            <proto>void <name>glTextureFoveationParametersQCOM</name></proto>
+            <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLuint</ptype> <name>layer</name></param>
+            <param><ptype>GLuint</ptype> <name>focalPoint</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalX</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>focalY</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainX</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>gainY</name></param>
+            <param group="CheckedFloat32"><ptype>GLfloat</ptype> <name>foveaArea</name></param>
+        </command>
+        <command>
             <proto>void <name>glTextureImage1DEXT</name></proto>
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
             <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
@@ -25743,7 +29231,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>border</name></param>
@@ -25754,7 +29242,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureImage2DMultisampleCoverageNV</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -25765,7 +29253,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureImage2DMultisampleNV</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -25777,7 +29265,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param group="CheckedInt32"><ptype>GLint</ptype> <name>level</name></param>
-            <param group="TextureComponentCount"><ptype>GLint</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLint</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25789,7 +29277,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureImage3DMultisampleCoverageNV</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>coverageSamples</name></param>
             <param><ptype>GLsizei</ptype> <name>colorSamples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
@@ -25801,7 +29289,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureImage3DMultisampleNV</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
             <param><ptype>GLint</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
@@ -25837,7 +29325,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterIiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -25850,7 +29338,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterIuiv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLuint</ptype> *<name>params</name></param>
         </command>
         <command>
@@ -25863,7 +29351,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterf</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLfloat</ptype> <name>param</name></param>
         </command>
         <command>
@@ -25877,7 +29365,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameterfv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLfloat</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -25890,7 +29378,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameteri</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param><ptype>GLint</ptype> <name>param</name></param>
         </command>
         <command>
@@ -25904,7 +29392,7 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureParameteriv</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>pname</name></param>
+            <param group="TextureParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
             <param>const <ptype>GLint</ptype> *<name>param</name></param>
         </command>
         <command>
@@ -25930,7 +29418,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage1D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
@@ -25938,14 +29426,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
         </command>
         <command>
             <proto>void <name>glTextureStorage2D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -25954,7 +29442,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
         </command>
@@ -25962,7 +29450,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage2DMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
@@ -25972,7 +29460,7 @@ typedef unsigned int GLhandleARB;
             <param group="Texture"><ptype>GLuint</ptype> <name>texture</name></param>
             <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param group="TextureInternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
@@ -25981,7 +29469,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3D</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -25991,7 +29479,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>levels</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26000,7 +29488,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glTextureStorage3DMultisample</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
@@ -26011,22 +29499,75 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>texture</name></param>
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>samples</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>fixedsamplelocations</name></param>
         </command>
         <command>
-            <proto>void <name>glTextureStorageSparseAMD</name></proto>
+            <proto>void <name>glTextureStorageMem1DEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTextureStorageMem2DEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTextureStorageMem2DMultisampleEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTextureStorageMem3DEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLsizei</ptype> <name>levels</name></param>
             <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTextureStorageMem3DMultisampleEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLsizei</ptype> <name>samples</name></param>
+            <param><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLsizei</ptype> <name>depth</name></param>
+            <param><ptype>GLboolean</ptype> <name>fixedSampleLocations</name></param>
+            <param><ptype>GLuint</ptype> <name>memory</name></param>
+            <param><ptype>GLuint64</ptype> <name>offset</name></param>
+        </command>
+        <command>
+            <proto>void <name>glTextureStorageSparseAMD</name></proto>
+            <param><ptype>GLuint</ptype> <name>texture</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalFormat</name></param>
+            <param><ptype>GLsizei</ptype> <name>width</name></param>
+            <param><ptype>GLsizei</ptype> <name>height</name></param>
+            <param><ptype>GLsizei</ptype> <name>depth</name></param>
             <param><ptype>GLsizei</ptype> <name>layers</name></param>
-            <param><ptype>GLbitfield</ptype> <name>flags</name></param>
+            <param group="TextureStorageMaskAMD"><ptype>GLbitfield</ptype> <name>flags</name></param>
         </command>
         <command>
             <proto>void <name>glTextureSubImage1D</name></proto>
@@ -26034,8 +29575,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>level</name></param>
             <param><ptype>GLint</ptype> <name>xoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -26057,8 +29598,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLint</ptype> <name>yoffset</name></param>
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -26084,8 +29625,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLsizei</ptype> <name>width</name></param>
             <param><ptype>GLsizei</ptype> <name>height</name></param>
             <param><ptype>GLsizei</ptype> <name>depth</name></param>
-            <param><ptype>GLenum</ptype> <name>format</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="PixelFormat"><ptype>GLenum</ptype> <name>format</name></param>
+            <param group="PixelType"><ptype>GLenum</ptype> <name>type</name></param>
             <param>const void *<name>pixels</name></param>
         </command>
         <command>
@@ -26106,9 +29647,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureView</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -26117,9 +29658,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureViewEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -26129,9 +29670,9 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glTextureViewOES</name></proto>
             <param><ptype>GLuint</ptype> <name>texture</name></param>
-            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="TextureTarget"><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLuint</ptype> <name>origtexture</name></param>
-            <param><ptype>GLenum</ptype> <name>internalformat</name></param>
+            <param group="InternalFormat"><ptype>GLenum</ptype> <name>internalformat</name></param>
             <param><ptype>GLuint</ptype> <name>minlevel</name></param>
             <param><ptype>GLuint</ptype> <name>numlevels</name></param>
             <param><ptype>GLuint</ptype> <name>minlayer</name></param>
@@ -26179,7 +29720,8 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLchar</ptype> *const*<name>varyings</name></param>
-            <param><ptype>GLenum</ptype> <name>bufferMode</name></param>
+            <param group="TransformFeedbackBufferMode" ><ptype>GLenum</ptype> <name>bufferMode</name></param>
+            <glx type="render" opcode="359"/>
         </command>
         <command>
             <proto>void <name>glTransformFeedbackVaryingsEXT</name></proto>
@@ -26808,6 +30350,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>program</name></param>
             <param><ptype>GLuint</ptype> <name>uniformBlockIndex</name></param>
             <param><ptype>GLuint</ptype> <name>uniformBlockBinding</name></param>
+            <glx type="render" opcode="366"/>
         </command>
         <command>
             <proto>void <name>glUniformBufferEXT</name></proto>
@@ -27056,7 +30599,7 @@ typedef unsigned int GLhandleARB;
         </command>
         <command>
             <proto>void <name>glUniformSubroutinesuiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>shadertype</name></param>
+            <param group="ShaderType"><ptype>GLenum</ptype> <name>shadertype</name></param>
             <param><ptype>GLsizei</ptype> <name>count</name></param>
             <param len="count">const <ptype>GLuint</ptype> *<name>indices</name></param>
         </command>
@@ -27114,6 +30657,10 @@ typedef unsigned int GLhandleARB;
             <param group="PreserveModeATI"><ptype>GLenum</ptype> <name>preserve</name></param>
         </command>
         <command>
+            <proto>void <name>glUploadGpuMaskNVX</name></proto>
+            <param><ptype>GLbitfield</ptype> <name>mask</name></param>
+        </command>
+        <command>
             <proto>void <name>glUseProgram</name></proto>
             <param><ptype>GLuint</ptype> <name>program</name></param>
         </command>
@@ -27125,13 +30672,13 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glUseProgramStages</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param><ptype>GLbitfield</ptype> <name>stages</name></param>
+            <param group="UseProgramStageMask"><ptype>GLbitfield</ptype> <name>stages</name></param>
             <param><ptype>GLuint</ptype> <name>program</name></param>
         </command>
         <command>
             <proto>void <name>glUseProgramStagesEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>pipeline</name></param>
-            <param><ptype>GLbitfield</ptype> <name>stages</name></param>
+            <param group="UseProgramStageMask"><ptype>GLbitfield</ptype> <name>stages</name></param>
             <param><ptype>GLuint</ptype> <name>program</name></param>
         </command>
         <command>
@@ -27177,6 +30724,14 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>target</name></param>
             <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
             <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
+        </command>
+        <command>
+            <proto group="vdpauSurfaceNV"><ptype>GLvdpauSurfaceNV</ptype> <name>glVDPAURegisterVideoSurfaceWithPictureStructureNV</name></proto>
+            <param>const void *<name>vdpSurface</name></param>
+            <param><ptype>GLenum</ptype> <name>target</name></param>
+            <param><ptype>GLsizei</ptype> <name>numTextureNames</name></param>
+            <param len="numTextureNames">const <ptype>GLuint</ptype> *<name>textureNames</name></param>
+            <param group="Boolean"><ptype>GLboolean</ptype> <name>isFrameStructure</name></param>
         </command>
         <command>
             <proto>void <name>glVDPAUSurfaceAccessNV</name></proto>
@@ -27512,7 +31067,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
@@ -27521,7 +31076,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribIType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -27529,7 +31084,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -27651,7 +31206,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
@@ -27660,7 +31215,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribIType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -27669,7 +31224,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
@@ -27678,7 +31233,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>vaobj</name></param>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
@@ -27687,7 +31242,7 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLuint</ptype> <name>buffer</name></param>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param group="BufferOffset"><ptype>GLintptr</ptype> <name>offset</name></param>
         </command>
@@ -28527,7 +32082,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
@@ -28535,7 +32090,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
@@ -28803,21 +32358,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribIFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribIType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribIFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribIType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribIPointer</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
         </command>
@@ -28825,7 +32380,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribIPointerEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param group="VertexAttribEnum"><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="COMPSIZE(size,type,stride)">const void *<name>pointer</name></param>
             <alias name="glVertexAttribIPointer"/>
@@ -29036,21 +32591,21 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribLFormat</name></proto>
             <param><ptype>GLuint</ptype> <name>attribindex</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>relativeoffset</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribLFormatNV</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribLType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribLPointer</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="size">const void *<name>pointer</name></param>
         </command>
@@ -29058,7 +32613,7 @@ typedef unsigned int GLhandleARB;
             <proto>void <name>glVertexAttribLPointerEXT</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
             <param len="size">const void *<name>pointer</name></param>
             <alias name="glVertexAttribLPointer"/>
@@ -29066,56 +32621,56 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexAttribP1ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP1uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP2uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP3uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4ui</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexAttribP4uiv</name></proto>
             <param><ptype>GLuint</ptype> <name>index</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexAttribPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param group="Boolean"><ptype>GLboolean</ptype> <name>normalized</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
@@ -29294,37 +32849,37 @@ typedef unsigned int GLhandleARB;
         <command>
             <proto>void <name>glVertexFormatNV</name></proto>
             <param><ptype>GLint</ptype> <name>size</name></param>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLsizei</ptype> <name>stride</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP2ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP2uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP3ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP3uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP4ui</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param><ptype>GLuint</ptype> <name>value</name></param>
         </command>
         <command>
             <proto>void <name>glVertexP4uiv</name></proto>
-            <param><ptype>GLenum</ptype> <name>type</name></param>
+            <param group="VertexPointerType"><ptype>GLenum</ptype> <name>type</name></param>
             <param len="1">const <ptype>GLuint</ptype> *<name>value</name></param>
         </command>
         <command>
@@ -29678,6 +33233,22 @@ typedef unsigned int GLhandleARB;
             <param><ptype>GLenum</ptype> <name>swizzley</name></param>
             <param><ptype>GLenum</ptype> <name>swizzlez</name></param>
             <param><ptype>GLenum</ptype> <name>swizzlew</name></param>
+        </command>
+        <command>
+            <proto>void <name>glWaitSemaphoreEXT</name></proto>
+            <param><ptype>GLuint</ptype> <name>semaphore</name></param>
+            <param><ptype>GLuint</ptype> <name>numBufferBarriers</name></param>
+            <param len="COMPSIZE(numBufferBarriers)">const <ptype>GLuint</ptype> *<name>buffers</name></param>
+            <param><ptype>GLuint</ptype> <name>numTextureBarriers</name></param>
+            <param len="COMPSIZE(numTextureBarriers)">const <ptype>GLuint</ptype> *<name>textures</name></param>
+            <param group="TextureLayout" len="COMPSIZE(numTextureBarriers)">const <ptype>GLenum</ptype> *<name>srcLayouts</name></param>
+        </command>
+        <command>
+            <proto>void <name>glWaitSemaphoreui64NVX</name></proto>
+            <param><ptype>GLuint</ptype> <name>waitGpu</name></param>
+            <param><ptype>GLsizei</ptype> <name>fenceObjectCount</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint</ptype> *<name>semaphoreArray</name></param>
+            <param len="fenceObjectCount">const <ptype>GLuint64</ptype> *<name>fenceValueArray</name></param>
         </command>
         <command>
             <proto>void <name>glWaitSync</name></proto>
@@ -30124,6 +33695,48 @@ typedef unsigned int GLhandleARB;
             <param group="VertexShaderWriteMaskEXT"><ptype>GLenum</ptype> <name>outZ</name></param>
             <param group="VertexShaderWriteMaskEXT"><ptype>GLenum</ptype> <name>outW</name></param>
         </command>
+        <command>
+            <proto>void <name>glDrawVkImageNV</name></proto>
+            <param><ptype>GLuint64</ptype> <name>vkImage</name></param>
+            <param><ptype>GLuint</ptype> <name>sampler</name></param>
+            <param><ptype>GLfloat</ptype> <name>x0</name></param>
+            <param><ptype>GLfloat</ptype> <name>y0</name></param>
+            <param><ptype>GLfloat</ptype> <name>x1</name></param>
+            <param><ptype>GLfloat</ptype> <name>y1</name></param>
+            <param><ptype>GLfloat</ptype> <name>z</name></param>
+            <param><ptype>GLfloat</ptype> <name>s0</name></param>
+            <param><ptype>GLfloat</ptype> <name>t0</name></param>
+            <param><ptype>GLfloat</ptype> <name>s1</name></param>
+            <param><ptype>GLfloat</ptype> <name>t1</name></param>
+        </command>
+        <command>
+            <proto><ptype>GLVULKANPROCNV</ptype> <name>glGetVkProcAddrNV</name></proto>
+            <param len="COMPSIZE(name)">const <ptype>GLchar</ptype> *<name>name</name></param>
+        </command>
+        <command>
+            <proto>void <name>glWaitVkSemaphoreNV</name></proto>
+            <param><ptype>GLuint64</ptype> <name>vkSemaphore</name></param>
+        </command>
+        <command>
+            <proto>void <name>glSignalVkSemaphoreNV</name></proto>
+            <param><ptype>GLuint64</ptype> <name>vkSemaphore</name></param>
+        </command>
+        <command>
+            <proto>void <name>glSignalVkFenceNV</name></proto>
+            <param><ptype>GLuint64</ptype> <name>vkFence</name></param>
+        </command>
+         <command>
+            <proto>void <name>glFramebufferParameteriMESA</name></proto>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param><ptype>GLint</ptype> <name>param</name></param>
+        </command>
+        <command>
+            <proto>void <name>glGetFramebufferParameterivMESA</name></proto>
+            <param group="FramebufferTarget"><ptype>GLenum</ptype> <name>target</name></param>
+            <param group="FramebufferAttachmentParameterName"><ptype>GLenum</ptype> <name>pname</name></param>
+            <param len="COMPSIZE(pname)"><ptype>GLint</ptype> *<name>params</name></param>
+        </command>
 
     </commands>
 
@@ -30131,6 +33744,430 @@ typedef unsigned int GLhandleARB;
     <feature api="gl" name="GL_VERSION_1_0" number="1.0">
         <require>
             <type name="GLvoid" comment="No longer used in headers"/>
+            <enum name="GL_DEPTH_BUFFER_BIT"/>
+            <enum name="GL_STENCIL_BUFFER_BIT"/>
+            <enum name="GL_COLOR_BUFFER_BIT"/>
+            <enum name="GL_FALSE"/>
+            <enum name="GL_TRUE"/>
+            <enum name="GL_POINTS"/>
+            <enum name="GL_LINES"/>
+            <enum name="GL_LINE_LOOP"/>
+            <enum name="GL_LINE_STRIP"/>
+            <enum name="GL_TRIANGLES"/>
+            <enum name="GL_TRIANGLE_STRIP"/>
+            <enum name="GL_TRIANGLE_FAN"/>
+            <enum name="GL_QUADS"/>
+            <enum name="GL_NEVER"/>
+            <enum name="GL_LESS"/>
+            <enum name="GL_EQUAL"/>
+            <enum name="GL_LEQUAL"/>
+            <enum name="GL_GREATER"/>
+            <enum name="GL_NOTEQUAL"/>
+            <enum name="GL_GEQUAL"/>
+            <enum name="GL_ALWAYS"/>
+            <enum name="GL_ZERO"/>
+            <enum name="GL_ONE"/>
+            <enum name="GL_SRC_COLOR"/>
+            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
+            <enum name="GL_SRC_ALPHA"/>
+            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
+            <enum name="GL_DST_ALPHA"/>
+            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
+            <enum name="GL_DST_COLOR"/>
+            <enum name="GL_ONE_MINUS_DST_COLOR"/>
+            <enum name="GL_SRC_ALPHA_SATURATE"/>
+            <enum name="GL_NONE"/>
+            <enum name="GL_FRONT_LEFT"/>
+            <enum name="GL_FRONT_RIGHT"/>
+            <enum name="GL_BACK_LEFT"/>
+            <enum name="GL_BACK_RIGHT"/>
+            <enum name="GL_FRONT"/>
+            <enum name="GL_BACK"/>
+            <enum name="GL_LEFT"/>
+            <enum name="GL_RIGHT"/>
+            <enum name="GL_FRONT_AND_BACK"/>
+            <enum name="GL_NO_ERROR"/>
+            <enum name="GL_INVALID_ENUM"/>
+            <enum name="GL_INVALID_VALUE"/>
+            <enum name="GL_INVALID_OPERATION"/>
+            <enum name="GL_OUT_OF_MEMORY"/>
+            <enum name="GL_CW"/>
+            <enum name="GL_CCW"/>
+            <enum name="GL_POINT_SIZE"/>
+            <enum name="GL_POINT_SIZE_RANGE"/>
+            <enum name="GL_POINT_SIZE_GRANULARITY"/>
+            <enum name="GL_LINE_SMOOTH"/>
+            <enum name="GL_LINE_WIDTH"/>
+            <enum name="GL_LINE_WIDTH_RANGE"/>
+            <enum name="GL_LINE_WIDTH_GRANULARITY"/>
+            <enum name="GL_POLYGON_MODE"/>
+            <enum name="GL_POLYGON_SMOOTH"/>
+            <enum name="GL_CULL_FACE"/>
+            <enum name="GL_CULL_FACE_MODE"/>
+            <enum name="GL_FRONT_FACE"/>
+            <enum name="GL_DEPTH_RANGE"/>
+            <enum name="GL_DEPTH_TEST"/>
+            <enum name="GL_DEPTH_WRITEMASK"/>
+            <enum name="GL_DEPTH_CLEAR_VALUE"/>
+            <enum name="GL_DEPTH_FUNC"/>
+            <enum name="GL_STENCIL_TEST"/>
+            <enum name="GL_STENCIL_CLEAR_VALUE"/>
+            <enum name="GL_STENCIL_FUNC"/>
+            <enum name="GL_STENCIL_VALUE_MASK"/>
+            <enum name="GL_STENCIL_FAIL"/>
+            <enum name="GL_STENCIL_PASS_DEPTH_FAIL"/>
+            <enum name="GL_STENCIL_PASS_DEPTH_PASS"/>
+            <enum name="GL_STENCIL_REF"/>
+            <enum name="GL_STENCIL_WRITEMASK"/>
+            <enum name="GL_VIEWPORT"/>
+            <enum name="GL_DITHER"/>
+            <enum name="GL_BLEND_DST"/>
+            <enum name="GL_BLEND_SRC"/>
+            <enum name="GL_BLEND"/>
+            <enum name="GL_LOGIC_OP_MODE"/>
+            <enum name="GL_DRAW_BUFFER"/>
+            <enum name="GL_READ_BUFFER"/>
+            <enum name="GL_SCISSOR_BOX"/>
+            <enum name="GL_SCISSOR_TEST"/>
+            <enum name="GL_COLOR_CLEAR_VALUE"/>
+            <enum name="GL_COLOR_WRITEMASK"/>
+            <enum name="GL_DOUBLEBUFFER"/>
+            <enum name="GL_STEREO"/>
+            <enum name="GL_LINE_SMOOTH_HINT"/>
+            <enum name="GL_POLYGON_SMOOTH_HINT"/>
+            <enum name="GL_UNPACK_SWAP_BYTES"/>
+            <enum name="GL_UNPACK_LSB_FIRST"/>
+            <enum name="GL_UNPACK_ROW_LENGTH"/>
+            <enum name="GL_UNPACK_SKIP_ROWS"/>
+            <enum name="GL_UNPACK_SKIP_PIXELS"/>
+            <enum name="GL_UNPACK_ALIGNMENT"/>
+            <enum name="GL_PACK_SWAP_BYTES"/>
+            <enum name="GL_PACK_LSB_FIRST"/>
+            <enum name="GL_PACK_ROW_LENGTH"/>
+            <enum name="GL_PACK_SKIP_ROWS"/>
+            <enum name="GL_PACK_SKIP_PIXELS"/>
+            <enum name="GL_PACK_ALIGNMENT"/>
+            <enum name="GL_MAX_TEXTURE_SIZE"/>
+            <enum name="GL_MAX_VIEWPORT_DIMS"/>
+            <enum name="GL_SUBPIXEL_BITS"/>
+            <enum name="GL_TEXTURE_1D"/>
+            <enum name="GL_TEXTURE_2D"/>
+            <enum name="GL_TEXTURE_WIDTH"/>
+            <enum name="GL_TEXTURE_HEIGHT"/>
+            <enum name="GL_TEXTURE_BORDER_COLOR"/>
+            <enum name="GL_DONT_CARE"/>
+            <enum name="GL_FASTEST"/>
+            <enum name="GL_NICEST"/>
+            <enum name="GL_BYTE"/>
+            <enum name="GL_UNSIGNED_BYTE"/>
+            <enum name="GL_SHORT"/>
+            <enum name="GL_UNSIGNED_SHORT"/>
+            <enum name="GL_INT"/>
+            <enum name="GL_UNSIGNED_INT"/>
+            <enum name="GL_FLOAT"/>
+            <enum name="GL_STACK_OVERFLOW"/>
+            <enum name="GL_STACK_UNDERFLOW"/>
+            <enum name="GL_CLEAR"/>
+            <enum name="GL_AND"/>
+            <enum name="GL_AND_REVERSE"/>
+            <enum name="GL_COPY"/>
+            <enum name="GL_AND_INVERTED"/>
+            <enum name="GL_NOOP"/>
+            <enum name="GL_XOR"/>
+            <enum name="GL_OR"/>
+            <enum name="GL_NOR"/>
+            <enum name="GL_EQUIV"/>
+            <enum name="GL_INVERT"/>
+            <enum name="GL_OR_REVERSE"/>
+            <enum name="GL_COPY_INVERTED"/>
+            <enum name="GL_OR_INVERTED"/>
+            <enum name="GL_NAND"/>
+            <enum name="GL_SET"/>
+            <enum name="GL_TEXTURE"/>
+            <enum name="GL_COLOR"/>
+            <enum name="GL_DEPTH"/>
+            <enum name="GL_STENCIL"/>
+            <enum name="GL_STENCIL_INDEX"/>
+            <enum name="GL_DEPTH_COMPONENT"/>
+            <enum name="GL_RED"/>
+            <enum name="GL_GREEN"/>
+            <enum name="GL_BLUE"/>
+            <enum name="GL_ALPHA"/>
+            <enum name="GL_RGB"/>
+            <enum name="GL_RGBA"/>
+            <enum name="GL_POINT"/>
+            <enum name="GL_LINE"/>
+            <enum name="GL_FILL"/>
+            <enum name="GL_KEEP"/>
+            <enum name="GL_REPLACE"/>
+            <enum name="GL_INCR"/>
+            <enum name="GL_DECR"/>
+            <enum name="GL_VENDOR"/>
+            <enum name="GL_RENDERER"/>
+            <enum name="GL_VERSION"/>
+            <enum name="GL_EXTENSIONS"/>
+            <enum name="GL_NEAREST"/>
+            <enum name="GL_LINEAR"/>
+            <enum name="GL_NEAREST_MIPMAP_NEAREST"/>
+            <enum name="GL_LINEAR_MIPMAP_NEAREST"/>
+            <enum name="GL_NEAREST_MIPMAP_LINEAR"/>
+            <enum name="GL_LINEAR_MIPMAP_LINEAR"/>
+            <enum name="GL_TEXTURE_MAG_FILTER"/>
+            <enum name="GL_TEXTURE_MIN_FILTER"/>
+            <enum name="GL_TEXTURE_WRAP_S"/>
+            <enum name="GL_TEXTURE_WRAP_T"/>
+            <enum name="GL_REPEAT"/>
+            <enum name="GL_CURRENT_BIT"/>
+            <enum name="GL_POINT_BIT"/>
+            <enum name="GL_LINE_BIT"/>
+            <enum name="GL_POLYGON_BIT"/>
+            <enum name="GL_POLYGON_STIPPLE_BIT"/>
+            <enum name="GL_PIXEL_MODE_BIT"/>
+            <enum name="GL_LIGHTING_BIT"/>
+            <enum name="GL_FOG_BIT"/>
+            <enum name="GL_ACCUM_BUFFER_BIT"/>
+            <enum name="GL_VIEWPORT_BIT"/>
+            <enum name="GL_TRANSFORM_BIT"/>
+            <enum name="GL_ENABLE_BIT"/>
+            <enum name="GL_HINT_BIT"/>
+            <enum name="GL_EVAL_BIT"/>
+            <enum name="GL_LIST_BIT"/>
+            <enum name="GL_TEXTURE_BIT"/>
+            <enum name="GL_SCISSOR_BIT"/>
+            <enum name="GL_ALL_ATTRIB_BITS"/>
+            <enum name="GL_QUAD_STRIP"/>
+            <enum name="GL_POLYGON"/>
+            <enum name="GL_ACCUM"/>
+            <enum name="GL_LOAD"/>
+            <enum name="GL_RETURN"/>
+            <enum name="GL_MULT"/>
+            <enum name="GL_ADD"/>
+            <enum name="GL_AUX0"/>
+            <enum name="GL_AUX1"/>
+            <enum name="GL_AUX2"/>
+            <enum name="GL_AUX3"/>
+            <enum name="GL_2D"/>
+            <enum name="GL_3D"/>
+            <enum name="GL_3D_COLOR"/>
+            <enum name="GL_3D_COLOR_TEXTURE"/>
+            <enum name="GL_4D_COLOR_TEXTURE"/>
+            <enum name="GL_PASS_THROUGH_TOKEN"/>
+            <enum name="GL_POINT_TOKEN"/>
+            <enum name="GL_LINE_TOKEN"/>
+            <enum name="GL_POLYGON_TOKEN"/>
+            <enum name="GL_BITMAP_TOKEN"/>
+            <enum name="GL_DRAW_PIXEL_TOKEN"/>
+            <enum name="GL_COPY_PIXEL_TOKEN"/>
+            <enum name="GL_LINE_RESET_TOKEN"/>
+            <enum name="GL_EXP"/>
+            <enum name="GL_EXP2"/>
+            <enum name="GL_COEFF"/>
+            <enum name="GL_ORDER"/>
+            <enum name="GL_DOMAIN"/>
+            <enum name="GL_PIXEL_MAP_I_TO_I"/>
+            <enum name="GL_PIXEL_MAP_S_TO_S"/>
+            <enum name="GL_PIXEL_MAP_I_TO_R"/>
+            <enum name="GL_PIXEL_MAP_I_TO_G"/>
+            <enum name="GL_PIXEL_MAP_I_TO_B"/>
+            <enum name="GL_PIXEL_MAP_I_TO_A"/>
+            <enum name="GL_PIXEL_MAP_R_TO_R"/>
+            <enum name="GL_PIXEL_MAP_G_TO_G"/>
+            <enum name="GL_PIXEL_MAP_B_TO_B"/>
+            <enum name="GL_PIXEL_MAP_A_TO_A"/>
+            <enum name="GL_CURRENT_COLOR"/>
+            <enum name="GL_CURRENT_INDEX"/>
+            <enum name="GL_CURRENT_NORMAL"/>
+            <enum name="GL_CURRENT_TEXTURE_COORDS"/>
+            <enum name="GL_CURRENT_RASTER_COLOR"/>
+            <enum name="GL_CURRENT_RASTER_INDEX"/>
+            <enum name="GL_CURRENT_RASTER_TEXTURE_COORDS"/>
+            <enum name="GL_CURRENT_RASTER_POSITION"/>
+            <enum name="GL_CURRENT_RASTER_POSITION_VALID"/>
+            <enum name="GL_CURRENT_RASTER_DISTANCE"/>
+            <enum name="GL_POINT_SMOOTH"/>
+            <enum name="GL_LINE_STIPPLE"/>
+            <enum name="GL_LINE_STIPPLE_PATTERN"/>
+            <enum name="GL_LINE_STIPPLE_REPEAT"/>
+            <enum name="GL_LIST_MODE"/>
+            <enum name="GL_MAX_LIST_NESTING"/>
+            <enum name="GL_LIST_BASE"/>
+            <enum name="GL_LIST_INDEX"/>
+            <enum name="GL_POLYGON_STIPPLE"/>
+            <enum name="GL_EDGE_FLAG"/>
+            <enum name="GL_LIGHTING"/>
+            <enum name="GL_LIGHT_MODEL_LOCAL_VIEWER"/>
+            <enum name="GL_LIGHT_MODEL_TWO_SIDE"/>
+            <enum name="GL_LIGHT_MODEL_AMBIENT"/>
+            <enum name="GL_SHADE_MODEL"/>
+            <enum name="GL_COLOR_MATERIAL_FACE"/>
+            <enum name="GL_COLOR_MATERIAL_PARAMETER"/>
+            <enum name="GL_COLOR_MATERIAL"/>
+            <enum name="GL_FOG"/>
+            <enum name="GL_FOG_INDEX"/>
+            <enum name="GL_FOG_DENSITY"/>
+            <enum name="GL_FOG_START"/>
+            <enum name="GL_FOG_END"/>
+            <enum name="GL_FOG_MODE"/>
+            <enum name="GL_FOG_COLOR"/>
+            <enum name="GL_ACCUM_CLEAR_VALUE"/>
+            <enum name="GL_MATRIX_MODE"/>
+            <enum name="GL_NORMALIZE"/>
+            <enum name="GL_MODELVIEW_STACK_DEPTH"/>
+            <enum name="GL_PROJECTION_STACK_DEPTH"/>
+            <enum name="GL_TEXTURE_STACK_DEPTH"/>
+            <enum name="GL_MODELVIEW_MATRIX"/>
+            <enum name="GL_PROJECTION_MATRIX"/>
+            <enum name="GL_TEXTURE_MATRIX"/>
+            <enum name="GL_ATTRIB_STACK_DEPTH"/>
+            <enum name="GL_ALPHA_TEST"/>
+            <enum name="GL_ALPHA_TEST_FUNC"/>
+            <enum name="GL_ALPHA_TEST_REF"/>
+            <enum name="GL_LOGIC_OP"/>
+            <enum name="GL_AUX_BUFFERS"/>
+            <enum name="GL_INDEX_CLEAR_VALUE"/>
+            <enum name="GL_INDEX_WRITEMASK"/>
+            <enum name="GL_INDEX_MODE"/>
+            <enum name="GL_RGBA_MODE"/>
+            <enum name="GL_RENDER_MODE"/>
+            <enum name="GL_PERSPECTIVE_CORRECTION_HINT"/>
+            <enum name="GL_POINT_SMOOTH_HINT"/>
+            <enum name="GL_FOG_HINT"/>
+            <enum name="GL_TEXTURE_GEN_S"/>
+            <enum name="GL_TEXTURE_GEN_T"/>
+            <enum name="GL_TEXTURE_GEN_R"/>
+            <enum name="GL_TEXTURE_GEN_Q"/>
+            <enum name="GL_PIXEL_MAP_I_TO_I_SIZE"/>
+            <enum name="GL_PIXEL_MAP_S_TO_S_SIZE"/>
+            <enum name="GL_PIXEL_MAP_I_TO_R_SIZE"/>
+            <enum name="GL_PIXEL_MAP_I_TO_G_SIZE"/>
+            <enum name="GL_PIXEL_MAP_I_TO_B_SIZE"/>
+            <enum name="GL_PIXEL_MAP_I_TO_A_SIZE"/>
+            <enum name="GL_PIXEL_MAP_R_TO_R_SIZE"/>
+            <enum name="GL_PIXEL_MAP_G_TO_G_SIZE"/>
+            <enum name="GL_PIXEL_MAP_B_TO_B_SIZE"/>
+            <enum name="GL_PIXEL_MAP_A_TO_A_SIZE"/>
+            <enum name="GL_MAP_COLOR"/>
+            <enum name="GL_MAP_STENCIL"/>
+            <enum name="GL_INDEX_SHIFT"/>
+            <enum name="GL_INDEX_OFFSET"/>
+            <enum name="GL_RED_SCALE"/>
+            <enum name="GL_RED_BIAS"/>
+            <enum name="GL_ZOOM_X"/>
+            <enum name="GL_ZOOM_Y"/>
+            <enum name="GL_GREEN_SCALE"/>
+            <enum name="GL_GREEN_BIAS"/>
+            <enum name="GL_BLUE_SCALE"/>
+            <enum name="GL_BLUE_BIAS"/>
+            <enum name="GL_ALPHA_SCALE"/>
+            <enum name="GL_ALPHA_BIAS"/>
+            <enum name="GL_DEPTH_SCALE"/>
+            <enum name="GL_DEPTH_BIAS"/>
+            <enum name="GL_MAX_EVAL_ORDER"/>
+            <enum name="GL_MAX_LIGHTS"/>
+            <enum name="GL_MAX_CLIP_PLANES"/>
+            <enum name="GL_MAX_PIXEL_MAP_TABLE"/>
+            <enum name="GL_MAX_ATTRIB_STACK_DEPTH"/>
+            <enum name="GL_MAX_MODELVIEW_STACK_DEPTH"/>
+            <enum name="GL_MAX_NAME_STACK_DEPTH"/>
+            <enum name="GL_MAX_PROJECTION_STACK_DEPTH"/>
+            <enum name="GL_MAX_TEXTURE_STACK_DEPTH"/>
+            <enum name="GL_INDEX_BITS"/>
+            <enum name="GL_RED_BITS"/>
+            <enum name="GL_GREEN_BITS"/>
+            <enum name="GL_BLUE_BITS"/>
+            <enum name="GL_ALPHA_BITS"/>
+            <enum name="GL_DEPTH_BITS"/>
+            <enum name="GL_STENCIL_BITS"/>
+            <enum name="GL_ACCUM_RED_BITS"/>
+            <enum name="GL_ACCUM_GREEN_BITS"/>
+            <enum name="GL_ACCUM_BLUE_BITS"/>
+            <enum name="GL_ACCUM_ALPHA_BITS"/>
+            <enum name="GL_NAME_STACK_DEPTH"/>
+            <enum name="GL_AUTO_NORMAL"/>
+            <enum name="GL_MAP1_COLOR_4"/>
+            <enum name="GL_MAP1_INDEX"/>
+            <enum name="GL_MAP1_NORMAL"/>
+            <enum name="GL_MAP1_TEXTURE_COORD_1"/>
+            <enum name="GL_MAP1_TEXTURE_COORD_2"/>
+            <enum name="GL_MAP1_TEXTURE_COORD_3"/>
+            <enum name="GL_MAP1_TEXTURE_COORD_4"/>
+            <enum name="GL_MAP1_VERTEX_3"/>
+            <enum name="GL_MAP1_VERTEX_4"/>
+            <enum name="GL_MAP2_COLOR_4"/>
+            <enum name="GL_MAP2_INDEX"/>
+            <enum name="GL_MAP2_NORMAL"/>
+            <enum name="GL_MAP2_TEXTURE_COORD_1"/>
+            <enum name="GL_MAP2_TEXTURE_COORD_2"/>
+            <enum name="GL_MAP2_TEXTURE_COORD_3"/>
+            <enum name="GL_MAP2_TEXTURE_COORD_4"/>
+            <enum name="GL_MAP2_VERTEX_3"/>
+            <enum name="GL_MAP2_VERTEX_4"/>
+            <enum name="GL_MAP1_GRID_DOMAIN"/>
+            <enum name="GL_MAP1_GRID_SEGMENTS"/>
+            <enum name="GL_MAP2_GRID_DOMAIN"/>
+            <enum name="GL_MAP2_GRID_SEGMENTS"/>
+            <enum name="GL_TEXTURE_COMPONENTS"/>
+            <enum name="GL_TEXTURE_BORDER"/>
+            <enum name="GL_AMBIENT"/>
+            <enum name="GL_DIFFUSE"/>
+            <enum name="GL_SPECULAR"/>
+            <enum name="GL_POSITION"/>
+            <enum name="GL_SPOT_DIRECTION"/>
+            <enum name="GL_SPOT_EXPONENT"/>
+            <enum name="GL_SPOT_CUTOFF"/>
+            <enum name="GL_CONSTANT_ATTENUATION"/>
+            <enum name="GL_LINEAR_ATTENUATION"/>
+            <enum name="GL_QUADRATIC_ATTENUATION"/>
+            <enum name="GL_COMPILE"/>
+            <enum name="GL_COMPILE_AND_EXECUTE"/>
+            <enum name="GL_2_BYTES"/>
+            <enum name="GL_3_BYTES"/>
+            <enum name="GL_4_BYTES"/>
+            <enum name="GL_EMISSION"/>
+            <enum name="GL_SHININESS"/>
+            <enum name="GL_AMBIENT_AND_DIFFUSE"/>
+            <enum name="GL_COLOR_INDEXES"/>
+            <enum name="GL_MODELVIEW"/>
+            <enum name="GL_PROJECTION"/>
+            <enum name="GL_COLOR_INDEX"/>
+            <enum name="GL_LUMINANCE"/>
+            <enum name="GL_LUMINANCE_ALPHA"/>
+            <enum name="GL_BITMAP"/>
+            <enum name="GL_RENDER"/>
+            <enum name="GL_FEEDBACK"/>
+            <enum name="GL_SELECT"/>
+            <enum name="GL_FLAT"/>
+            <enum name="GL_SMOOTH"/>
+            <enum name="GL_S"/>
+            <enum name="GL_T"/>
+            <enum name="GL_R"/>
+            <enum name="GL_Q"/>
+            <enum name="GL_MODULATE"/>
+            <enum name="GL_DECAL"/>
+            <enum name="GL_TEXTURE_ENV_MODE"/>
+            <enum name="GL_TEXTURE_ENV_COLOR"/>
+            <enum name="GL_TEXTURE_ENV"/>
+            <enum name="GL_EYE_LINEAR"/>
+            <enum name="GL_OBJECT_LINEAR"/>
+            <enum name="GL_SPHERE_MAP"/>
+            <enum name="GL_TEXTURE_GEN_MODE"/>
+            <enum name="GL_OBJECT_PLANE"/>
+            <enum name="GL_EYE_PLANE"/>
+            <enum name="GL_CLAMP"/>
+            <enum name="GL_CLIP_PLANE0"/>
+            <enum name="GL_CLIP_PLANE1"/>
+            <enum name="GL_CLIP_PLANE2"/>
+            <enum name="GL_CLIP_PLANE3"/>
+            <enum name="GL_CLIP_PLANE4"/>
+            <enum name="GL_CLIP_PLANE5"/>
+            <enum name="GL_LIGHT0"/>
+            <enum name="GL_LIGHT1"/>
+            <enum name="GL_LIGHT2"/>
+            <enum name="GL_LIGHT3"/>
+            <enum name="GL_LIGHT4"/>
+            <enum name="GL_LIGHT5"/>
+            <enum name="GL_LIGHT6"/>
+            <enum name="GL_LIGHT7"/>
             <command name="glCullFace"/>
             <command name="glFrontFace"/>
             <command name="glHint"/>
@@ -30443,116 +34480,7 @@ typedef unsigned int GLhandleARB;
         <require>
             <type name="GLclampf" comment="No longer used in GL 1.1, but still defined in Mesa gl.h"/>
             <type name="GLclampd" comment="No longer used in GL 1.1, but still defined in Mesa gl.h"/>
-            <!-- Many of these are really VERSION_1_0 enums -->
-            <enum name="GL_DEPTH_BUFFER_BIT"/>
-            <enum name="GL_STENCIL_BUFFER_BIT"/>
-            <enum name="GL_COLOR_BUFFER_BIT"/>
-            <enum name="GL_FALSE"/>
-            <enum name="GL_TRUE"/>
-            <enum name="GL_POINTS"/>
-            <enum name="GL_LINES"/>
-            <enum name="GL_LINE_LOOP"/>
-            <enum name="GL_LINE_STRIP"/>
-            <enum name="GL_TRIANGLES"/>
-            <enum name="GL_TRIANGLE_STRIP"/>
-            <enum name="GL_TRIANGLE_FAN"/>
-            <enum name="GL_QUADS"/>
-            <enum name="GL_NEVER"/>
-            <enum name="GL_LESS"/>
-            <enum name="GL_EQUAL"/>
-            <enum name="GL_LEQUAL"/>
-            <enum name="GL_GREATER"/>
-            <enum name="GL_NOTEQUAL"/>
-            <enum name="GL_GEQUAL"/>
-            <enum name="GL_ALWAYS"/>
-            <enum name="GL_ZERO"/>
-            <enum name="GL_ONE"/>
-            <enum name="GL_SRC_COLOR"/>
-            <enum name="GL_ONE_MINUS_SRC_COLOR"/>
-            <enum name="GL_SRC_ALPHA"/>
-            <enum name="GL_ONE_MINUS_SRC_ALPHA"/>
-            <enum name="GL_DST_ALPHA"/>
-            <enum name="GL_ONE_MINUS_DST_ALPHA"/>
-            <enum name="GL_DST_COLOR"/>
-            <enum name="GL_ONE_MINUS_DST_COLOR"/>
-            <enum name="GL_SRC_ALPHA_SATURATE"/>
-            <enum name="GL_NONE"/>
-            <enum name="GL_FRONT_LEFT"/>
-            <enum name="GL_FRONT_RIGHT"/>
-            <enum name="GL_BACK_LEFT"/>
-            <enum name="GL_BACK_RIGHT"/>
-            <enum name="GL_FRONT"/>
-            <enum name="GL_BACK"/>
-            <enum name="GL_LEFT"/>
-            <enum name="GL_RIGHT"/>
-            <enum name="GL_FRONT_AND_BACK"/>
-            <enum name="GL_NO_ERROR"/>
-            <enum name="GL_INVALID_ENUM"/>
-            <enum name="GL_INVALID_VALUE"/>
-            <enum name="GL_INVALID_OPERATION"/>
-            <enum name="GL_OUT_OF_MEMORY"/>
-            <enum name="GL_CW"/>
-            <enum name="GL_CCW"/>
-            <enum name="GL_POINT_SIZE"/>
-            <enum name="GL_POINT_SIZE_RANGE"/>
-            <enum name="GL_POINT_SIZE_GRANULARITY"/>
-            <enum name="GL_LINE_SMOOTH"/>
-            <enum name="GL_LINE_WIDTH"/>
-            <enum name="GL_LINE_WIDTH_RANGE"/>
-            <enum name="GL_LINE_WIDTH_GRANULARITY"/>
-            <enum name="GL_POLYGON_MODE"/>
-            <enum name="GL_POLYGON_SMOOTH"/>
-            <enum name="GL_CULL_FACE"/>
-            <enum name="GL_CULL_FACE_MODE"/>
-            <enum name="GL_FRONT_FACE"/>
-            <enum name="GL_DEPTH_RANGE"/>
-            <enum name="GL_DEPTH_TEST"/>
-            <enum name="GL_DEPTH_WRITEMASK"/>
-            <enum name="GL_DEPTH_CLEAR_VALUE"/>
-            <enum name="GL_DEPTH_FUNC"/>
-            <enum name="GL_STENCIL_TEST"/>
-            <enum name="GL_STENCIL_CLEAR_VALUE"/>
-            <enum name="GL_STENCIL_FUNC"/>
-            <enum name="GL_STENCIL_VALUE_MASK"/>
-            <enum name="GL_STENCIL_FAIL"/>
-            <enum name="GL_STENCIL_PASS_DEPTH_FAIL"/>
-            <enum name="GL_STENCIL_PASS_DEPTH_PASS"/>
-            <enum name="GL_STENCIL_REF"/>
-            <enum name="GL_STENCIL_WRITEMASK"/>
-            <enum name="GL_VIEWPORT"/>
-            <enum name="GL_DITHER"/>
-            <enum name="GL_BLEND_DST"/>
-            <enum name="GL_BLEND_SRC"/>
-            <enum name="GL_BLEND"/>
-            <enum name="GL_LOGIC_OP_MODE"/>
             <enum name="GL_COLOR_LOGIC_OP"/>
-            <enum name="GL_DRAW_BUFFER"/>
-            <enum name="GL_READ_BUFFER"/>
-            <enum name="GL_SCISSOR_BOX"/>
-            <enum name="GL_SCISSOR_TEST"/>
-            <enum name="GL_COLOR_CLEAR_VALUE"/>
-            <enum name="GL_COLOR_WRITEMASK"/>
-            <enum name="GL_DOUBLEBUFFER"/>
-            <enum name="GL_STEREO"/>
-            <enum name="GL_LINE_SMOOTH_HINT"/>
-            <enum name="GL_POLYGON_SMOOTH_HINT"/>
-            <enum name="GL_UNPACK_SWAP_BYTES"/>
-            <enum name="GL_UNPACK_LSB_FIRST"/>
-            <enum name="GL_UNPACK_ROW_LENGTH"/>
-            <enum name="GL_UNPACK_SKIP_ROWS"/>
-            <enum name="GL_UNPACK_SKIP_PIXELS"/>
-            <enum name="GL_UNPACK_ALIGNMENT"/>
-            <enum name="GL_PACK_SWAP_BYTES"/>
-            <enum name="GL_PACK_LSB_FIRST"/>
-            <enum name="GL_PACK_ROW_LENGTH"/>
-            <enum name="GL_PACK_SKIP_ROWS"/>
-            <enum name="GL_PACK_SKIP_PIXELS"/>
-            <enum name="GL_PACK_ALIGNMENT"/>
-            <enum name="GL_MAX_TEXTURE_SIZE"/>
-            <enum name="GL_MAX_VIEWPORT_DIMS"/>
-            <enum name="GL_SUBPIXEL_BITS"/>
-            <enum name="GL_TEXTURE_1D"/>
-            <enum name="GL_TEXTURE_2D"/>
             <enum name="GL_POLYGON_OFFSET_UNITS"/>
             <enum name="GL_POLYGON_OFFSET_POINT"/>
             <enum name="GL_POLYGON_OFFSET_LINE"/>
@@ -30560,79 +34488,14 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_POLYGON_OFFSET_FACTOR"/>
             <enum name="GL_TEXTURE_BINDING_1D"/>
             <enum name="GL_TEXTURE_BINDING_2D"/>
-            <enum name="GL_TEXTURE_WIDTH"/>
-            <enum name="GL_TEXTURE_HEIGHT"/>
             <enum name="GL_TEXTURE_INTERNAL_FORMAT"/>
-            <enum name="GL_TEXTURE_BORDER_COLOR"/>
             <enum name="GL_TEXTURE_RED_SIZE"/>
             <enum name="GL_TEXTURE_GREEN_SIZE"/>
             <enum name="GL_TEXTURE_BLUE_SIZE"/>
             <enum name="GL_TEXTURE_ALPHA_SIZE"/>
-            <enum name="GL_DONT_CARE"/>
-            <enum name="GL_FASTEST"/>
-            <enum name="GL_NICEST"/>
-            <enum name="GL_BYTE"/>
-            <enum name="GL_UNSIGNED_BYTE"/>
-            <enum name="GL_SHORT"/>
-            <enum name="GL_UNSIGNED_SHORT"/>
-            <enum name="GL_INT"/>
-            <enum name="GL_UNSIGNED_INT"/>
-            <enum name="GL_FLOAT"/>
             <enum name="GL_DOUBLE"/>
-            <enum name="GL_STACK_OVERFLOW"/>
-            <enum name="GL_STACK_UNDERFLOW"/>
-            <enum name="GL_CLEAR"/>
-            <enum name="GL_AND"/>
-            <enum name="GL_AND_REVERSE"/>
-            <enum name="GL_COPY"/>
-            <enum name="GL_AND_INVERTED"/>
-            <enum name="GL_NOOP"/>
-            <enum name="GL_XOR"/>
-            <enum name="GL_OR"/>
-            <enum name="GL_NOR"/>
-            <enum name="GL_EQUIV"/>
-            <enum name="GL_INVERT"/>
-            <enum name="GL_OR_REVERSE"/>
-            <enum name="GL_COPY_INVERTED"/>
-            <enum name="GL_OR_INVERTED"/>
-            <enum name="GL_NAND"/>
-            <enum name="GL_SET"/>
-            <enum name="GL_TEXTURE"/>
-            <enum name="GL_COLOR"/>
-            <enum name="GL_DEPTH"/>
-            <enum name="GL_STENCIL"/>
-            <enum name="GL_STENCIL_INDEX"/>
-            <enum name="GL_DEPTH_COMPONENT"/>
-            <enum name="GL_RED"/>
-            <enum name="GL_GREEN"/>
-            <enum name="GL_BLUE"/>
-            <enum name="GL_ALPHA"/>
-            <enum name="GL_RGB"/>
-            <enum name="GL_RGBA"/>
-            <enum name="GL_POINT"/>
-            <enum name="GL_LINE"/>
-            <enum name="GL_FILL"/>
-            <enum name="GL_KEEP"/>
-            <enum name="GL_REPLACE"/>
-            <enum name="GL_INCR"/>
-            <enum name="GL_DECR"/>
-            <enum name="GL_VENDOR"/>
-            <enum name="GL_RENDERER"/>
-            <enum name="GL_VERSION"/>
-            <enum name="GL_EXTENSIONS"/>
-            <enum name="GL_NEAREST"/>
-            <enum name="GL_LINEAR"/>
-            <enum name="GL_NEAREST_MIPMAP_NEAREST"/>
-            <enum name="GL_LINEAR_MIPMAP_NEAREST"/>
-            <enum name="GL_NEAREST_MIPMAP_LINEAR"/>
-            <enum name="GL_LINEAR_MIPMAP_LINEAR"/>
-            <enum name="GL_TEXTURE_MAG_FILTER"/>
-            <enum name="GL_TEXTURE_MIN_FILTER"/>
-            <enum name="GL_TEXTURE_WRAP_S"/>
-            <enum name="GL_TEXTURE_WRAP_T"/>
             <enum name="GL_PROXY_TEXTURE_1D"/>
             <enum name="GL_PROXY_TEXTURE_2D"/>
-            <enum name="GL_REPEAT"/>
             <enum name="GL_R3_G3_B2"/>
             <enum name="GL_RGB4"/>
             <enum name="GL_RGB5"/>
@@ -30647,66 +34510,9 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_RGB10_A2"/>
             <enum name="GL_RGBA12"/>
             <enum name="GL_RGBA16"/>
-            <enum name="GL_CURRENT_BIT"/>
-            <enum name="GL_POINT_BIT"/>
-            <enum name="GL_LINE_BIT"/>
-            <enum name="GL_POLYGON_BIT"/>
-            <enum name="GL_POLYGON_STIPPLE_BIT"/>
-            <enum name="GL_PIXEL_MODE_BIT"/>
-            <enum name="GL_LIGHTING_BIT"/>
-            <enum name="GL_FOG_BIT"/>
-            <enum name="GL_ACCUM_BUFFER_BIT"/>
-            <enum name="GL_VIEWPORT_BIT"/>
-            <enum name="GL_TRANSFORM_BIT"/>
-            <enum name="GL_ENABLE_BIT"/>
-            <enum name="GL_HINT_BIT"/>
-            <enum name="GL_EVAL_BIT"/>
-            <enum name="GL_LIST_BIT"/>
-            <enum name="GL_TEXTURE_BIT"/>
-            <enum name="GL_SCISSOR_BIT"/>
-            <enum name="GL_ALL_ATTRIB_BITS"/>
             <enum name="GL_CLIENT_PIXEL_STORE_BIT"/>
             <enum name="GL_CLIENT_VERTEX_ARRAY_BIT"/>
             <enum name="GL_CLIENT_ALL_ATTRIB_BITS"/>
-            <enum name="GL_QUAD_STRIP"/>
-            <enum name="GL_POLYGON"/>
-            <enum name="GL_ACCUM"/>
-            <enum name="GL_LOAD"/>
-            <enum name="GL_RETURN"/>
-            <enum name="GL_MULT"/>
-            <enum name="GL_ADD"/>
-            <enum name="GL_AUX0"/>
-            <enum name="GL_AUX1"/>
-            <enum name="GL_AUX2"/>
-            <enum name="GL_AUX3"/>
-            <enum name="GL_2D"/>
-            <enum name="GL_3D"/>
-            <enum name="GL_3D_COLOR"/>
-            <enum name="GL_3D_COLOR_TEXTURE"/>
-            <enum name="GL_4D_COLOR_TEXTURE"/>
-            <enum name="GL_PASS_THROUGH_TOKEN"/>
-            <enum name="GL_POINT_TOKEN"/>
-            <enum name="GL_LINE_TOKEN"/>
-            <enum name="GL_POLYGON_TOKEN"/>
-            <enum name="GL_BITMAP_TOKEN"/>
-            <enum name="GL_DRAW_PIXEL_TOKEN"/>
-            <enum name="GL_COPY_PIXEL_TOKEN"/>
-            <enum name="GL_LINE_RESET_TOKEN"/>
-            <enum name="GL_EXP"/>
-            <enum name="GL_EXP2"/>
-            <enum name="GL_COEFF"/>
-            <enum name="GL_ORDER"/>
-            <enum name="GL_DOMAIN"/>
-            <enum name="GL_PIXEL_MAP_I_TO_I"/>
-            <enum name="GL_PIXEL_MAP_S_TO_S"/>
-            <enum name="GL_PIXEL_MAP_I_TO_R"/>
-            <enum name="GL_PIXEL_MAP_I_TO_G"/>
-            <enum name="GL_PIXEL_MAP_I_TO_B"/>
-            <enum name="GL_PIXEL_MAP_I_TO_A"/>
-            <enum name="GL_PIXEL_MAP_R_TO_R"/>
-            <enum name="GL_PIXEL_MAP_G_TO_G"/>
-            <enum name="GL_PIXEL_MAP_B_TO_B"/>
-            <enum name="GL_PIXEL_MAP_A_TO_A"/>
             <enum name="GL_VERTEX_ARRAY_POINTER"/>
             <enum name="GL_NORMAL_ARRAY_POINTER"/>
             <enum name="GL_COLOR_ARRAY_POINTER"/>
@@ -30715,141 +34521,9 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_EDGE_FLAG_ARRAY_POINTER"/>
             <enum name="GL_FEEDBACK_BUFFER_POINTER"/>
             <enum name="GL_SELECTION_BUFFER_POINTER"/>
-            <enum name="GL_CURRENT_COLOR"/>
-            <enum name="GL_CURRENT_INDEX"/>
-            <enum name="GL_CURRENT_NORMAL"/>
-            <enum name="GL_CURRENT_TEXTURE_COORDS"/>
-            <enum name="GL_CURRENT_RASTER_COLOR"/>
-            <enum name="GL_CURRENT_RASTER_INDEX"/>
-            <enum name="GL_CURRENT_RASTER_TEXTURE_COORDS"/>
-            <enum name="GL_CURRENT_RASTER_POSITION"/>
-            <enum name="GL_CURRENT_RASTER_POSITION_VALID"/>
-            <enum name="GL_CURRENT_RASTER_DISTANCE"/>
-            <enum name="GL_POINT_SMOOTH"/>
-            <enum name="GL_LINE_STIPPLE"/>
-            <enum name="GL_LINE_STIPPLE_PATTERN"/>
-            <enum name="GL_LINE_STIPPLE_REPEAT"/>
-            <enum name="GL_LIST_MODE"/>
-            <enum name="GL_MAX_LIST_NESTING"/>
-            <enum name="GL_LIST_BASE"/>
-            <enum name="GL_LIST_INDEX"/>
-            <enum name="GL_POLYGON_STIPPLE"/>
-            <enum name="GL_EDGE_FLAG"/>
-            <enum name="GL_LIGHTING"/>
-            <enum name="GL_LIGHT_MODEL_LOCAL_VIEWER"/>
-            <enum name="GL_LIGHT_MODEL_TWO_SIDE"/>
-            <enum name="GL_LIGHT_MODEL_AMBIENT"/>
-            <enum name="GL_SHADE_MODEL"/>
-            <enum name="GL_COLOR_MATERIAL_FACE"/>
-            <enum name="GL_COLOR_MATERIAL_PARAMETER"/>
-            <enum name="GL_COLOR_MATERIAL"/>
-            <enum name="GL_FOG"/>
-            <enum name="GL_FOG_INDEX"/>
-            <enum name="GL_FOG_DENSITY"/>
-            <enum name="GL_FOG_START"/>
-            <enum name="GL_FOG_END"/>
-            <enum name="GL_FOG_MODE"/>
-            <enum name="GL_FOG_COLOR"/>
-            <enum name="GL_ACCUM_CLEAR_VALUE"/>
-            <enum name="GL_MATRIX_MODE"/>
-            <enum name="GL_NORMALIZE"/>
-            <enum name="GL_MODELVIEW_STACK_DEPTH"/>
-            <enum name="GL_PROJECTION_STACK_DEPTH"/>
-            <enum name="GL_TEXTURE_STACK_DEPTH"/>
-            <enum name="GL_MODELVIEW_MATRIX"/>
-            <enum name="GL_PROJECTION_MATRIX"/>
-            <enum name="GL_TEXTURE_MATRIX"/>
-            <enum name="GL_ATTRIB_STACK_DEPTH"/>
             <enum name="GL_CLIENT_ATTRIB_STACK_DEPTH"/>
-            <enum name="GL_ALPHA_TEST"/>
-            <enum name="GL_ALPHA_TEST_FUNC"/>
-            <enum name="GL_ALPHA_TEST_REF"/>
             <enum name="GL_INDEX_LOGIC_OP"/>
-            <enum name="GL_LOGIC_OP"/>
-            <enum name="GL_AUX_BUFFERS"/>
-            <enum name="GL_INDEX_CLEAR_VALUE"/>
-            <enum name="GL_INDEX_WRITEMASK"/>
-            <enum name="GL_INDEX_MODE"/>
-            <enum name="GL_RGBA_MODE"/>
-            <enum name="GL_RENDER_MODE"/>
-            <enum name="GL_PERSPECTIVE_CORRECTION_HINT"/>
-            <enum name="GL_POINT_SMOOTH_HINT"/>
-            <enum name="GL_FOG_HINT"/>
-            <enum name="GL_TEXTURE_GEN_S"/>
-            <enum name="GL_TEXTURE_GEN_T"/>
-            <enum name="GL_TEXTURE_GEN_R"/>
-            <enum name="GL_TEXTURE_GEN_Q"/>
-            <enum name="GL_PIXEL_MAP_I_TO_I_SIZE"/>
-            <enum name="GL_PIXEL_MAP_S_TO_S_SIZE"/>
-            <enum name="GL_PIXEL_MAP_I_TO_R_SIZE"/>
-            <enum name="GL_PIXEL_MAP_I_TO_G_SIZE"/>
-            <enum name="GL_PIXEL_MAP_I_TO_B_SIZE"/>
-            <enum name="GL_PIXEL_MAP_I_TO_A_SIZE"/>
-            <enum name="GL_PIXEL_MAP_R_TO_R_SIZE"/>
-            <enum name="GL_PIXEL_MAP_G_TO_G_SIZE"/>
-            <enum name="GL_PIXEL_MAP_B_TO_B_SIZE"/>
-            <enum name="GL_PIXEL_MAP_A_TO_A_SIZE"/>
-            <enum name="GL_MAP_COLOR"/>
-            <enum name="GL_MAP_STENCIL"/>
-            <enum name="GL_INDEX_SHIFT"/>
-            <enum name="GL_INDEX_OFFSET"/>
-            <enum name="GL_RED_SCALE"/>
-            <enum name="GL_RED_BIAS"/>
-            <enum name="GL_ZOOM_X"/>
-            <enum name="GL_ZOOM_Y"/>
-            <enum name="GL_GREEN_SCALE"/>
-            <enum name="GL_GREEN_BIAS"/>
-            <enum name="GL_BLUE_SCALE"/>
-            <enum name="GL_BLUE_BIAS"/>
-            <enum name="GL_ALPHA_SCALE"/>
-            <enum name="GL_ALPHA_BIAS"/>
-            <enum name="GL_DEPTH_SCALE"/>
-            <enum name="GL_DEPTH_BIAS"/>
-            <enum name="GL_MAX_EVAL_ORDER"/>
-            <enum name="GL_MAX_LIGHTS"/>
-            <enum name="GL_MAX_CLIP_PLANES"/>
-            <enum name="GL_MAX_PIXEL_MAP_TABLE"/>
-            <enum name="GL_MAX_ATTRIB_STACK_DEPTH"/>
-            <enum name="GL_MAX_MODELVIEW_STACK_DEPTH"/>
-            <enum name="GL_MAX_NAME_STACK_DEPTH"/>
-            <enum name="GL_MAX_PROJECTION_STACK_DEPTH"/>
-            <enum name="GL_MAX_TEXTURE_STACK_DEPTH"/>
             <enum name="GL_MAX_CLIENT_ATTRIB_STACK_DEPTH"/>
-            <enum name="GL_INDEX_BITS"/>
-            <enum name="GL_RED_BITS"/>
-            <enum name="GL_GREEN_BITS"/>
-            <enum name="GL_BLUE_BITS"/>
-            <enum name="GL_ALPHA_BITS"/>
-            <enum name="GL_DEPTH_BITS"/>
-            <enum name="GL_STENCIL_BITS"/>
-            <enum name="GL_ACCUM_RED_BITS"/>
-            <enum name="GL_ACCUM_GREEN_BITS"/>
-            <enum name="GL_ACCUM_BLUE_BITS"/>
-            <enum name="GL_ACCUM_ALPHA_BITS"/>
-            <enum name="GL_NAME_STACK_DEPTH"/>
-            <enum name="GL_AUTO_NORMAL"/>
-            <enum name="GL_MAP1_COLOR_4"/>
-            <enum name="GL_MAP1_INDEX"/>
-            <enum name="GL_MAP1_NORMAL"/>
-            <enum name="GL_MAP1_TEXTURE_COORD_1"/>
-            <enum name="GL_MAP1_TEXTURE_COORD_2"/>
-            <enum name="GL_MAP1_TEXTURE_COORD_3"/>
-            <enum name="GL_MAP1_TEXTURE_COORD_4"/>
-            <enum name="GL_MAP1_VERTEX_3"/>
-            <enum name="GL_MAP1_VERTEX_4"/>
-            <enum name="GL_MAP2_COLOR_4"/>
-            <enum name="GL_MAP2_INDEX"/>
-            <enum name="GL_MAP2_NORMAL"/>
-            <enum name="GL_MAP2_TEXTURE_COORD_1"/>
-            <enum name="GL_MAP2_TEXTURE_COORD_2"/>
-            <enum name="GL_MAP2_TEXTURE_COORD_3"/>
-            <enum name="GL_MAP2_TEXTURE_COORD_4"/>
-            <enum name="GL_MAP2_VERTEX_3"/>
-            <enum name="GL_MAP2_VERTEX_4"/>
-            <enum name="GL_MAP1_GRID_DOMAIN"/>
-            <enum name="GL_MAP1_GRID_SEGMENTS"/>
-            <enum name="GL_MAP2_GRID_DOMAIN"/>
-            <enum name="GL_MAP2_GRID_SEGMENTS"/>
             <enum name="GL_FEEDBACK_BUFFER_SIZE"/>
             <enum name="GL_FEEDBACK_BUFFER_TYPE"/>
             <enum name="GL_SELECTION_BUFFER_SIZE"/>
@@ -30873,58 +34547,10 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_TEXTURE_COORD_ARRAY_TYPE"/>
             <enum name="GL_TEXTURE_COORD_ARRAY_STRIDE"/>
             <enum name="GL_EDGE_FLAG_ARRAY_STRIDE"/>
-            <enum name="GL_TEXTURE_COMPONENTS"/>
-            <enum name="GL_TEXTURE_BORDER"/>
             <enum name="GL_TEXTURE_LUMINANCE_SIZE"/>
             <enum name="GL_TEXTURE_INTENSITY_SIZE"/>
             <enum name="GL_TEXTURE_PRIORITY"/>
             <enum name="GL_TEXTURE_RESIDENT"/>
-            <enum name="GL_AMBIENT"/>
-            <enum name="GL_DIFFUSE"/>
-            <enum name="GL_SPECULAR"/>
-            <enum name="GL_POSITION"/>
-            <enum name="GL_SPOT_DIRECTION"/>
-            <enum name="GL_SPOT_EXPONENT"/>
-            <enum name="GL_SPOT_CUTOFF"/>
-            <enum name="GL_CONSTANT_ATTENUATION"/>
-            <enum name="GL_LINEAR_ATTENUATION"/>
-            <enum name="GL_QUADRATIC_ATTENUATION"/>
-            <enum name="GL_COMPILE"/>
-            <enum name="GL_COMPILE_AND_EXECUTE"/>
-            <enum name="GL_2_BYTES"/>
-            <enum name="GL_3_BYTES"/>
-            <enum name="GL_4_BYTES"/>
-            <enum name="GL_EMISSION"/>
-            <enum name="GL_SHININESS"/>
-            <enum name="GL_AMBIENT_AND_DIFFUSE"/>
-            <enum name="GL_COLOR_INDEXES"/>
-            <enum name="GL_MODELVIEW"/>
-            <enum name="GL_PROJECTION"/>
-            <enum name="GL_COLOR_INDEX"/>
-            <enum name="GL_LUMINANCE"/>
-            <enum name="GL_LUMINANCE_ALPHA"/>
-            <enum name="GL_BITMAP"/>
-            <enum name="GL_RENDER"/>
-            <enum name="GL_FEEDBACK"/>
-            <enum name="GL_SELECT"/>
-            <enum name="GL_FLAT"/>
-            <enum name="GL_SMOOTH"/>
-            <enum name="GL_S"/>
-            <enum name="GL_T"/>
-            <enum name="GL_R"/>
-            <enum name="GL_Q"/>
-            <enum name="GL_MODULATE"/>
-            <enum name="GL_DECAL"/>
-            <enum name="GL_TEXTURE_ENV_MODE"/>
-            <enum name="GL_TEXTURE_ENV_COLOR"/>
-            <enum name="GL_TEXTURE_ENV"/>
-            <enum name="GL_EYE_LINEAR"/>
-            <enum name="GL_OBJECT_LINEAR"/>
-            <enum name="GL_SPHERE_MAP"/>
-            <enum name="GL_TEXTURE_GEN_MODE"/>
-            <enum name="GL_OBJECT_PLANE"/>
-            <enum name="GL_EYE_PLANE"/>
-            <enum name="GL_CLAMP"/>
             <enum name="GL_ALPHA4"/>
             <enum name="GL_ALPHA8"/>
             <enum name="GL_ALPHA12"/>
@@ -30958,20 +34584,6 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_T2F_N3F_V3F"/>
             <enum name="GL_T2F_C4F_N3F_V3F"/>
             <enum name="GL_T4F_C4F_N3F_V4F"/>
-            <enum name="GL_CLIP_PLANE0"/>
-            <enum name="GL_CLIP_PLANE1"/>
-            <enum name="GL_CLIP_PLANE2"/>
-            <enum name="GL_CLIP_PLANE3"/>
-            <enum name="GL_CLIP_PLANE4"/>
-            <enum name="GL_CLIP_PLANE5"/>
-            <enum name="GL_LIGHT0"/>
-            <enum name="GL_LIGHT1"/>
-            <enum name="GL_LIGHT2"/>
-            <enum name="GL_LIGHT3"/>
-            <enum name="GL_LIGHT4"/>
-            <enum name="GL_LIGHT5"/>
-            <enum name="GL_LIGHT6"/>
-            <enum name="GL_LIGHT7"/>
             <command name="glDrawArrays"/>
             <command name="glDrawElements"/>
             <command name="glGetPointerv"/>
@@ -31051,7 +34663,7 @@ typedef unsigned int GLhandleARB;
             <command name="glTexImage3D"/>
             <command name="glTexSubImage3D"/>
             <command name="glCopyTexSubImage3D"/>
-          </require>
+        </require>
     </feature>
     <feature api="gl" name="GL_VERSION_1_3" number="1.3">
         <require>
@@ -31287,15 +34899,17 @@ typedef unsigned int GLhandleARB;
             <command name="glWindowPos3sv"/>
         </require>
         <require comment="Promoted from ARB_imaging subset to core">
-            <enum name="GL_FUNC_ADD"/>
-            <enum name="GL_FUNC_SUBTRACT"/>
-            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
-            <enum name="GL_MIN"/>
-            <enum name="GL_MAX"/>
+            <enum name="GL_BLEND_COLOR"/>
+            <enum name="GL_BLEND_EQUATION"/>
             <enum name="GL_CONSTANT_COLOR"/>
             <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
             <enum name="GL_CONSTANT_ALPHA"/>
             <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
+            <enum name="GL_FUNC_ADD"/>
+            <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
+            <enum name="GL_FUNC_SUBTRACT"/>
+            <enum name="GL_MIN"/>
+            <enum name="GL_MAX"/>
             <command name="glBlendColor"/>
             <command name="glBlendEquation"/>
         </require>
@@ -31847,6 +35461,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_RENDERBUFFER_STENCIL_SIZE"/>
             <enum name="GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE"/>
             <enum name="GL_MAX_SAMPLES"/>
+            <enum name="GL_INDEX"/>
             <command name="glIsRenderbuffer"/>
             <command name="glBindRenderbuffer"/>
             <command name="glDeleteRenderbuffers"/>
@@ -31868,8 +35483,7 @@ typedef unsigned int GLhandleARB;
             <command name="glRenderbufferStorageMultisample"/>
             <command name="glFramebufferTextureLayer"/>
         </require>
-        <require profile="compatibility" comment="Reuse ARB_framebuffer_object compatibility profile">
-            <enum name="GL_INDEX"/>
+        <require comment="Reuse ARB_texture_float">
             <enum name="GL_TEXTURE_LUMINANCE_TYPE"/>
             <enum name="GL_TEXTURE_INTENSITY_TYPE"/>
         </require>
@@ -32917,6 +36531,7 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CLAMP_VERTEX_COLOR"/>
             <enum name="GL_CLAMP_FRAGMENT_COLOR"/>
             <enum name="GL_ALPHA_INTEGER"/>
+            <enum name="GL_INDEX"/>
             <enum name="GL_TEXTURE_LUMINANCE_TYPE"/>
             <enum name="GL_TEXTURE_INTENSITY_TYPE"/>
         </remove>
@@ -33248,6 +36863,7 @@ typedef unsigned int GLhandleARB;
             <command name="glGenProgramPipelines"/>
             <command name="glIsProgramPipeline"/>
             <command name="glGetProgramPipelineiv"/>
+            <command name="glProgramParameteri"/>
             <command name="glProgramUniform1i"/>
             <command name="glProgramUniform1iv"/>
             <command name="glProgramUniform1f"/>
@@ -33909,7 +37525,6 @@ typedef unsigned int GLhandleARB;
         <require profile="core" comment="Restore functionality removed in GL 3.2 core to GL 4.3. Needed for debug interface.">
             <enum name="GL_STACK_UNDERFLOW"/>
             <enum name="GL_STACK_OVERFLOW"/>
-            <command name="glGetPointerv"/>
         </require>
         <!-- Deprecated in OpenGL 4.3 core;
              deprecate tag not defined/supported yet
@@ -34158,9 +37773,69 @@ typedef unsigned int GLhandleARB;
             <enum name="GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH"/>
         </require>
     </feature>
+    <feature api="gl" name="GL_VERSION_4_6" number="4.6">
+        <require comment="Reuse GL_KHR_context_flush_control">
+            <enum name="GL_CONTEXT_RELEASE_BEHAVIOR"/>
+            <enum name="GL_NONE"/>
+            <enum name="GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH"/>
+        </require>
+        <require comment="Reuse GL_ARB_gl_spirv">
+            <enum name="GL_SHADER_BINARY_FORMAT_SPIR_V"/>
+            <enum name="GL_SPIR_V_BINARY"/>
+            <command name="glSpecializeShader"/>
+        </require>
+        <require comment="Reuse GL_ARB_indirect_parameters">
+            <enum name="GL_PARAMETER_BUFFER"/>
+            <enum name="GL_PARAMETER_BUFFER_BINDING"/>
+            <command name="glMultiDrawArraysIndirectCount"/>
+            <command name="glMultiDrawElementsIndirectCount"/>
+        </require>
+        <require comment="Reuse GL_KHR_no_error">
+            <enum name="GL_CONTEXT_FLAG_NO_ERROR_BIT"/>
+        </require>
+        <require comment="Reuse GL_ARB_pipeline_statistics_query">
+            <enum name="GL_VERTICES_SUBMITTED"/>
+            <enum name="GL_PRIMITIVES_SUBMITTED"/>
+            <enum name="GL_VERTEX_SHADER_INVOCATIONS"/>
+            <enum name="GL_TESS_CONTROL_SHADER_PATCHES"/>
+            <enum name="GL_TESS_EVALUATION_SHADER_INVOCATIONS"/>
+            <enum name="GL_GEOMETRY_SHADER_INVOCATIONS"/>
+            <enum name="GL_GEOMETRY_SHADER_PRIMITIVES_EMITTED"/>
+            <enum name="GL_FRAGMENT_SHADER_INVOCATIONS"/>
+            <enum name="GL_COMPUTE_SHADER_INVOCATIONS"/>
+            <enum name="GL_CLIPPING_INPUT_PRIMITIVES"/>
+            <enum name="GL_CLIPPING_OUTPUT_PRIMITIVES"/>
+        </require>
+        <require comment="Reuse GL_ARB_polygon_offset_clamp">
+            <enum name="GL_POLYGON_OFFSET_CLAMP"/>
+            <command name="glPolygonOffsetClamp"/>
+        </require>
+        <require comment="Reuse GL_ARB_shader_atomic_counter_ops (none)"/>
+        <require comment="Reuse GL_ARB_shader_draw_parameters (none)"/>
+        <require comment="Reuse GL_ARB_shader_group_vote (none)"/>
+        <require comment="Reuse GL_ARB_spirv_extensions">
+            <enum name="GL_SPIR_V_EXTENSIONS"/>
+            <enum name="GL_NUM_SPIR_V_EXTENSIONS"/>
+        </require>
+        <require comment="Reuse GL_ARB_texture_filter_anisotropic">
+            <enum name="GL_TEXTURE_MAX_ANISOTROPY"/>
+            <enum name="GL_MAX_TEXTURE_MAX_ANISOTROPY"/>
+        </require>
+        <require comment="Reuse GL_ARB_transform_feedback_overflow_query">
+            <enum name="GL_TRANSFORM_FEEDBACK_OVERFLOW"/>
+            <enum name="GL_TRANSFORM_FEEDBACK_STREAM_OVERFLOW"/>
+        </require>
+    </feature>
+
 
     <!-- SECTION: OpenGL ES 1.0/1.1 API interface definitions. -->
     <feature api="gles1" name="GL_VERSION_ES_CM_1_0" number="1.0">
+        <require comment="Not used by the API, for compatibility with old gl.h">
+            <type name="GLbyte"/>
+            <type name="GLclampf"/>
+            <type name="GLshort"/>
+            <type name="GLushort"/>
+        </require>
         <require>
             <!-- Additional API definition macros - ES 1.0/1.1, common/common-lite all in one header -->
             <enum name="GL_VERSION_ES_CL_1_0"/>
@@ -36629,7 +40304,19 @@ typedef unsigned int GLhandleARB;
                 <command name="glBlendEquationSeparateIndexedAMD"/>
             </require>
         </extension>
-        <extension name="GL_AMD_framebuffer_sample_positions" supported="disabled">
+        <extension name="GL_AMD_framebuffer_multisample_advanced" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_RENDERBUFFER_STORAGE_SAMPLES_AMD"/>
+                <enum name="GL_MAX_COLOR_FRAMEBUFFER_SAMPLES_AMD"/>
+                <enum name="GL_MAX_COLOR_FRAMEBUFFER_STORAGE_SAMPLES_AMD"/>
+                <enum name="GL_MAX_DEPTH_STENCIL_FRAMEBUFFER_SAMPLES_AMD"/>
+                <enum name="GL_NUM_SUPPORTED_MULTISAMPLE_MODES_AMD"/>
+                <enum name="GL_SUPPORTED_MULTISAMPLE_MODES_AMD"/>
+                <command name="glRenderbufferStorageMultisampleAdvancedAMD"/>
+                <command name="glNamedRenderbufferStorageMultisampleAdvancedAMD"/>
+            </require>
+        </extension>
+        <extension name="GL_AMD_framebuffer_sample_positions" supported="gl">
             <require>
                 <enum name="GL_SUBSAMPLE_DISTANCE_AMD"/>
                 <enum name="GL_PIXELS_PER_SAMPLE_PATTERN_X_AMD"/>
@@ -36659,6 +40346,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_FLOAT16_MAT4x3_AMD"/>
             </require>
         </extension>
+        <extension name="GL_AMD_gpu_shader_int16" supported="gl"/>
         <extension name="GL_AMD_gpu_shader_int64" supported="gl">
             <require>
                 <enum name="GL_INT64_NV"/>
@@ -36822,6 +40510,8 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_AMD_shader_atomic_counter_ops" supported="gl"/>
         <extension name="GL_AMD_shader_ballot" supported="gl"/>
+        <extension name="GL_AMD_shader_gpu_shader_half_float_fetch" supported="gl"/>
+        <extension name="GL_AMD_shader_image_load_store_lod" supported="gl"/>
         <extension name="GL_AMD_shader_stencil_export" supported="gl"/>
         <extension name="GL_AMD_shader_trinary_minmax" supported="gl"/>
         <extension name="GL_AMD_shader_explicit_vertex_parameter" supported="gl"/>
@@ -36849,6 +40539,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glStencilOpValueAMD"/>
             </require>
         </extension>
+        <extension name="GL_AMD_texture_gather_bias_lod" supported="gl"/>
         <extension name="GL_AMD_texture_texture4" supported="gl"/>
         <extension name="GL_AMD_transform_feedback3_lines_triangles" supported="gl"/>
         <extension name="GL_AMD_transform_feedback4" supported="gl">
@@ -37242,7 +40933,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glMemoryBarrierByRegion"/>
             </require>
         </extension>
-        <extension name="GL_ARB_ES3_2_compatibility" supported="gl">
+        <extension name="GL_ARB_ES3_2_compatibility" supported="gl|glcore">
             <require>
                 <enum name="GL_PRIMITIVE_BOUNDING_BOX_ARB"/>
                 <enum name="GL_MULTISAMPLE_LINE_WIDTH_RANGE_ARB"/>
@@ -37668,7 +41359,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glDrawElementsIndirect"/>
             </require>
         </extension>
-        <extension name="GL_ARB_draw_instanced" supported="gl">
+        <extension name="GL_ARB_draw_instanced" supported="gl|glcore">
             <require>
                 <command name="glDrawArraysInstancedARB"/>
                 <command name="glDrawElementsInstancedARB"/>
@@ -37801,7 +41492,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_FRAGMENT_SHADER_DERIVATIVE_HINT_ARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_fragment_shader_interlock" supported="gl"/>
+        <extension name="GL_ARB_fragment_shader_interlock" supported="gl|glcore"/>
         <extension name="GL_ARB_framebuffer_no_attachments" supported="gl|glcore">
             <require>
                 <enum name="GL_FRAMEBUFFER_DEFAULT_WIDTH"/>
@@ -37921,7 +41612,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_FRAMEBUFFER_SRGB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_geometry_shader4" supported="gl">
+        <extension name="GL_ARB_geometry_shader4" supported="gl|glcore">
             <require>
                 <enum name="GL_LINES_ADJACENCY_ARB"/>
                 <enum name="GL_LINE_STRIP_ADJACENCY_ARB"/>
@@ -37964,6 +41655,13 @@ typedef unsigned int GLhandleARB;
             <require>
                 <command name="glGetTextureSubImage"/>
                 <command name="glGetCompressedTextureSubImage"/>
+            </require>
+        </extension>
+        <extension name="GL_ARB_gl_spirv" supported="gl|glcore">
+            <require>
+                <enum name="GL_SHADER_BINARY_FORMAT_SPIR_V_ARB"/>
+                <enum name="GL_SPIR_V_BINARY_ARB"/>
+                <command name="glSpecializeShaderARB"/>
             </require>
         </extension>
         <extension name="GL_ARB_gpu_shader5" supported="gl|glcore">
@@ -38011,7 +41709,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetUniformdv"/>
             </require>
         </extension>
-        <extension name="GL_ARB_gpu_shader_int64" supported="gl">
+        <extension name="GL_ARB_gpu_shader_int64" supported="gl|glcore">
             <require>
                 <enum name="GL_INT64_ARB"/>
                 <enum name="GL_UNSIGNED_INT64_ARB"/>
@@ -38073,17 +41771,17 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_ARB_imaging" supported="gl|glcore" comment="Now treating ARB_imaging as an extension, not a GL API version">
             <require>
+                <enum name="GL_BLEND_COLOR"/>
+                <enum name="GL_BLEND_EQUATION"/>
                 <enum name="GL_CONSTANT_COLOR"/>
                 <enum name="GL_ONE_MINUS_CONSTANT_COLOR"/>
                 <enum name="GL_CONSTANT_ALPHA"/>
                 <enum name="GL_ONE_MINUS_CONSTANT_ALPHA"/>
-                <enum name="GL_BLEND_COLOR"/>
                 <enum name="GL_FUNC_ADD"/>
+                <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
+                <enum name="GL_FUNC_SUBTRACT"/>
                 <enum name="GL_MIN"/>
                 <enum name="GL_MAX"/>
-                <enum name="GL_BLEND_EQUATION"/>
-                <enum name="GL_FUNC_SUBTRACT"/>
-                <enum name="GL_FUNC_REVERSE_SUBTRACT"/>
                 <command name="glBlendColor"/>
                 <command name="glBlendEquation"/>
             </require>
@@ -38194,7 +41892,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glMultiDrawElementsIndirectCountARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_instanced_arrays" supported="gl">
+        <extension name="GL_ARB_instanced_arrays" supported="gl|glcore">
             <require>
                 <enum name="GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ARB"/>
                 <command name="glVertexAttribDivisorARB"/>
@@ -38323,6 +42021,29 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_VIEW_CLASS_RGTC2_RG"/>
                 <enum name="GL_VIEW_CLASS_BPTC_UNORM"/>
                 <enum name="GL_VIEW_CLASS_BPTC_FLOAT"/>
+            </require>
+            <require comment="Supported only if GL_ARB_ES3_compatibility is supported">
+                <enum name="GL_VIEW_CLASS_EAC_R11"/>
+                <enum name="GL_VIEW_CLASS_EAC_RG11"/>
+                <enum name="GL_VIEW_CLASS_ETC2_RGB"/>
+                <enum name="GL_VIEW_CLASS_ETC2_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ETC2_EAC_RGBA"/>
+            </require>
+            <require comment="Supported only if GL_KHR_texture_compression_astc_ldr is supported">
+                <enum name="GL_VIEW_CLASS_ASTC_4x4_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_5x4_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_5x5_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_6x5_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_6x6_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_8x5_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_8x6_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_8x8_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_10x5_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_10x6_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_10x8_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_10x10_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_12x10_RGBA"/>
+                <enum name="GL_VIEW_CLASS_ASTC_12x12_RGBA"/>
                 <command name="glGetInternalformati64v"/>
             </require>
         </extension>
@@ -38497,7 +42218,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_ANY_SAMPLES_PASSED"/>
             </require>
         </extension>
-        <extension name="GL_ARB_parallel_shader_compile" supported="gl">
+        <extension name="GL_ARB_parallel_shader_compile" supported="gl|glcore">
             <require>
                 <enum name="GL_MAX_SHADER_COMPILER_THREADS_ARB"/>
                 <enum name="GL_COMPLETION_STATUS_ARB"/>
@@ -38519,7 +42240,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_CLIPPING_OUTPUT_PRIMITIVES_ARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_pixel_buffer_object" supported="gl">
+        <extension name="GL_ARB_pixel_buffer_object" supported="gl|glcore">
             <require>
                 <enum name="GL_PIXEL_PACK_BUFFER_ARB"/>
                 <enum name="GL_PIXEL_UNPACK_BUFFER_ARB"/>
@@ -38543,7 +42264,13 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_COORD_REPLACE_ARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_post_depth_coverage" supported="gl"/>
+        <extension name="GL_ARB_polygon_offset_clamp" supported="gl|glcore">
+            <require>
+                <enum name="GL_POLYGON_OFFSET_CLAMP"/>
+                <command name="glPolygonOffsetClamp"/>
+            </require>
+        </extension>
+        <extension name="GL_ARB_post_depth_coverage" supported="gl|glcore"/>
         <extension name="GL_ARB_program_interface_query" supported="gl|glcore">
             <require>
                 <enum name="GL_UNIFORM"/>
@@ -38657,7 +42384,7 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_ARB_robustness_isolation" supported="gl|glcore"/>
-        <extension name="GL_ARB_sample_locations" supported="gl">
+        <extension name="GL_ARB_sample_locations" supported="gl|glcore">
             <require>
                 <enum name="GL_SAMPLE_LOCATION_SUBPIXEL_BITS_ARB"/>
                 <enum name="GL_SAMPLE_LOCATION_PIXEL_GRID_WIDTH_ARB"/>
@@ -38727,6 +42454,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glGenProgramPipelines"/>
                 <command name="glIsProgramPipeline"/>
                 <command name="glGetProgramPipelineiv"/>
+                <command name="glProgramParameteri"/>
                 <command name="glProgramUniform1i"/>
                 <command name="glProgramUniform1iv"/>
                 <command name="glProgramUniform1f"/>
@@ -38781,7 +42509,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetProgramPipelineInfoLog"/>
             </require>
         </extension>
-        <extension name="GL_ARB_shader_atomic_counter_ops" supported="gl"/>
+        <extension name="GL_ARB_shader_atomic_counter_ops" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_atomic_counters" supported="gl|glcore">
             <require>
                 <enum name="GL_ATOMIC_COUNTER_BUFFER"/>
@@ -38816,9 +42544,9 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetActiveAtomicCounterBufferiv"/>
             </require>
         </extension>
-        <extension name="GL_ARB_shader_ballot" supported="gl"/>
+        <extension name="GL_ARB_shader_ballot" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_bit_encoding" supported="gl|glcore"/>
-        <extension name="GL_ARB_shader_clock" supported="gl"/>
+        <extension name="GL_ARB_shader_clock" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_draw_parameters" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_group_vote" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_image_load_store" supported="gl|glcore">
@@ -39018,7 +42746,7 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_ARB_shader_texture_image_samples" supported="gl|glcore"/>
         <extension name="GL_ARB_shader_texture_lod" supported="gl"/>
-        <extension name="GL_ARB_shader_viewport_layer_array" supported="gl"/>
+        <extension name="GL_ARB_shader_viewport_layer_array" supported="gl|glcore"/>
         <extension name="GL_ARB_shading_language_100" supported="gl">
             <require>
                 <enum name="GL_SHADING_LANGUAGE_VERSION_ARB"/>
@@ -39060,7 +42788,7 @@ typedef unsigned int GLhandleARB;
             <require comment="Supported only if GL_EXT_direct_state_access is supported">
                 <command name="glNamedBufferPageCommitmentEXT"/>
             </require>
-            <require comment="Supported only if GL_ARb_direct_state_access or GL 4.5 is supported">
+            <require comment="Supported only if GL_ARB_direct_state_access or GL 4.5 is supported">
                 <command name="glNamedBufferPageCommitmentARB"/>
             </require>
         </extension>
@@ -39080,8 +42808,14 @@ typedef unsigned int GLhandleARB;
                 <command name="glTexPageCommitmentARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_sparse_texture2" supported="gl|glcore|gles2"/>
-        <extension name="GL_ARB_sparse_texture_clamp" supported="gl"/>
+        <extension name="GL_ARB_sparse_texture2" supported="gl|glcore"/>
+        <extension name="GL_ARB_sparse_texture_clamp" supported="gl|glcore"/>
+        <extension name="GL_ARB_spirv_extensions" supported="gl|glcore">
+            <require>
+                <enum name="GL_SPIR_V_EXTENSIONS"/>
+                <enum name="GL_NUM_SPIR_V_EXTENSIONS"/>
+            </require>
+        </extension>
         <extension name="GL_ARB_stencil_texturing" supported="gl|glcore">
             <require>
                 <enum name="GL_DEPTH_STENCIL_TEXTURE_MODE"/>
@@ -39161,12 +42895,12 @@ typedef unsigned int GLhandleARB;
                 <command name="glTextureBarrier"/>
             </require>
         </extension>
-        <extension name="GL_ARB_texture_border_clamp" supported="gl">
+        <extension name="GL_ARB_texture_border_clamp" supported="gl|glcore">
             <require>
                 <enum name="GL_CLAMP_TO_BORDER_ARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_texture_buffer_object" supported="gl">
+        <extension name="GL_ARB_texture_buffer_object" supported="gl|glcore">
             <require>
                 <enum name="GL_TEXTURE_BUFFER_ARB"/>
                 <enum name="GL_MAX_TEXTURE_BUFFER_SIZE_ARB"/>
@@ -39290,7 +43024,13 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_DOT3_RGBA_ARB"/>
             </require>
         </extension>
-        <extension name="GL_ARB_texture_filter_minmax" supported="gl">
+        <extension name="GL_ARB_texture_filter_anisotropic" supported="gl|glcore">
+            <require>
+                <enum name="GL_TEXTURE_MAX_ANISOTROPY"/>
+                <enum name="GL_MAX_TEXTURE_MAX_ANISOTROPY"/>
+            </require>
+        </extension>
+        <extension name="GL_ARB_texture_filter_minmax" supported="gl|glcore">
             <require>
                 <enum name="GL_TEXTURE_REDUCTION_MODE_ARB"/>
                 <enum name="GL_WEIGHTED_AVERAGE_ARB"/>
@@ -39332,7 +43072,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MIRROR_CLAMP_TO_EDGE"/>
             </require>
         </extension>
-        <extension name="GL_ARB_texture_mirrored_repeat" supported="gl">
+        <extension name="GL_ARB_texture_mirrored_repeat" supported="gl|glcore">
             <require>
                 <enum name="GL_MIRRORED_REPEAT_ARB"/>
             </require>
@@ -39366,7 +43106,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glSampleMaski"/>
             </require>
         </extension>
-        <extension name="GL_ARB_texture_non_power_of_two" supported="gl"/>
+        <extension name="GL_ARB_texture_non_power_of_two" supported="gl|glcore"/>
         <extension name="GL_ARB_texture_query_levels" supported="gl|glcore"/>
         <extension name="GL_ARB_texture_query_lod" supported="gl|glcore"/>
         <extension name="GL_ARB_texture_rectangle" supported="gl">
@@ -40407,6 +44147,17 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_422_REV_AVERAGE_EXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_EGL_image_array" supported="gles2">
+        </extension>
+        <extension name="GL_EXT_EGL_image_storage" supported="gl|glcore|gles2">
+            <require>
+                <type name="GLeglImageOES"/>
+                <command name="glEGLImageTargetTexStorageEXT"/>
+            </require>
+            <require comment="Supported only if GL_EXT_direct_state_access, ARB_direct_state_access, or OpenGL 4.5 are supported">
+                <command name="glEGLImageTargetTextureStorageEXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_YUV_target" supported="gles2">
             <require>
                 <enum name="GL_SAMPLER_EXTERNAL_2D_Y2Y_EXT"/>
@@ -40524,6 +44275,17 @@ typedef unsigned int GLhandleARB;
             <require>
                 <command name="glClearTexImageEXT"/>
                 <command name="glClearTexSubImageEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_clip_control" supported="gles2">
+            <require comment="Port of GL_ARB_clip_control">
+                <command name="glClipControlEXT"/>
+                <enum name="GL_LOWER_LEFT_EXT"/>
+                <enum name="GL_UPPER_LEFT_EXT"/>
+                <enum name="GL_NEGATIVE_ONE_TO_ONE_EXT"/>
+                <enum name="GL_ZERO_TO_ONE_EXT"/>
+                <enum name="GL_CLIP_ORIGIN_EXT"/>
+                <enum name="GL_CLIP_DEPTH_MODE_EXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_clip_cull_distance" supported="gles2">
@@ -40696,7 +44458,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TRANSFORM_FEEDBACK"/>
             </require>
         </extension>
-        <extension name="GL_EXT_debug_marker" supported="gl|glcore|gles2">
+        <extension name="GL_EXT_debug_marker" supported="gl|glcore|gles1|gles2">
             <require>
                 <command name="glInsertEventMarkerEXT"/>
                 <command name="glPushGroupMarkerEXT"/>
@@ -40710,7 +44472,12 @@ typedef unsigned int GLhandleARB;
                 <command name="glDepthBoundsEXT"/>
             </require>
         </extension>
-        <extension name="GL_EXT_direct_state_access" supported="gl" comment="DSA extension doesn't identify which interfaces are core profile and keeps getting expanded. This is in sync with revision 34, 2010/09/07">
+        <extension name="GL_EXT_depth_clamp" supported="gles2">
+            <require>
+                <enum name="GL_DEPTH_CLAMP_EXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_direct_state_access" supported="gl|glcore" comment="DSA extension doesn't identify which interfaces are core profile and keeps getting expanded. This is in sync with revision 34, 2010/09/07">
             <require>
                 <enum name="GL_PROGRAM_MATRIX_EXT"/>
                 <enum name="GL_TRANSPOSE_PROGRAM_MATRIX_EXT"/>
@@ -41210,6 +44977,12 @@ typedef unsigned int GLhandleARB;
                 <command name="glDrawTransformFeedbackInstancedEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_external_buffer" supported="gl|gles2">
+            <require>
+                <command name="glBufferStorageExternalEXT"/>
+                <command name="glNamedBufferStorageExternalEXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_float_blend" supported="gles2"/>
         <extension name="GL_EXT_fog_coord" supported="gl">
             <require>
@@ -41537,6 +45310,67 @@ typedef unsigned int GLhandleARB;
                 <command name="glFlushMappedBufferRangeEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_memory_object" supported="gl|gles2">
+            <require>
+                <enum name="GL_TEXTURE_TILING_EXT"/>
+                <enum name="GL_DEDICATED_MEMORY_OBJECT_EXT"/>
+                <enum name="GL_PROTECTED_MEMORY_OBJECT_EXT"/>
+                <enum name="GL_NUM_TILING_TYPES_EXT"/>
+                <enum name="GL_TILING_TYPES_EXT"/>
+                <enum name="GL_OPTIMAL_TILING_EXT"/>
+                <enum name="GL_LINEAR_TILING_EXT"/>
+                <enum name="GL_NUM_DEVICE_UUIDS_EXT"/>
+                <enum name="GL_DEVICE_UUID_EXT"/>
+                <enum name="GL_DRIVER_UUID_EXT"/>
+                <enum name="GL_UUID_SIZE_EXT"/>
+                <command name="glGetUnsignedBytevEXT"/>
+                <command name="glGetUnsignedBytei_vEXT"/>
+                <command name="glDeleteMemoryObjectsEXT"/>
+                <command name="glIsMemoryObjectEXT"/>
+                <command name="glCreateMemoryObjectsEXT"/>
+                <command name="glMemoryObjectParameterivEXT"/>
+                <command name="glGetMemoryObjectParameterivEXT"/>
+                <command name="glTexStorageMem2DEXT"/>
+                <command name="glTexStorageMem2DMultisampleEXT"/>
+                <command name="glTexStorageMem3DEXT"/>
+                <command name="glTexStorageMem3DMultisampleEXT"/>
+                <command name="glBufferStorageMemEXT"/>
+            </require>
+            <require comment="Supported only if GL_EXT_direct_state_access is supported">
+                <command name="glTextureStorageMem2DEXT"/>
+                <command name="glTextureStorageMem2DMultisampleEXT"/>
+                <command name="glTextureStorageMem3DEXT"/>
+                <command name="glTextureStorageMem3DMultisampleEXT"/>
+                <command name="glNamedBufferStorageMemEXT"/>
+            </require>
+            <require api="gl">
+                <command name="glTexStorageMem1DEXT"/>
+            </require>
+            <require api="gl" comment="Supported only if GL_EXT_direct_state_access is supported">
+                <command name="glTextureStorageMem1DEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_memory_object_fd" supported="gl|gles2">
+            <require>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_FD_EXT"/>
+                <command name="glImportMemoryFdEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_memory_object_win32" supported="gl|gles2">
+            <require>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_EXT"/>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT"/>
+                <enum name="GL_DEVICE_LUID_EXT"/>
+                <enum name="GL_DEVICE_NODE_MASK_EXT"/>
+                <enum name="GL_LUID_SIZE_EXT"/>
+                <enum name="GL_HANDLE_TYPE_D3D12_TILEPOOL_EXT"/>
+                <enum name="GL_HANDLE_TYPE_D3D12_RESOURCE_EXT"/>
+                <enum name="GL_HANDLE_TYPE_D3D11_IMAGE_EXT"/>
+                <enum name="GL_HANDLE_TYPE_D3D11_IMAGE_KMT_EXT"/>
+                <command name="glImportMemoryWin32HandleEXT"/>
+                <command name="glImportMemoryWin32NameEXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_misc_attribute" supported="gl"/>
         <extension name="GL_EXT_multi_draw_arrays" supported="gl|gles1|gles2">
             <require>
@@ -41601,6 +45435,9 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetIntegeri_vEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_multiview_tessellation_geometry_shader" supported="gl|glcore|gles2"/>
+        <extension name="GL_EXT_multiview_texture_multisample" supported="gl|glcore|gles2"/>
+        <extension name="GL_EXT_multiview_timer_query" supported="gl|glcore|gles2"/>
         <extension name="GL_EXT_occlusion_query_boolean" supported="gles2">
             <require>
                 <enum name="GL_ANY_SAMPLES_PASSED_EXT"/>
@@ -41791,6 +45628,51 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetnUniformivEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_semaphore" supported="gl|gles2">
+            <require>
+                <enum name="GL_NUM_DEVICE_UUIDS_EXT"/>
+                <enum name="GL_DEVICE_UUID_EXT"/>
+                <enum name="GL_DRIVER_UUID_EXT"/>
+                <enum name="GL_UUID_SIZE_EXT"/>
+                <enum name="GL_LAYOUT_GENERAL_EXT"/>
+                <enum name="GL_LAYOUT_COLOR_ATTACHMENT_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_STENCIL_ATTACHMENT_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_STENCIL_READ_ONLY_EXT"/>
+                <enum name="GL_LAYOUT_SHADER_READ_ONLY_EXT"/>
+                <enum name="GL_LAYOUT_TRANSFER_SRC_EXT"/>
+                <enum name="GL_LAYOUT_TRANSFER_DST_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_EXT"/>
+                <enum name="GL_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_EXT"/>
+                <command name="glGetUnsignedBytevEXT"/>
+                <command name="glGetUnsignedBytei_vEXT"/>
+                <command name="glGenSemaphoresEXT"/>
+                <command name="glDeleteSemaphoresEXT"/>
+                <command name="glIsSemaphoreEXT"/>
+                <command name="glSemaphoreParameterui64vEXT"/>
+                <command name="glGetSemaphoreParameterui64vEXT"/>
+                <command name="glWaitSemaphoreEXT"/>
+                <command name="glSignalSemaphoreEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_semaphore_fd" supported="gl|gles2">
+            <require>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_FD_EXT"/>
+                <command name="glImportSemaphoreFdEXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_semaphore_win32" supported="gl|gles2">
+            <require>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_EXT"/>
+                <enum name="GL_HANDLE_TYPE_OPAQUE_WIN32_KMT_EXT"/>
+                <enum name="GL_DEVICE_LUID_EXT"/>
+                <enum name="GL_DEVICE_NODE_MASK_EXT"/>
+                <enum name="GL_LUID_SIZE_EXT"/>
+                <enum name="GL_HANDLE_TYPE_D3D12_FENCE_EXT"/>
+                <enum name="GL_D3D12_FENCE_VALUE_EXT"/>
+                <command name="glImportSemaphoreWin32HandleEXT"/>
+                <command name="glImportSemaphoreWin32NameEXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_sRGB" supported="gles1|gles2">
             <require>
                 <enum name="GL_SRGB_EXT"/>
@@ -41902,9 +45784,15 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_SEPARATE_SPECULAR_COLOR_EXT"/>
             </require>
         </extension>
-        <extension name="GL_EXT_shader_framebuffer_fetch" supported="gles2">
+        <extension name="GL_EXT_shader_framebuffer_fetch" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_shader_framebuffer_fetch_non_coherent" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT"/>
+                <command name="glFramebufferFetchBarrierEXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_shader_group_vote" supported="gles2"/>
@@ -42028,7 +45916,7 @@ typedef unsigned int GLhandleARB;
                 <!-- <command name="glTexturePageCommitmentEXT"/> -->
             </require>
         </extension>
-        <extension name="GL_EXT_sparse_texture2" supported="gl"/>
+        <extension name="GL_EXT_sparse_texture2" supported="gl|gles2"/>
         <extension name="GL_EXT_stencil_clear_tag" supported="gl">
             <require>
                 <enum name="GL_STENCIL_TAG_BITS_EXT"/>
@@ -42228,6 +46116,19 @@ typedef unsigned int GLhandleARB;
                 <command name="glTexBufferEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_texture_compression_astc_decode_mode" supported="gles2">
+            <require>
+                <enum name="GL_TEXTURE_ASTC_DECODE_PRECISION_EXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_texture_compression_bptc" supported="gles2">
+            <require>
+                <enum name="GL_COMPRESSED_RGBA_BPTC_UNORM_EXT"/>
+                <enum name="GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT"/>
+                <enum name="GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT"/>
+                <enum name="GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_texture_compression_dxt1" supported="gles1|gles2">
             <require>
                 <enum name="GL_COMPRESSED_RGB_S3TC_DXT1_EXT"/>
@@ -42242,7 +46143,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_COMPRESSED_SIGNED_LUMINANCE_ALPHA_LATC2_EXT"/>
             </require>
         </extension>
-        <extension name="GL_EXT_texture_compression_rgtc" supported="gl">
+        <extension name="GL_EXT_texture_compression_rgtc" supported="gl|gles2">
             <require>
                 <enum name="GL_COMPRESSED_RED_RGTC1_EXT"/>
                 <enum name="GL_COMPRESSED_SIGNED_RED_RGTC1_EXT"/>
@@ -42256,6 +46157,14 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_COMPRESSED_RGBA_S3TC_DXT1_EXT"/>
                 <enum name="GL_COMPRESSED_RGBA_S3TC_DXT3_EXT"/>
                 <enum name="GL_COMPRESSED_RGBA_S3TC_DXT5_EXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_texture_compression_s3tc_srgb" supported="gles2">
+            <require>
+                <enum name="GL_COMPRESSED_SRGB_S3TC_DXT1_EXT"/>
+                <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT"/>
+                <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT"/>
+                <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_texture_cube_map" supported="gl" comment="Replaced by ARB_texture_cube_map, but was apparently shipped anyway?">
@@ -42327,18 +46236,18 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_EXT_texture_filter_minmax" supported="gl|glcore|gles2">
             <require>
-                <enum name="GL_RASTER_MULTISAMPLE_EXT"/>
-                <enum name="GL_RASTER_SAMPLES_EXT"/>
-                <enum name="GL_MAX_RASTER_SAMPLES_EXT"/>
-                <enum name="GL_RASTER_FIXED_SAMPLE_LOCATIONS_EXT"/>
-                <enum name="GL_MULTISAMPLE_RASTERIZATION_ALLOWED_EXT"/>
-                <enum name="GL_EFFECTIVE_RASTER_SAMPLES_EXT"/>
-                <command name="glRasterSamplesEXT"/>
+                <enum name="GL_TEXTURE_REDUCTION_MODE_EXT"/>
+                <enum name="GL_WEIGHTED_AVERAGE_EXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_texture_format_BGRA8888" supported="gles1|gles2">
             <require>
                 <enum name="GL_BGRA_EXT"/>
+            </require>
+        </extension>
+        <extension name="GL_EXT_texture_format_sRGB_override" supported="gles2">
+            <require>
+                <enum name="GL_TEXTURE_FORMAT_SRGB_OVERRIDE_EXT"/>
             </require>
         </extension>
         <extension name="GL_EXT_texture_integer" supported="gl">
@@ -42412,6 +46321,11 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MIRROR_CLAMP_TO_BORDER_EXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_texture_mirror_clamp_to_edge" supported="gles2">
+            <require>
+                <enum name="GL_MIRROR_CLAMP_TO_EDGE_EXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_texture_norm16" supported="gles2">
             <require>
                 <enum name="GL_R16_EXT"/>
@@ -42446,6 +46360,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glTextureNormalEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_texture_query_lod" supported="gles2"/>
         <extension name="GL_EXT_texture_rg" supported="gles2">
             <require>
                 <enum name="GL_RED_EXT"/>
@@ -42474,7 +46389,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT"/>
             </require>
         </extension>
-        <extension name="GL_EXT_texture_sRGB_R8" supported="gles2">
+        <extension name="GL_EXT_texture_sRGB_R8" supported="gles2|gl|glcore">
             <require>
                 <enum name="GL_SR8_EXT"/>
             </require>
@@ -42879,6 +46794,12 @@ typedef unsigned int GLhandleARB;
                 <command name="glVertexWeightPointerEXT"/>
             </require>
         </extension>
+        <extension name="GL_EXT_win32_keyed_mutex" supported="gl|gles2">
+            <require>
+                <command name="glAcquireKeyedMutexWin32EXT"/>
+                <command name="glReleaseKeyedMutexWin32EXT"/>
+            </require>
+        </extension>
         <extension name="GL_EXT_window_rectangles" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_INCLUSIVE_EXT"/>
@@ -43148,6 +47069,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glMapTexture2DINTEL"/>
             </require>
         </extension>
+        <extension name="GL_INTEL_blackhole_render" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_BLACKHOLE_RENDER_INTEL"/>
+            </require>
+        </extension>
         <extension name="GL_INTEL_parallel_arrays" supported="gl">
             <require>
                 <enum name="GL_PARALLEL_ARRAYS_INTEL"/>
@@ -43232,7 +47158,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_NONE"/>
             </require>
         </extension>
-        <extension name="GL_KHR_debug" supported="gl|glcore|gles2">
+        <extension name="GL_KHR_debug" supported="gl|glcore|gles1|gles2">
             <require api="gl" comment="KHR extensions *mandate* suffixes for ES, unlike for GL">
                 <enum name="GL_DEBUG_OUTPUT_SYNCHRONOUS"/>
                 <enum name="GL_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH"/>
@@ -43383,6 +47309,22 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetnUniformuivKHR"/>
             </require>
         </extension>
+        <extension name="GL_KHR_shader_subgroup" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SUBGROUP_SIZE_KHR"/>
+                <enum name="GL_SUBGROUP_SUPPORTED_STAGES_KHR"/>
+                <enum name="GL_SUBGROUP_SUPPORTED_FEATURES_KHR"/>
+                <enum name="GL_SUBGROUP_QUAD_ALL_STAGES_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_BASIC_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_VOTE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_ARITHMETIC_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_BALLOT_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_CLUSTERED_BIT_KHR"/>
+                <enum name="GL_SUBGROUP_FEATURE_QUAD_BIT_KHR"/>
+            </require>
+        </extension>
         <extension name="GL_KHR_texture_compression_astc_hdr" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_COMPRESSED_RGBA_ASTC_4x4_KHR"/>
@@ -43448,6 +47390,13 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_KHR_texture_compression_astc_sliced_3d" supported="gl|glcore|gles2"/>
+        <extension name="GL_KHR_parallel_shader_compile" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_MAX_SHADER_COMPILER_THREADS_KHR"/>
+                <enum name="GL_COMPLETION_STATUS_KHR"/>
+                <command name="glMaxShaderCompilerThreadsKHR"/>
+            </require>
+        </extension>
         <extension name="GL_MESAX_texture_stack" supported="gl">
             <require>
                 <enum name="GL_TEXTURE_1D_STACK_MESAX"/>
@@ -43458,14 +47407,34 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_TEXTURE_2D_STACK_BINDING_MESAX"/>
             </require>
         </extension>
+        <extension name="GL_MESA_framebuffer_flip_y" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_FRAMEBUFFER_FLIP_Y_MESA"/>
+                <command name="glFramebufferParameteriMESA"/>
+                <command name="glGetFramebufferParameterivMESA"/>
+            </require>
+        </extension>
         <extension name="GL_MESA_pack_invert" supported="gl">
             <require>
                 <enum name="GL_PACK_INVERT_MESA"/>
             </require>
         </extension>
+        <extension name="GL_MESA_program_binary_formats" supported="gl|gles2">
+            <require>
+                <enum name="GL_PROGRAM_BINARY_FORMAT_MESA"/>
+            </require>
+        </extension>
         <extension name="GL_MESA_resize_buffers" supported="gl">
             <require>
                 <command name="glResizeBuffersMESA"/>
+            </require>
+        </extension>
+        <extension name="GL_MESA_shader_integer_functions" supported="gl|gles2"/>
+        <extension name="GL_MESA_tile_raster_order" supported="gl">
+            <require>
+                <enum name="GL_TILE_RASTER_ORDER_FIXED_MESA"/>
+                <enum name="GL_TILE_RASTER_ORDER_INCREASING_X_MESA"/>
+                <enum name="GL_TILE_RASTER_ORDER_INCREASING_Y_MESA"/>
             </require>
         </extension>
         <extension name="GL_MESA_window_pos" supported="gl">
@@ -43503,6 +47472,12 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_YCBCR_MESA"/>
             </require>
         </extension>
+        <extension name="GL_NVX_blend_equation_advanced_multi_draw_buffers" supported="gl|gles2"/>
+        <extension name="GL_NVX_cross_process_interop" supported="disabled">
+            <require comment="unpublished experimental extension">
+                <enum name="GL_EXTERNAL_STORAGE_BIT_NVX"/>
+            </require>
+        </extension>
         <extension name="GL_NVX_conditional_render" supported="gl">
             <require>
                 <command name="glBeginConditionalRenderNVX"/>
@@ -43518,13 +47493,31 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_GPU_MEMORY_INFO_EVICTED_MEMORY_NVX"/>
             </require>
         </extension>
-        <extension name="GL_NV_bindless_multi_draw_indirect" supported="gl">
+        <extension name="GL_NVX_linked_gpu_multicast" supported="gl">
+            <require>
+                <enum name="GL_LGPU_SEPARATE_STORAGE_BIT_NVX"/>
+                <enum name="GL_MAX_LGPU_GPUS_NVX"/>
+                <command name="glLGPUNamedBufferSubDataNVX"/>
+                <command name="glLGPUCopyImageSubDataNVX"/>
+                <command name="glLGPUInterlockNVX"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_alpha_to_coverage_dither_control" supported="gl">
+            <require>
+                <enum name="GL_ALPHA_TO_COVERAGE_DITHER_DEFAULT_NV"/>
+                <enum name="GL_ALPHA_TO_COVERAGE_DITHER_ENABLE_NV"/>
+                <enum name="GL_ALPHA_TO_COVERAGE_DITHER_DISABLE_NV"/>
+                <enum name="GL_ALPHA_TO_COVERAGE_DITHER_MODE_NV"/>
+                <command name="glAlphaToCoverageDitherControlNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_bindless_multi_draw_indirect" supported="gl|glcore">
             <require>
                 <command name="glMultiDrawArraysIndirectBindlessNV"/>
                 <command name="glMultiDrawElementsIndirectBindlessNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_bindless_multi_draw_indirect_count" supported="gl">
+        <extension name="GL_NV_bindless_multi_draw_indirect_count" supported="gl|glcore">
             <require>
                 <command name="glMultiDrawArraysIndirectBindlessCountNV"/>
                 <command name="glMultiDrawElementsIndirectBindlessCountNV"/>
@@ -43609,8 +47602,14 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_BLEND_ADVANCED_COHERENT_NV"/>
             </require>
         </extension>
+        <extension name="GL_NV_blend_minmax_factor" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_FACTOR_MIN_AMD"/>
+                <enum name="GL_FACTOR_MAX_AMD"/>
+            </require>
+        </extension>
         <extension name="GL_NV_blend_square" supported="gl"/>
-        <extension name="GL_NV_clip_space_w_scaling" supported="gl">
+        <extension name="GL_NV_clip_space_w_scaling" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_VIEWPORT_POSITION_W_SCALE_NV"/>
                 <enum name="GL_VIEWPORT_POSITION_W_SCALE_X_COEFF_NV"/>
@@ -43618,7 +47617,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glViewportPositionWScaleNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_command_list" supported="gl">
+        <extension name="GL_NV_command_list" supported="gl|glcore">
             <require>
                 <enum name="GL_TERMINATE_SEQUENCE_COMMAND_NV"/>
                 <enum name="GL_NOP_COMMAND_NV"/>
@@ -43664,6 +47663,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_COMPUTE_PROGRAM_PARAMETER_BUFFER_NV"/>
             </require>
         </extension>
+        <extension name="GL_NV_compute_shader_derivatives" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_conditional_render" supported="gl|glcore|gles2">
             <require>
                 <enum name="GL_QUERY_WAIT_NV"/>
@@ -43683,12 +47683,17 @@ typedef unsigned int GLhandleARB;
                 <command name="glSubpixelPrecisionBiasNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_conservative_raster_dilate" supported="gl">
+        <extension name="GL_NV_conservative_raster_dilate" supported="gl|glcore">
             <require>
                 <enum name="GL_CONSERVATIVE_RASTER_DILATE_NV"/>
                 <enum name="GL_CONSERVATIVE_RASTER_DILATE_RANGE_NV"/>
                 <enum name="GL_CONSERVATIVE_RASTER_DILATE_GRANULARITY_NV"/>
                 <command name="glConservativeRasterParameterfNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_conservative_raster_pre_snap" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_CONSERVATIVE_RASTER_MODE_PRE_SNAP_NV"/>
             </require>
         </extension>
         <extension name="GL_NV_conservative_raster_pre_snap_triangles" supported="gl|glcore|gles2">
@@ -43700,6 +47705,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glConservativeRasterParameteriNV"/>
             </require>
         </extension>
+        <extension name="GL_NV_conservative_raster_underestimation" supported="gl|glcore"/>
         <extension name="GL_NV_copy_buffer" supported="gles2">
             <require>
                 <enum name="GL_COPY_READ_BUFFER_NV"/>
@@ -43807,6 +47813,15 @@ typedef unsigned int GLhandleARB;
         <extension name="GL_NV_draw_texture" supported="gl">
             <require>
                 <command name="glDrawTextureNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_draw_vulkan_image" supported="gl|glcore|gles2">
+            <require>
+                <command name="glDrawVkImageNV"/>
+                <command name="glGetVkProcAddrNV"/>
+                <command name="glWaitVkSemaphoreNV"/>
+                <command name="glSignalVkSemaphoreNV"/>
+                <command name="glSignalVkFenceNV"/>
             </require>
         </extension>
         <extension name="GL_NV_evaluators" supported="gl">
@@ -43967,6 +47982,7 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_NV_fragment_program4" supported="gl"/>
         <extension name="GL_NV_fragment_program_option" supported="gl"/>
+        <extension name="GL_NV_fragment_shader_barycentric" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_fragment_shader_interlock" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_framebuffer_blit" supported="gles2">
             <require>
@@ -44007,7 +48023,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glRenderbufferStorageMultisampleNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_framebuffer_multisample_coverage" supported="gl">
+        <extension name="GL_NV_framebuffer_multisample_coverage" supported="gl|glcore">
             <require>
                 <enum name="GL_RENDERBUFFER_COVERAGE_SAMPLES_NV"/>
                 <enum name="GL_RENDERBUFFER_COLOR_SAMPLES_NV"/>
@@ -44228,6 +48244,126 @@ typedef unsigned int GLhandleARB;
             <require>
                 <enum name="GL_MAX_SHININESS_NV"/>
                 <enum name="GL_MAX_SPOT_EXPONENT_NV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_gpu_multicast" supported="gl">
+            <require>
+                <enum name="GL_PER_GPU_STORAGE_BIT_NV"/>
+                <enum name="GL_MULTICAST_GPUS_NV"/>
+                <enum name="GL_RENDER_GPU_MASK_NV"/>
+                <enum name="GL_PER_GPU_STORAGE_NV"/>
+                <enum name="GL_MULTICAST_PROGRAMMABLE_SAMPLE_LOCATION_NV"/>
+                <command name="glRenderGpuMaskNV"/>
+                <command name="glMulticastBufferSubDataNV"/>
+                <command name="glMulticastCopyBufferSubDataNV"/>
+                <command name="glMulticastCopyImageSubDataNV"/>
+                <command name="glMulticastBlitFramebufferNV"/>
+                <command name="glMulticastFramebufferSampleLocationsfvNV"/>
+                <command name="glMulticastBarrierNV"/>
+                <command name="glMulticastWaitSyncNV"/>
+                <command name="glMulticastGetQueryObjectivNV"/>
+                <command name="glMulticastGetQueryObjectuivNV"/>
+                <command name="glMulticastGetQueryObjecti64vNV"/>
+                <command name="glMulticastGetQueryObjectui64vNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NVX_gpu_multicast2" supported="gl">
+            <require>
+                <enum name="GL_UPLOAD_GPU_MASK_NVX"/>
+                <command name="glUploadGpuMaskNVX"/>
+                <command name="glMulticastViewportArrayvNVX"/>
+                <command name="glMulticastViewportPositionWScaleNVX"/>
+                <command name="glMulticastScissorArrayvNVX"/>
+                <command name="glAsyncCopyBufferSubDataNVX"/>
+                <command name="glAsyncCopyImageSubDataNVX"/>
+            </require>
+        </extension>
+        <extension name="GL_NVX_progress_fence" supported="gl">
+            <require>
+                <command name="glCreateProgressFenceNVX"/>
+                <command name="glSignalSemaphoreui64NVX"/>
+                <command name="glWaitSemaphoreui64NVX"/>
+                <command name="glClientWaitSemaphoreui64NVX"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_memory_attachment" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_ATTACHED_MEMORY_OBJECT_NV"/>
+                <enum name="GL_ATTACHED_MEMORY_OFFSET_NV"/>
+                <enum name="GL_MEMORY_ATTACHABLE_ALIGNMENT_NV"/>
+                <enum name="GL_MEMORY_ATTACHABLE_SIZE_NV"/>
+                <enum name="GL_MEMORY_ATTACHABLE_NV"/>
+                <enum name="GL_DETACHED_MEMORY_INCARNATION_NV"/>
+                <enum name="GL_DETACHED_TEXTURES_NV"/>
+                <enum name="GL_DETACHED_BUFFERS_NV"/>
+                <enum name="GL_MAX_DETACHED_TEXTURES_NV"/>
+                <enum name="GL_MAX_DETACHED_BUFFERS_NV"/>
+                <command name="glGetMemoryObjectDetachedResourcesuivNV"/>
+                <command name="glResetMemoryObjectParameterNV"/>
+                <command name="glTexAttachMemoryNV"/>
+                <command name="glBufferAttachMemoryNV"/>
+            </require>
+            <require comment="Supported only if GL_EXT_direct_state_access is supported">
+                <command name="glTextureAttachMemoryNV"/>
+                <command name="glNamedBufferAttachMemoryNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_mesh_shader" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_MESH_SHADER_NV"/>
+                <enum name="GL_TASK_SHADER_NV"/>
+                <enum name="GL_MAX_MESH_UNIFORM_BLOCKS_NV"/>
+                <enum name="GL_MAX_MESH_TEXTURE_IMAGE_UNITS_NV"/>
+                <enum name="GL_MAX_MESH_IMAGE_UNIFORMS_NV"/>
+                <enum name="GL_MAX_MESH_UNIFORM_COMPONENTS_NV"/>
+                <enum name="GL_MAX_MESH_ATOMIC_COUNTER_BUFFERS_NV"/>
+                <enum name="GL_MAX_MESH_ATOMIC_COUNTERS_NV"/>
+                <enum name="GL_MAX_MESH_SHADER_STORAGE_BLOCKS_NV"/>
+                <enum name="GL_MAX_COMBINED_MESH_UNIFORM_COMPONENTS_NV"/>
+                <enum name="GL_MAX_TASK_UNIFORM_BLOCKS_NV"/>
+                <enum name="GL_MAX_TASK_TEXTURE_IMAGE_UNITS_NV"/>
+                <enum name="GL_MAX_TASK_IMAGE_UNIFORMS_NV"/>
+                <enum name="GL_MAX_TASK_UNIFORM_COMPONENTS_NV"/>
+                <enum name="GL_MAX_TASK_ATOMIC_COUNTER_BUFFERS_NV"/>
+                <enum name="GL_MAX_TASK_ATOMIC_COUNTERS_NV"/>
+                <enum name="GL_MAX_TASK_SHADER_STORAGE_BLOCKS_NV"/>
+                <enum name="GL_MAX_COMBINED_TASK_UNIFORM_COMPONENTS_NV"/>
+                <enum name="GL_MAX_MESH_WORK_GROUP_INVOCATIONS_NV"/>
+                <enum name="GL_MAX_TASK_WORK_GROUP_INVOCATIONS_NV"/>
+                <enum name="GL_MAX_MESH_TOTAL_MEMORY_SIZE_NV"/>
+                <enum name="GL_MAX_TASK_TOTAL_MEMORY_SIZE_NV"/>
+                <enum name="GL_MAX_MESH_OUTPUT_VERTICES_NV"/>
+                <enum name="GL_MAX_MESH_OUTPUT_PRIMITIVES_NV"/>
+                <enum name="GL_MAX_TASK_OUTPUT_COUNT_NV"/>
+                <enum name="GL_MAX_DRAW_MESH_TASKS_COUNT_NV"/>
+                <enum name="GL_MAX_MESH_VIEWS_NV"/>
+                <enum name="GL_MESH_OUTPUT_PER_VERTEX_GRANULARITY_NV"/>
+                <enum name="GL_MESH_OUTPUT_PER_PRIMITIVE_GRANULARITY_NV"/>
+                <enum name="GL_MAX_MESH_WORK_GROUP_SIZE_NV"/>
+                <enum name="GL_MAX_TASK_WORK_GROUP_SIZE_NV"/>
+                <enum name="GL_MESH_WORK_GROUP_SIZE_NV"/>
+                <enum name="GL_TASK_WORK_GROUP_SIZE_NV"/>
+                <enum name="GL_MESH_VERTICES_OUT_NV"/>
+                <enum name="GL_MESH_PRIMITIVES_OUT_NV"/>
+                <enum name="GL_MESH_OUTPUT_TYPE_NV"/>
+                <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_MESH_SHADER_NV"/>
+                <enum name="GL_UNIFORM_BLOCK_REFERENCED_BY_TASK_SHADER_NV"/>
+                <enum name="GL_REFERENCED_BY_MESH_SHADER_NV"/>
+                <enum name="GL_REFERENCED_BY_TASK_SHADER_NV"/>
+                <enum name="GL_MESH_SHADER_BIT_NV"/>
+                <enum name="GL_TASK_SHADER_BIT_NV"/>
+                <command name="glDrawMeshTasksNV"/>
+                <command name="glDrawMeshTasksIndirectNV"/>
+                <command name="glMultiDrawMeshTasksIndirectNV"/>
+                <command name="glMultiDrawMeshTasksIndirectCountNV"/>
+            </require>
+            <require comment="Supported only in OpenGL">
+                <enum name="GL_MESH_SUBROUTINE_NV"/>
+                <enum name="GL_TASK_SUBROUTINE_NV"/>
+                <enum name="GL_MESH_SUBROUTINE_UNIFORM_NV"/>
+                <enum name="GL_TASK_SUBROUTINE_UNIFORM_NV"/>
+                <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_MESH_SHADER_NV"/>
+                <enum name="GL_ATOMIC_COUNTER_BUFFER_REFERENCED_BY_TASK_SHADER_NV"/>
             </require>
         </extension>
         <extension name="GL_NV_multisample_coverage" supported="gl">
@@ -44529,6 +48665,25 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_PATH_MAX_PROJECTION_STACK_DEPTH_NV"/>
                 <enum name="GL_PATH_TRANSPOSE_PROJECTION_MATRIX_NV"/>
                 <enum name="GL_FRAGMENT_INPUT_NV"/>
+                <command name="glMatrixFrustumEXT"/>
+                <command name="glMatrixLoadIdentityEXT"/>
+                <command name="glMatrixLoadTransposefEXT"/>
+                <command name="glMatrixLoadTransposedEXT"/>
+                <command name="glMatrixLoadfEXT"/>
+                <command name="glMatrixLoaddEXT"/>
+                <command name="glMatrixMultTransposefEXT"/>
+                <command name="glMatrixMultTransposedEXT"/>
+                <command name="glMatrixMultfEXT"/>
+                <command name="glMatrixMultdEXT"/>
+                <command name="glMatrixOrthoEXT"/>
+                <command name="glMatrixPopEXT"/>
+                <command name="glMatrixPushEXT"/>
+                <command name="glMatrixRotatefEXT"/>
+                <command name="glMatrixRotatedEXT"/>
+                <command name="glMatrixScalefEXT"/>
+                <command name="glMatrixScaledEXT"/>
+                <command name="glMatrixTranslatefEXT"/>
+                <command name="glMatrixTranslatedEXT"/>
             </require>
         </extension>
         <extension name="GL_NV_path_rendering_shared_edge" supported="gl|glcore|gles2">
@@ -44546,6 +48701,14 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_READ_PIXEL_DATA_RANGE_POINTER_NV"/>
                 <command name="glPixelDataRangeNV"/>
                 <command name="glFlushPixelDataRangeNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_pixel_buffer_object" supported="gles2">
+            <require>
+                <enum name="GL_PIXEL_PACK_BUFFER_NV"/>
+                <enum name="GL_PIXEL_UNPACK_BUFFER_NV"/>
+                <enum name="GL_PIXEL_PACK_BUFFER_BINDING_NV"/>
+                <enum name="GL_PIXEL_UNPACK_BUFFER_BINDING_NV"/>
             </require>
         </extension>
         <extension name="GL_NV_point_sprite" supported="gl">
@@ -44590,6 +48753,24 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_PRIMITIVE_RESTART_INDEX_NV"/>
                 <command name="glPrimitiveRestartNV"/>
                 <command name="glPrimitiveRestartIndexNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_query_resource" supported="gl">
+            <require>
+                <enum name="GL_QUERY_RESOURCE_TYPE_VIDMEM_ALLOC_NV"/>
+                <enum name="GL_QUERY_RESOURCE_MEMTYPE_VIDMEM_NV"/>
+                <enum name="GL_QUERY_RESOURCE_SYS_RESERVED_NV"/>
+                <enum name="GL_QUERY_RESOURCE_TEXTURE_NV"/>
+                <enum name="GL_QUERY_RESOURCE_RENDERBUFFER_NV"/>
+                <enum name="GL_QUERY_RESOURCE_BUFFEROBJECT_NV"/>
+                <command name="glQueryResourceNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_query_resource_tag" supported="gl">
+            <require>
+                <command name="glGenQueryResourceTagNV"/>
+                <command name="glDeleteQueryResourceTagNV"/>
+                <command name="glQueryResourceTagNV"/>
             </require>
         </extension>
         <extension name="GL_NV_read_buffer" supported="gles2">
@@ -44682,6 +48863,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glGetCombinerStageParameterfvNV"/>
             </require>
         </extension>
+        <extension name="GL_NV_representative_fragment_test" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_REPRESENTATIVE_FRAGMENT_TEST_NV"/>
+            </require>
+        </extension>
         <extension name="GL_NV_robustness_video_memory_purge" supported="gl">
             <require>
                 <enum name="GL_PURGED_CONTEXT_RESET_NV"/>
@@ -44717,12 +48903,20 @@ typedef unsigned int GLhandleARB;
             </require>
         </extension>
         <extension name="GL_NV_sample_mask_override_coverage" supported="gl|glcore|gles2"/>
-        <extension name="GL_NV_shader_atomic_counters" supported="gl"/>
-        <extension name="GL_NV_shader_atomic_float" supported="gl"/>
-        <extension name="GL_NV_shader_atomic_float64" supported="gl"/>
+        <extension name="GL_NV_scissor_exclusive" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SCISSOR_TEST_EXCLUSIVE_NV"/>
+                <enum name="GL_SCISSOR_BOX_EXCLUSIVE_NV"/>
+                <command name="glScissorExclusiveNV"/>
+                <command name="glScissorExclusiveArrayvNV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_shader_atomic_counters" supported="gl|glcore"/>
+        <extension name="GL_NV_shader_atomic_float" supported="gl|glcore"/>
+        <extension name="GL_NV_shader_atomic_float64" supported="gl|glcore"/>
         <extension name="GL_NV_shader_atomic_fp16_vector" supported="gl|glcore|gles2"/>
-        <extension name="GL_NV_shader_atomic_int64" supported="gl"/>
-        <extension name="GL_NV_shader_buffer_load" supported="gl">
+        <extension name="GL_NV_shader_atomic_int64" supported="gl|glcore"/>
+        <extension name="GL_NV_shader_buffer_load" supported="gl|glcore">
             <require>
                 <enum name="GL_BUFFER_GPU_ADDRESS_NV"/>
                 <enum name="GL_GPU_ADDRESS_NV"/>
@@ -44743,7 +48937,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glProgramUniformui64vNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_shader_buffer_store" supported="gl">
+        <extension name="GL_NV_shader_buffer_store" supported="gl|glcore">
             <require>
                 <enum name="GL_SHADER_GLOBAL_ACCESS_BARRIER_BIT_NV"/>
                 <enum name="GL_READ_WRITE"/>
@@ -44752,14 +48946,53 @@ typedef unsigned int GLhandleARB;
         </extension>
         <extension name="GL_NV_shader_noperspective_interpolation" supported="gles2"/>
         <extension name="GL_NV_shader_storage_buffer_object" supported="gl"/>
-        <extension name="GL_NV_shader_thread_group" supported="gl">
+        <extension name="GL_NV_shader_subgroup_partitioned" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SUBGROUP_FEATURE_PARTITIONED_BIT_NV"/>
+            </require>
+        </extension>
+        <extension name="GL_NV_shader_texture_footprint" supported="gl|glcore|gles2"/>
+        <extension name="GL_NV_shader_thread_group" supported="gl|glcore">
             <require>
                 <enum name="GL_WARP_SIZE_NV"/>
                 <enum name="GL_WARPS_PER_SM_NV"/>
                 <enum name="GL_SM_COUNT_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_shader_thread_shuffle" supported="gl"/>
+        <extension name="GL_NV_shader_thread_shuffle" supported="gl|glcore"/>
+        <extension name="GL_NV_shading_rate_image" supported="gl|glcore|gles2">
+            <require>
+                <enum name="GL_SHADING_RATE_IMAGE_NV"/>
+                <enum name="GL_SHADING_RATE_NO_INVOCATIONS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_PIXEL_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_1X2_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_2X1_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_2X2_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_2X4_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_4X2_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_1_INVOCATION_PER_4X4_PIXELS_NV"/>
+                <enum name="GL_SHADING_RATE_2_INVOCATIONS_PER_PIXEL_NV"/>
+                <enum name="GL_SHADING_RATE_4_INVOCATIONS_PER_PIXEL_NV"/>
+                <enum name="GL_SHADING_RATE_8_INVOCATIONS_PER_PIXEL_NV"/>
+                <enum name="GL_SHADING_RATE_16_INVOCATIONS_PER_PIXEL_NV"/>
+                <enum name="GL_SHADING_RATE_IMAGE_BINDING_NV"/>
+                <enum name="GL_SHADING_RATE_IMAGE_TEXEL_WIDTH_NV"/>
+                <enum name="GL_SHADING_RATE_IMAGE_TEXEL_HEIGHT_NV"/>
+                <enum name="GL_SHADING_RATE_IMAGE_PALETTE_SIZE_NV"/>
+                <enum name="GL_MAX_COARSE_FRAGMENT_SAMPLES_NV"/>
+                <enum name="GL_SHADING_RATE_SAMPLE_ORDER_DEFAULT_NV"/>
+                <enum name="GL_SHADING_RATE_SAMPLE_ORDER_PIXEL_MAJOR_NV"/>
+                <enum name="GL_SHADING_RATE_SAMPLE_ORDER_SAMPLE_MAJOR_NV"/>
+                <command name="glBindShadingRateImageNV"/>
+                <command name="glGetShadingRateImagePaletteNV"/>
+                <command name="glGetShadingRateSampleLocationivNV"/>
+                <command name="glShadingRateImageBarrierNV"/>
+                <command name="glShadingRateImageBarrierNV"/>
+                <command name="glShadingRateImagePaletteNV"/>
+                <command name="glShadingRateSampleOrderNV"/>
+                <command name="glShadingRateSampleOrderCustomNV"/>
+            </require>
+        </extension>
         <extension name="GL_NV_shadow_samplers_array" supported="gles2">
             <require>
                 <enum name="GL_SAMPLER_2D_ARRAY_SHADOW_NV"/>
@@ -44770,7 +49003,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_SAMPLER_CUBE_SHADOW_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_stereo_view_rendering" supported="gl"/>
+        <extension name="GL_NV_stereo_view_rendering" supported="gl|glcore|gles2"/>
         <extension name="GL_NV_tessellation_program5" supported="gl">
             <require>
                 <enum name="GL_MAX_PROGRAM_PATCH_ATTRIBS_NV"/>
@@ -44793,7 +49026,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_REFLECTION_MAP_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_texture_barrier" supported="gl">
+        <extension name="GL_NV_texture_barrier" supported="gl|glcore">
             <require>
                 <command name="glTextureBarrierNV"/>
             </require>
@@ -44843,6 +49076,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MAX_RECTANGLE_TEXTURE_SIZE_NV"/>
             </require>
         </extension>
+        <extension name="GL_NV_texture_rectangle_compressed" supported="gl|glcore"/>
         <extension name="GL_NV_texture_shader" supported="gl">
             <require>
                 <enum name="GL_OFFSET_TEXTURE_RECTANGLE_NV"/>
@@ -45010,7 +49244,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glDrawTransformFeedbackNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_uniform_buffer_unified_memory" supported="gl">
+        <extension name="GL_NV_uniform_buffer_unified_memory" supported="gl|glcore">
             <require>
                 <enum name="GL_UNIFORM_BUFFER_UNIFIED_NV"/>
                 <enum name="GL_UNIFORM_BUFFER_ADDRESS_NV"/>
@@ -45035,6 +49269,11 @@ typedef unsigned int GLhandleARB;
                 <command name="glVDPAUUnmapSurfacesNV"/>
             </require>
         </extension>
+        <extension name="GL_NV_vdpau_interop2" supported="gl">
+            <require>
+                <command name="glVDPAURegisterVideoSurfaceWithPictureStructureNV"/>
+            </require>
+        </extension>
         <extension name="GL_NV_vertex_array_range" supported="gl">
             <require>
                 <enum name="GL_VERTEX_ARRAY_RANGE_NV"/>
@@ -45051,7 +49290,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_VERTEX_ARRAY_RANGE_WITHOUT_FLUSH_NV"/>
             </require>
         </extension>
-        <extension name="GL_NV_vertex_attrib_integer_64bit" supported="gl">
+        <extension name="GL_NV_vertex_attrib_integer_64bit" supported="gl|glcore">
             <require>
                 <enum name="GL_INT64_NV"/>
                 <enum name="GL_UNSIGNED_INT64_NV"/>
@@ -45076,7 +49315,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glVertexAttribLFormatNV"/>
             </require>
         </extension>
-        <extension name="GL_NV_vertex_buffer_unified_memory" supported="gl">
+        <extension name="GL_NV_vertex_buffer_unified_memory" supported="gl|glcore">
             <require>
                 <enum name="GL_VERTEX_ATTRIB_ARRAY_UNIFIED_NV"/>
                 <enum name="GL_ELEMENT_ARRAY_UNIFIED_NV"/>
@@ -45557,7 +49796,7 @@ typedef unsigned int GLhandleARB;
                 <command name="glDrawElementsBaseVertexOES"/>
                 <command name="glDrawRangeElementsBaseVertexOES" comment="Supported only if OpenGL ES 3.0 is supported"/>
                 <command name="glDrawElementsInstancedBaseVertexOES" comment="Supported only if OpenGL ES 3.0 is supported"/>
-                <command name="glMultiDrawElementsBaseVertexOES" comment="Supported only if GL_EXT_multi_draw_arrays is supported"/>
+                <command name="glMultiDrawElementsBaseVertexEXT" comment="Supported only if GL_EXT_multi_draw_arrays is supported"/>
             </require>
         </extension>
         <extension name="GL_OES_draw_texture" supported="gles1">
@@ -45961,7 +50200,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_DECR_WRAP_OES"/>
             </require>
         </extension>
-        <extension name="GL_OES_surfaceless_context" supported="gles2">
+        <extension name="GL_OES_surfaceless_context" supported="gles1|gles2">
             <require>
                 <enum name="GL_FRAMEBUFFER_UNDEFINED_OES"/>
             </require>
@@ -46178,7 +50417,7 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_MIRRORED_REPEAT_OES"/>
             </require>
         </extension>
-        <extension name="GL_OES_texture_npot" supported="gles2"/>
+        <extension name="GL_OES_texture_npot" supported="gles1|gles2"/>
         <extension name="GL_OES_texture_stencil8" supported="gles2">
             <require>
                 <enum name="GL_STENCIL_INDEX_OES"/>
@@ -46392,10 +50631,44 @@ typedef unsigned int GLhandleARB;
                 <command name="glExtGetProgramBinarySourceQCOM"/>
             </require>
         </extension>
+        <extension name="GL_QCOM_framebuffer_foveated" supported="gles2">
+            <require>
+                <enum name="GL_FOVEATION_ENABLE_BIT_QCOM"/>
+                <enum name="GL_FOVEATION_SCALED_BIN_METHOD_BIT_QCOM"/>
+                <command name="glFramebufferFoveationConfigQCOM"/>
+                <command name="glFramebufferFoveationParametersQCOM"/>
+            </require>
+        </extension>
+        <extension name="GL_QCOM_texture_foveated" supported="gles2">
+            <require>
+                <enum name="GL_FOVEATION_ENABLE_BIT_QCOM"/>
+                <enum name="GL_FOVEATION_SCALED_BIN_METHOD_BIT_QCOM"/>
+                <enum name="GL_TEXTURE_FOVEATED_FEATURE_BITS_QCOM"/>
+                <enum name="GL_TEXTURE_FOVEATED_MIN_PIXEL_DENSITY_QCOM"/>
+                <enum name="GL_TEXTURE_FOVEATED_FEATURE_QUERY_QCOM"/>
+                <enum name="GL_TEXTURE_FOVEATED_NUM_FOCAL_POINTS_QUERY_QCOM"/>
+                <enum name="GL_FRAMEBUFFER_INCOMPLETE_FOVEATION_QCOM"/>
+                <command name="glTextureFoveationParametersQCOM"/>
+            </require>
+        </extension>
+        <extension name="GL_QCOM_texture_foveated_subsampled_layout" supported="gles2">
+            <require>
+                <enum name="GL_FOVEATION_SUBSAMPLED_LAYOUT_METHOD_BIT_QCOM"/>
+                <enum name="GL_MAX_SHADER_SUBSAMPLED_IMAGE_UNITS_QCOM"/>
+            </require>
+        </extension>
         <extension name="GL_QCOM_perfmon_global_mode" supported="gles1|gles2">
             <require>
                 <enum name="GL_PERFMON_GLOBAL_MODE_QCOM"/>
             </require>
+        </extension>
+        <extension name="GL_QCOM_shader_framebuffer_fetch_noncoherent" supported="gles2">
+            <require>
+                <enum name="GL_FRAMEBUFFER_FETCH_NONCOHERENT_QCOM"/>
+                <command name="glFramebufferFetchBarrierQCOM"/>
+            </require>
+        </extension>
+        <extension name="GL_QCOM_shader_framebuffer_fetch_rate" supported="gles2">
         </extension>
         <extension name="GL_QCOM_tiled_rendering" supported="gles1|gles2">
             <require>
@@ -46439,6 +50712,8 @@ typedef unsigned int GLhandleARB;
             <require>
                 <enum name="GL_WRITEONLY_RENDERING_QCOM"/>
             </require>
+        </extension>
+        <extension name="GL_QCOM_YUV_texture_gather" supported="gles2">
         </extension>
         <extension name="GL_REND_screen_coordinates" supported="gl">
             <require>
@@ -47114,5 +51389,6 @@ typedef unsigned int GLhandleARB;
                 <enum name="GL_FOG_SPECULAR_TEXTURE_WIN"/>
             </require>
         </extension>
+        <extension name="GL_EXT_texture_shadow_lod" supported="gl|glcore|gles2"/>
     </extensions>
 </registry>

--- a/registry/glx.xml
+++ b/registry/glx.xml
@@ -1,36 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
-    <!--
-    Copyright (c) 2013-2016 The Khronos Group Inc.
+    <comment>
+Copyright (c) 2013-2018 The Khronos Group Inc.
 
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and/or associated documentation files (the
-    "Materials"), to deal in the Materials without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Materials, and to
-    permit persons to whom the Materials are furnished to do so, subject to
-    the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Materials.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-    THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-    -->
-    <!--
-    This file, glx.xml, is the GLX API Registry. The older ".spec" file
-    format has been retired and will no longer be updated with new
-    extensions and API versions. The canonical version of the registry,
-    together with documentation, schema, and Python generator scripts used
-    to generate C header files for GLX, can always be found in the Khronos
-    Registry at
-        http://www.opengl.org/registry/
-    -->
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+------------------------------------------------------------------------
+
+This file, glx.xml, is the GLX API Registry. The canonical version of the
+registry, together with documentation, schema, and Python generator scripts
+used to generate C header files for GLX, can always be found in the Khronos
+Registry at
+        https://github.com/KhronosGroup/OpenGL-Registry
+    </comment>
 
     <!-- SECTION: GLX type definitions. Does not include X or GL types. -->
     <types>
@@ -470,6 +462,17 @@ typedef unsigned __int64 uint64_t;
             <unused start="0x21A9" end="0x21AF"/>
     </enums>
 
+    <enums namespace="GLX" start="0x3100" end="0x3103" vendor="EXT" comment="Shared with EGL_IMG_context_priority">
+        <enum value="0x3100"        name="GLX_CONTEXT_PRIORITY_LEVEL_EXT"/>
+        <enum value="0x3101"        name="GLX_CONTEXT_PRIORITY_HIGH_EXT"/>
+        <enum value="0x3102"        name="GLX_CONTEXT_PRIORITY_MEDIUM_EXT"/>
+        <enum value="0x3103"        name="GLX_CONTEXT_PRIORITY_LOW_EXT"/>
+    </enums>
+
+    <enums namespace="GLX" start="0x31B3" end="0x31B3" vendor="ARB" comment="Shared with WGL.">
+        <enum value="0x31B3" name="GLX_CONTEXT_OPENGL_NO_ERROR_ARB"/>
+    </enums>
+
     <enums namespace="GLX" start="0x8000" end="0x804F" vendor="ARB">
         <enum value="0x8000"        name="GLX_NONE"                                 comment="Attribute value"/>
         <enum value="0x8001"        name="GLX_SLOW_CONFIG"                          comment="CONFIG_CAVEAT attribute value"/>
@@ -587,8 +590,7 @@ typedef unsigned __int64 uint64_t;
         <enum value="0x818B"        name="GLX_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA"/>
         <enum value="0x818C"        name="GLX_RENDERER_OPENGL_ES_PROFILE_VERSION_MESA"/>
         <enum value="0x818D"        name="GLX_RENDERER_OPENGL_ES2_PROFILE_VERSION_MESA"/>
-        <enum value="0x818E"        name="GLX_RENDERER_ID_MESA"/>
-            <unused start="0x818F"/>
+            <unused start="0x818E" end="0x818F"/>
     </enums>
 
 <!-- Please remember that new enumerant allocations must be obtained by
@@ -1076,6 +1078,9 @@ typedef unsigned __int64 uint64_t;
             <param>unsigned long *<name>mask</name></param>
         </command>
         <command>
+            <proto>int <name>glXGetSwapIntervalMESA</name></proto>
+        </command>
+        <command>
             <proto><ptype>Bool</ptype> <name>glXGetSyncValuesOML</name></proto>
             <param><ptype>Display</ptype> *<name>dpy</name></param>
             <param><ptype>GLXDrawable</ptype> <name>drawable</name></param>
@@ -1088,7 +1093,7 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>Display</ptype> *<name>dpy</name></param>
             <param><ptype>Window</ptype> <name>overlay</name></param>
             <param><ptype>Window</ptype> <name>underlay</name></param>
-            <param>long *<name>pTransparentIndex</name></param>
+            <param>unsigned long *<name>pTransparentIndex</name></param>
         </command>
         <command>
             <proto>int <name>glXGetVideoDeviceNV</name></proto>
@@ -1254,7 +1259,7 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>GLuint</ptype> *<name>count</name></param>
         </command>
         <command>
-            <proto>int <name>glXQueryGLXPbufferSGIX</name></proto>
+            <proto>void <name>glXQueryGLXPbufferSGIX</name></proto>
             <param><ptype>Display</ptype> *<name>dpy</name></param>
             <param><ptype>GLXPbufferSGIX</ptype> <name>pbuf</name></param>
             <param>int <name>attribute</name></param>
@@ -1395,8 +1400,8 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>GLboolean</ptype> <name>bBlock</name></param>
         </command>
         <command>
-            <proto><ptype>Bool</ptype> <name>glXSet3DfxModeMESA</name></proto>
-            <param>int <name>mode</name></param>
+            <proto><ptype>GLboolean</ptype> <name>glXSet3DfxModeMESA</name></proto>
+            <param>GLint <name>mode</name></param>
         </command>
         <command>
             <proto>void <name>glXSwapBuffers</name></proto>
@@ -1410,6 +1415,10 @@ typedef unsigned __int64 uint64_t;
             <param><ptype>int64_t</ptype> <name>target_msc</name></param>
             <param><ptype>int64_t</ptype> <name>divisor</name></param>
             <param><ptype>int64_t</ptype> <name>remainder</name></param>
+        </command>
+        <command>
+            <proto>int <name>glXSwapIntervalMESA</name></proto>
+            <param>unsigned int <name>interval</name></param>
         </command>
         <command>
             <proto>void <name>glXSwapIntervalEXT</name></proto>
@@ -1670,6 +1679,11 @@ typedef unsigned __int64 uint64_t;
                 <command name="glXCreateContextAttribsARB"/>
             </require>
         </extension>
+        <extension name="GLX_ARB_create_context_no_error" supported="glx">
+            <require>
+                <enum name="GLX_CONTEXT_OPENGL_NO_ERROR_ARB"/>
+            </require>
+        </extension>
         <extension name="GLX_ARB_create_context_profile" supported="glx">
             <require>
                 <enum name="GLX_CONTEXT_CORE_PROFILE_BIT_ARB"/>
@@ -1727,6 +1741,14 @@ typedef unsigned __int64 uint64_t;
                 <enum name="GLX_BACK_BUFFER_AGE_EXT"/>
             </require>
         </extension>
+        <extension name="GLX_EXT_context_priority" supported="glx">
+            <require>
+                <enum name="GLX_CONTEXT_PRIORITY_LEVEL_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_HIGH_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_MEDIUM_EXT"/>
+                <enum name="GLX_CONTEXT_PRIORITY_LOW_EXT"/>
+            </require>
+        </extension>
         <extension name="GLX_EXT_create_context_es_profile" supported="glx">
             <require>
                 <enum name="GLX_CONTEXT_ES_PROFILE_BIT_EXT"/>
@@ -1764,6 +1786,8 @@ typedef unsigned __int64 uint64_t;
             <require>
                 <enum name="GLX_VENDOR_NAMES_EXT"/>
             </require>
+        </extension>
+        <extension name="GLX_EXT_no_config_context" supported="glx">
         </extension>
         <extension name="GLX_EXT_stereo_tree" supported="glx">
             <require>
@@ -1888,7 +1912,6 @@ typedef unsigned __int64 uint64_t;
                 <enum name="GLX_RENDERER_OPENGL_COMPATIBILITY_PROFILE_VERSION_MESA"/>
                 <enum name="GLX_RENDERER_OPENGL_ES_PROFILE_VERSION_MESA"/>
                 <enum name="GLX_RENDERER_OPENGL_ES2_PROFILE_VERSION_MESA"/>
-                <enum name="GLX_RENDERER_ID_MESA"/>
                 <command name="glXQueryCurrentRendererIntegerMESA"/>
                 <command name="glXQueryCurrentRendererStringMESA"/>
                 <command name="glXQueryRendererIntegerMESA"/>
@@ -1905,6 +1928,12 @@ typedef unsigned __int64 uint64_t;
                 <enum name="GLX_3DFX_WINDOW_MODE_MESA"/>
                 <enum name="GLX_3DFX_FULLSCREEN_MODE_MESA"/>
                 <command name="glXSet3DfxModeMESA"/>
+            </require>
+        </extension>
+        <extension name="GLX_MESA_swap_control" supported="glx">
+            <require>
+                <command name="glXGetSwapIntervalMESA"/>
+                <command name="glXSwapIntervalMESA"/>
             </require>
         </extension>
         <extension name="GLX_NV_copy_buffer" supported="glx">

--- a/registry/wgl.xml
+++ b/registry/wgl.xml
@@ -1,36 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
-    <!--
-    Copyright (c) 2013-2016 The Khronos Group Inc.
+    <comment>
+Copyright (c) 2013-2018 The Khronos Group Inc.
 
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and/or associated documentation files (the
-    "Materials"), to deal in the Materials without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Materials, and to
-    permit persons to whom the Materials are furnished to do so, subject to
-    the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Materials.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-    THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-    -->
-    <!--
-    This file, wgl.xml, is the WGL API Registry. The older ".spec" file
-    format has been retired and will no longer be updated with new
-    extensions and API versions. The canonical version of the registry,
-    together with documentation, schema, and Python generator scripts used
-    to generate C header files for WGL, can always be found in the Khronos
-    Registry at
-        http://www.opengl.org/registry/
-    -->
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+------------------------------------------------------------------------
+
+This file, wgl.xml, is the WGL API Registry. The older ".spec" file
+format has been retired and will no longer be updated with new
+extensions and API versions. The canonical version of the registry,
+together with documentation, schema, and Python generator scripts used
+to generate C header files for WGL, can always be found in the Khronos
+Registry at
+        https://github.com/KhronosGroup/OpenGL-Registry
+    </comment>
 
     <!-- SECTION: WGL type definitions. Does not include base Windows types. -->
 
@@ -390,7 +384,12 @@
         <enum value="0x20A8"        name="WGL_TYPE_RGBA_UNSIGNED_FLOAT_EXT"/>
         <enum value="0x20A9"        name="WGL_FRAMEBUFFER_SRGB_CAPABLE_ARB"/>
         <enum value="0x20A9"        name="WGL_FRAMEBUFFER_SRGB_CAPABLE_EXT"/>
-            <unused start="0x20AA" end="0x20AF"/>
+        <enum value="0x20AA"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+        <enum value="0x20AB"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+        <enum value="0x20AC"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+        <enum value="0x20AD"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+        <enum value="0x20AE"        name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
+            <unused start="0x20AF" end="0x20AF"/>
         <enum value="0x20B0"        name="WGL_FLOAT_COMPONENTS_NV"/>
         <enum value="0x20B1"        name="WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_R_NV"/>
         <enum value="0x20B2"        name="WGL_BIND_TO_TEXTURE_RECTANGLE_FLOAT_RG_NV"/>
@@ -433,6 +432,7 @@
         <enum value="0x21A3"        name="WGL_GPU_RAM_AMD"/>
         <enum value="0x21A4"        name="WGL_GPU_CLOCK_AMD"/>
         <enum value="0x21A5"        name="WGL_GPU_NUM_PIPES_AMD"/>
+        <enum value="0x21A5"        name="WGL_TEXTURE_RECTANGLE_ATI" comment="Duplicates unrelated WGL_GPU_NUM_PIPES_AMD"/>
         <enum value="0x21A6"        name="WGL_GPU_NUM_SIMD_AMD"/>
         <enum value="0x21A7"        name="WGL_GPU_NUM_RB_AMD"/>
         <enum value="0x21A8"        name="WGL_GPU_NUM_SPI_AMD"/>
@@ -457,9 +457,13 @@
     </enums>
 
     <enums namespace="EGL" start="0x3080" end="0x30AF" vendor="KHR" comment="Values shared with EGL. Do not allocate additional values in this range.">
-        <enum value="0x3087" name="WGL_COLORSPACE_EXT"/>
+        <enum value="0x309D" name="WGL_COLORSPACE_EXT"/>
         <enum value="0x3089" name="WGL_COLORSPACE_SRGB_EXT"/>
         <enum value="0x308A" name="WGL_COLORSPACE_LINEAR_EXT"/>
+    </enums>
+
+    <enums namespace="WGL" start="0x31B3" end="0x31B3" vendor="ARB" comment="Shared with GLX.">
+        <enum value="0x31B3" name="WGL_CONTEXT_OPENGL_NO_ERROR_ARB"/>
     </enums>
 
     <enums namespace="GL" start="0x8250" end="0x826F" vendor="ARB" comment="Values shared with GL. Do not allocate additional values in this range.">
@@ -539,7 +543,7 @@
         </command>
         <command>
             <proto><ptype>BOOL</ptype> <name>wglBindVideoDeviceNV</name></proto>
-            <param><ptype>HDC</ptype> <name>hDC</name></param>
+            <param><ptype>HDC</ptype> <name>hDc</name></param>
             <param>unsigned int <name>uVideoSlot</name></param>
             <param><ptype>HVIDEOOUTPUTDEVICENV</ptype> <name>hVideoDevice</name></param>
             <param>const int *<name>piAttribList</name></param>
@@ -782,7 +786,7 @@
         </command>
         <command>
             <proto>int <name>wglEnumerateVideoDevicesNV</name></proto>
-            <param><ptype>HDC</ptype> <name>hDC</name></param>
+            <param><ptype>HDC</ptype> <name>hDc</name></param>
             <param><ptype>HVIDEOOUTPUTDEVICENV</ptype> *<name>phDeviceList</name></param>
         </command>
         <command>
@@ -913,7 +917,7 @@
         <command>
             <proto><ptype>INT</ptype> <name>wglGetGPUInfoAMD</name></proto>
             <param><ptype>UINT</ptype> <name>id</name></param>
-            <param>int <name>property</name></param>
+            <param><ptype>INT</ptype> <name>property</name></param>
             <param><ptype>GLenum</ptype> <name>dataType</name></param>
             <param><ptype>UINT</ptype> <name>size</name></param>
             <param>void *<name>data</name></param>
@@ -1236,7 +1240,7 @@
         <command>
             <proto><ptype>INT64</ptype> <name>wglSwapLayerBuffersMscOML</name></proto>
             <param><ptype>HDC</ptype> <name>hdc</name></param>
-            <param>int <name>fuPlanes</name></param>
+            <param><ptype>INT</ptype> <name>fuPlanes</name></param>
             <param><ptype>INT64</ptype> <name>target_msc</name></param>
             <param><ptype>INT64</ptype> <name>divisor</name></param>
             <param><ptype>INT64</ptype> <name>remainder</name></param>
@@ -1451,6 +1455,11 @@
                 <command name="wglCreateContextAttribsARB"/>
             </require>
         </extension>
+        <extension name="WGL_ARB_create_context_no_error" supported="wgl">
+            <require>
+                <enum name="WGL_CONTEXT_OPENGL_NO_ERROR_ARB"/>
+            </require>
+        </extension>
         <extension name="WGL_ARB_create_context_profile" supported="wgl">
             <require>
                 <enum name="WGL_CONTEXT_PROFILE_MASK_ARB"/>
@@ -1622,6 +1631,11 @@
         <extension name="WGL_ATI_pixel_format_float" supported="wgl">
             <require>
                 <enum name="WGL_TYPE_RGBA_FLOAT_ATI"/>
+            </require>
+        </extension>
+        <extension name="WGL_ATI_render_texture_rectangle" supported="wgl">
+            <require>
+                <enum name="WGL_TEXTURE_RECTANGLE_ATI"/>
             </require>
         </extension>
         <extension name="WGL_EXT_colorspace" supported="wgl">
@@ -1974,6 +1988,15 @@
                 <command name="wglSwapLayerBuffersMscOML"/>
                 <command name="wglWaitForMscOML"/>
                 <command name="wglWaitForSbcOML"/>
+            </require>
+        </extension>
+        <extension name="WGL_NV_multigpu_context" supported="wgl">
+            <require>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_SINGLE_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_AFR_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTICAST_NV"/>
+                <enum name="WGL_CONTEXT_MULTIGPU_ATTRIB_MULTI_DISPLAY_MULTICAST_NV"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
Seems like commit 5a281aeaa56a5c56f059a7457e94cb2a2a0cee86 was made without moving `khronos-registry` branch
So fixing it.
Regestry versions:
- OpenGL: 253836ac53b2e248fa47d96cacc18a63ac27c703
- EGL: a9bef577b041caab108257ea386d0302290d4361