### PR TITLE
Define APIENTRY the same way its defined in windows.h

### DIFF
--- a/include/epoxy/gl.h
+++ b/include/epoxy/gl.h
@@ -56,7 +56,10 @@
 
 #else
 #ifndef APIENTRY
-#define APIENTRY __stdcall
+#ifndef WINAPI
+#define WINAPI __stdcall
+#endif
+#define APIENTRY WINAPI
 #endif
 
 #ifndef GLAPIENTRY


### PR DESCRIPTION
This avoids redefinition warnings when including epoxy/gl.h before windows.h