### PR TITLE
Fix inconsistent linkage when building as static on Windows

### DIFF
--- a/include/epoxy/common.h
+++ b/include/epoxy/common.h
@@ -38,7 +38,7 @@
 #endif
 
 #ifndef EPOXY_PUBLIC
-# if defined(_MSC_VER)
+# if defined(_MSC_VER) && defined(EPOXY_SHARED)
 #  define EPOXY_PUBLIC __declspec(dllimport) extern
 # else
 #  define EPOXY_PUBLIC extern

--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,7 @@ libtype = get_option('default_library')
 # Visibility compiler flags; we only use this for shared libraries
 visibility_cflags = []
 if libtype == 'shared'
+  common_cflags += [ '-DEPOXY_SHARED' ]
   if host_system == 'windows'
     conf.set('DLL_EXPORT', true)
     conf.set('EPOXY_PUBLIC', '__declspec(dllexport) extern')


### PR DESCRIPTION
`EPOXY_PUBLIC` is defined to `__declspec(dllexport) extern` in meson.build only if building as a shared library on Windows. Otherwise it's defined to `extern` if building as a shared library, and if building as static, it is not defined at all.

However, when `EPOXY_PUBLIC` is not defined, `epoxy/common.h` will define `EPOXY_PUBLIC` to `__declspec(dllimport) extern` if building on MSVC.

I'm not exactly sure what's going on with the duplicated definition here, but I have worked around the problem by defining `EPOXY_SHARED` if building as a shared library. This define is set in `common_cflags`, which means it will be propagated through to pkgconfig, so consuming libraries will set this variable appropriately. Then I have changed common.h to only define `EPOXY_PUBLIC` for dll imports if `EPOXY_SHARED` is also set.