### PR TITLE
Sync egl.xml from KhronosGroup/EGL-Registry

### DIFF
--- a/registry/egl.xml
+++ b/registry/egl.xml
@@ -1,27 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <!--
-    Copyright (c) 2013-2017 The Khronos Group Inc.
-
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and/or associated documentation files (the
-    "Materials"), to deal in the Materials without restriction, including
-    without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Materials, and to
-    permit persons to whom the Materials are furnished to do so, subject to
-    the following conditions:
-
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Materials.
-
-    THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-    MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-    -->
+    Copyright 2013-2020 The Khronos Group Inc.
+    SPDX-License-Identifier: Apache-2.0
+     -->
     <!--
     This file, egl.xml, is the EGL API Registry. The older ".spec" file
     format has been retired and will no longer be updated with new
@@ -49,6 +31,9 @@
         <type name="NativePixmapType" requires="eglplatform"/>
         <type name="NativeWindowType" requires="eglplatform"/>
         <type>struct <name>AHardwareBuffer</name>;</type>
+        <type>struct <name>wl_buffer</name>;</type>
+        <type>struct <name>wl_display</name>;</type>
+        <type>struct <name>wl_resource</name>;</type>
         <!-- Dummy placeholders for non-EGL types -->
         <type name="Bool"/>
             <!-- These are actual EGL types.  -->
@@ -89,7 +74,13 @@
     EGLint iHeight;
     EGLint iStride;
 };</type>
+        <!-- Backwards-compatibility hack: Downstream implementations shipped
+             incorrect function pointer names for some years. -->
         <type>typedef void (<apientry/> *<name>EGLDEBUGPROCKHR</name>)(EGLenum error,const char *command,EGLint messageType,EGLLabelKHR threadLabel,EGLLabelKHR objectLabel,const char* message);</type>
+        <type>#define <name>PFNEGLBINDWAYLANDDISPLAYWL</name> PFNEGLBINDWAYLANDDISPLAYWLPROC</type>
+        <type>#define <name>PFNEGLUNBINDWAYLANDDISPLAYWL</name> PFNEGLUNBINDWAYLANDDISPLAYWLPROC</type>
+        <type>#define <name>PFNEGLQUERYWAYLANDBUFFERWL</name> PFNEGLQUERYWAYLANDBUFFERWLPROC</type>
+        <type>#define <name>PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL</name> PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWLPROC</type>
     </types>
 
     <!-- SECTION: EGL enumerant (token) definitions. -->
@@ -581,9 +572,26 @@
         <enum value="0x31D7" name="EGL_PLATFORM_GBM_MESA" alias="EGL_PLATFORM_GBM_KHR"/>
         <enum value="0x31D8" name="EGL_PLATFORM_WAYLAND_KHR"/>
         <enum value="0x31D8" name="EGL_PLATFORM_WAYLAND_EXT" alias="EGL_PLATFORM_WAYLAND_KHR"/>
-            <unused start="0x31D9" end="0x31DC"/>
+        <enum value="0x31DC" name="EGL_PLATFORM_XCB_EXT"/>
         <enum value="0x31DD" name="EGL_PLATFORM_SURFACELESS_MESA"/>
-            <unused start="0x31DE" end="0x31DF"/>
+        <enum value="0x31DE" name="EGL_PLATFORM_XCB_SCREEN_EXT"/>
+        <enum value="0x31DF" name="EGL_PRESENT_OPAQUE_EXT"/>
+    </enums>
+
+    <!-- Due to an oversight in development, these enums alias the above MESA
+         vendor range for EGL the X11/GBM/Wayland/surfaceless platforms.
+         They are both currently in wide use and cannot be changed, however
+         the tokens cannot be used in the same contexts and the aliasing is
+         therefore harmless. Future Wayland tokens should not create further
+         aliasing in this range.-->
+    <enums namespace="EGL" start="0x31D5" end="0x31DB" vendor="WL" comment="EGL_WL_bind_wayland_display">
+        <enum value="0x31D5" name="EGL_WAYLAND_BUFFER_WL"/>
+        <enum value="0x31D6" name="EGL_WAYLAND_PLANE_WL"/>
+        <enum value="0x31D7" name="EGL_TEXTURE_Y_U_V_WL"/>
+        <enum value="0x31D8" name="EGL_TEXTURE_Y_UV_WL"/>
+        <enum value="0x31D9" name="EGL_TEXTURE_Y_XUXV_WL"/>
+        <enum value="0x31DA" name="EGL_TEXTURE_EXTERNAL_WL"/>
+        <enum value="0x31DB" name="EGL_WAYLAND_Y_INVERTED_WL"/>
     </enums>
 
     <enums namespace="EGL" start="0x31E0" end="0x31EF" vendor="HI" comment="Reserved for Mark Callow (Khronos bug 6799)">
@@ -719,9 +727,13 @@
         <enum value="0x3284" name="EGL_YUV_CHROMA_SITING_0_EXT"/>
         <enum value="0x3285" name="EGL_YUV_CHROMA_SITING_0_5_EXT"/>
         <enum value="0x3286" name="EGL_DISCARD_SAMPLES_ARM"/>
-            <unused start="0x3287" end="0x3289"/>
+        <enum value="0x3287" name="EGL_COLOR_COMPONENT_TYPE_UNSIGNED_INTEGER_ARM"/>
+        <enum value="0x3288" name="EGL_COLOR_COMPONENT_TYPE_INTEGER_ARM"/>
+            <unused start="0x3289" end="0x3289"/>
         <enum value="0x328A" name="EGL_SYNC_PRIOR_COMMANDS_IMPLICIT_EXTERNAL_ARM"/>
-            <unused start="0x328B" end="0x328F"/>
+            <unused start="0x328B" end="0x328D"/>
+        <enum value="0x328E" name="EGL_SURFACE_COMPRESSION_PLANE1_EXT"/>
+        <enum value="0x328F" name="EGL_SURFACE_COMPRESSION_PLANE2_EXT"/>
     </enums>
 
     <enums namespace="EGL" start="0x3290" end="0x329F" vendor="MESA" comment="Reserved for John K&#229;re Alsaker (Public bug 757)">
@@ -819,7 +831,8 @@
         <enum value="0x333A" name="EGL_COLOR_COMPONENT_TYPE_FIXED_EXT"/>
         <enum value="0x333B" name="EGL_COLOR_COMPONENT_TYPE_FLOAT_EXT"/>
         <enum value="0x333C" name="EGL_DRM_MASTER_FD_EXT"/>
-            <unused start="0x333D" end="0x333E"/>
+        <enum value="0x333D" name="EGL_OPENWF_DEVICE_EXT"/>
+            <unused start="0x333E"/>
         <enum value="0x333F" name="EGL_GL_COLORSPACE_BT2020_LINEAR_EXT"/>
         <enum value="0x3340" name="EGL_GL_COLORSPACE_BT2020_PQ_EXT"/>
         <enum value="0x3341" name="EGL_SMPTE2086_DISPLAY_PRIMARY_RX_EXT"/>
@@ -843,7 +856,11 @@
         <enum value="0x3352" name="EGL_TRACK_REFERENCES_KHR"/>
             <unused start="0x3353" end="0x3356"/>
         <enum value="0x3357" name="EGL_CONTEXT_PRIORITY_REALTIME_NV"/>
-            <unused start="0x3358" end="0x335F"/>
+            <unused start="0x3358" end="0x335B"/>
+        <enum value="0x335C" name="EGL_DEVICE_UUID_EXT"/>
+        <enum value="0x335D" name="EGL_DRIVER_UUID_EXT"/>
+        <enum value="0x335E" name="EGL_DRIVER_NAME_EXT"/>
+        <enum value="0x335F" name="EGL_RENDERER_EXT"/>
         <enum value="0x3360" name="EGL_CTA861_3_MAX_CONTENT_LIGHT_LEVEL_EXT"/>
         <enum value="0x3361" name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
         <enum value="0x3362" name="EGL_GL_COLORSPACE_DISPLAY_P3_LINEAR_EXT"/>
@@ -863,7 +880,14 @@
         <enum value="0x3370" name="EGL_Y_AXIS_NV"/>
         <enum value="0x3371" name="EGL_STREAM_DMA_NV"/>
         <enum value="0x3372" name="EGL_STREAM_DMA_SERVER_NV"/>
-            <unused start="0x3373" end="0x339F"/>
+        <enum value="0x3373" name="EGL_STREAM_CONSUMER_IMAGE_NV"/>
+        <enum value="0x3374" name="EGL_STREAM_IMAGE_ADD_NV"/>
+        <enum value="0x3375" name="EGL_STREAM_IMAGE_REMOVE_NV"/>
+        <enum value="0x3376" name="EGL_STREAM_IMAGE_AVAILABLE_NV"/>
+        <enum value="0x3377" name="EGL_DRM_RENDER_NODE_FILE_EXT"/>
+        <enum value="0x3378" name="EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV" />
+        <enum value="0x3379" name="EGL_ALLOC_NEW_DISPLAY_EXT"/>
+            <unused start="0x337A" end="0x339F"/>
     </enums>
 
     <enums namespace="EGL" start="0x33A0" end="0x33AF" vendor="ANGLE" comment="Reserved for Shannon Woods (Bug 13175)">
@@ -1002,6 +1026,74 @@
         <enum value="0x3490" name="EGL_GL_COLORSPACE_DISPLAY_P3_PASSTHROUGH_EXT"/>
             <unused start="0x3491" end="0x349F"/>
     </enums>
+    <enums namespace="EGL" start="0x34A0" end="0x34AF" vendor="ANGLE" comment="Reserved for Ken Russell - ANGLE (via github pull request)">
+            <unused start="0x34A0" end="0x34AF"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x34B0" end="0x34BF" vendor="ARM" comment="Reserved for Jan-Harald Fredriksen (via github pull request)">
+        <enum value="0x34B0" name="EGL_SURFACE_COMPRESSION_EXT"/>
+        <enum value="0x34B1" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_NONE_EXT"/>
+        <enum value="0x34B2" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_DEFAULT_EXT"/>
+            <unused start="0x34B3" end="0x34B3"/>
+        <enum value="0x34B4" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_1BPC_EXT"/>
+        <enum value="0x34B5" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_2BPC_EXT"/>
+        <enum value="0x34B6" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_3BPC_EXT"/>
+        <enum value="0x34B7" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_4BPC_EXT"/>
+        <enum value="0x34B8" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_5BPC_EXT"/>
+        <enum value="0x34B9" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_6BPC_EXT"/>
+        <enum value="0x34BA" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_7BPC_EXT"/>
+        <enum value="0x34BB" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_8BPC_EXT"/>
+        <enum value="0x34BC" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_9BPC_EXT"/>
+        <enum value="0x34BD" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_10BPC_EXT"/>
+        <enum value="0x34BE" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_11BPC_EXT"/>
+        <enum value="0x34BF" name="EGL_SURFACE_COMPRESSION_FIXED_RATE_12BPC_EXT"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x34C0" end="0x34CF" vendor="EXT" comment="Reserved for Robert Mader (PR 124)">
+        <enum value="0x34C0" name="EGL_CONFIG_SELECT_GROUP_EXT"/>
+            <unused start="0x34C1" end="0x34CF"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x34D0" end="0x34DF" vendor="ANGLE" comment="Reserved for Peng Huang - ANGLE (via github pull request)">
+            <unused start="0x34D0" end="0x34DF"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x34E0" end="0x34EF" vendor="Huawei" comment="Reserved for Openharmony OS (via github pull request)">
+            <unused start="0x34E0" end="0x34EF"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x34F0" end="0x34FF" vendor="ANGLE" comment="Reserved for Ken Russell - ANGLE (via github pull request)">
+            <unused start="0x34F0" end="0x34FF"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3500" end="0x352F" vendor="COREAVI" comment="Reserved for Daniel Herring (via github pull request)">
+        <unused start="0x3500" end="0x352F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3530" end="0x353F" vendor="MESA" comment="Reserved for Simon Zeni (PR 165)">
+            <enum value="0x3530" name="EGL_GL_TEXTURE_CUBE_MAP_MESA"/>
+                <unused start="0x3531" end="0x353F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3540" end="0x354F" vendor="EXT" comment="Reserved for Chris Glover (EGL_EXT_gl_colorspace_bt2020)">
+            <enum value="0x3540" name="EGL_GL_COLORSPACE_BT2020_HLG_EXT"/>
+                <unused start="0x3541" end="0x354F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3550" end="0x355F" vendor="QNX" comment="Reserved for Mike Gorchak of QNX (QNX platform and native buffer)">
+        <enum value="0x3550" name="EGL_PLATFORM_SCREEN_QNX"/>
+        <enum value="0x3551" name="EGL_NATIVE_BUFFER_QNX"/>
+            <unused start="0x3552" end="0x355F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3560" end="0x356F" vendor="SAMSUNG" comment="Reserved for Jeff Vigil of Samsung (private extensions)">
+        <unused start="0x3560" end="0x356F"/>
+    </enums>
+
+    <enums namespace="EGL" start="0x3570" end="0x357F" vendor="Google" comment="Reserved for Tom Murphy (EGL-Registry pull #204)">
+        <enum value="0x3570" name="EGL_TELEMETRY_HINT_ANDROID"/>
+            <unused start="0x3571" end="0x357F"/>
+    </enums>
 
 <!-- Please remember that new enumerant allocations must be obtained by
      request to the Khronos API registrar (see comments at the top of this
@@ -1012,8 +1104,8 @@
 
 <!-- Reservable for future use. To generate a new range, allocate multiples
      of 16 starting at the lowest available point in this block. -->
-    <enums namespace="EGL" start="0x34A0" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
-            <unused start="0x34A0" end="0x3FFF"/>
+    <enums namespace="EGL" start="0x3580" end="0x3FFF" vendor="KHR" comment="Reserved for future use">
+            <unused start="0x3580" end="0x3FFF"/>
     </enums>
 
     <enums namespace="EGL" start="0x8F70" end="0x8F7F" vendor="HI" comment="For Mark Callow, Khronos bug 4055. Shared with GL.">
@@ -1344,6 +1436,13 @@
             <proto><ptype>EGLint</ptype> <name>eglGetError</name></proto>
         </command>
         <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglGetMscRateANGLE</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLSurface</ptype> <name>surface</name></param>
+            <param><ptype>EGLint</ptype> *<name>numerator</name></param>
+            <param><ptype>EGLint</ptype> *<name>denominator</name></param>
+        </command>
+        <command>
             <proto><ptype>EGLClientBuffer</ptype> <name>eglGetNativeClientBufferANDROID</name></proto>
             <param>const struct <ptype>AHardwareBuffer</ptype> *<name>buffer</name></param>
         </command>
@@ -1655,6 +1754,15 @@
             <param><ptype>EGLint</ptype> <name>name</name></param>
         </command>
         <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglQuerySupportedCompressionRatesEXT</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLConfig</ptype> <name>config</name></param>
+            <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
+            <param><ptype>EGLint</ptype> *<name>rates</name></param>
+            <param><ptype>EGLint</ptype> <name>rate_size</name></param>
+            <param><ptype>EGLint</ptype> *<name>num_rates</name></param>
+        </command>
+        <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglQuerySurface</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLSurface</ptype> <name>surface</name></param>
@@ -1796,14 +1904,14 @@
             <proto><ptype>EGLBoolean</ptype> <name>eglSwapBuffersWithDamageEXT</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLSurface</ptype> <name>surface</name></param>
-            <param><ptype>EGLint</ptype> *<name>rects</name></param>
+            <param>const <ptype>EGLint</ptype> *<name>rects</name></param>
             <param><ptype>EGLint</ptype> <name>n_rects</name></param>
         </command>
         <command>
             <proto><ptype>EGLBoolean</ptype> <name>eglSwapBuffersWithDamageKHR</name></proto>
             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
             <param><ptype>EGLSurface</ptype> <name>surface</name></param>
-            <param><ptype>EGLint</ptype> *<name>rects</name></param>
+            <param>const <ptype>EGLint</ptype> *<name>rects</name></param>
             <param><ptype>EGLint</ptype> <name>n_rects</name></param>
         </command>
         <command>
@@ -1899,6 +2007,70 @@
             <proto><ptype>EGLBoolean</ptype> <name>eglCompositorSwapPolicyEXT</name></proto>
             <param><ptype>EGLint</ptype> <name>external_win_id</name></param>
             <param><ptype>EGLint</ptype> <name>policy</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglBindWaylandDisplayWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_display</ptype> *<name>display</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglUnbindWaylandDisplayWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_display</ptype> *<name>display</name></param>
+        </command>
+        <command>
+            <proto><ptype>EGLBoolean</ptype> <name>eglQueryWaylandBufferWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param>struct <ptype>wl_resource</ptype> *<name>buffer</name></param>
+            <param><ptype>EGLint</ptype> <name>attribute</name></param>
+            <param><ptype>EGLint</ptype> *<name>value</name></param>
+        </command>
+        <command>
+            <proto>struct <ptype>wl_buffer</ptype> *<name>eglCreateWaylandBufferFromImageWL</name></proto>
+            <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+            <param><ptype>EGLImageKHR</ptype> <name>image</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglStreamImageConsumerConnectNV</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
+             <param><ptype>EGLint</ptype> <name>num_modifiers</name></param>
+             <param>const <ptype>EGLuint64KHR</ptype> *<name>modifiers</name></param>
+             <param>const <ptype>EGLAttrib</ptype> *<name>attrib_list</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLint</ptype> <name>eglQueryStreamConsumerEventNV</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
+             <param><ptype>EGLTime</ptype> <name>timeout</name></param>
+             <param><ptype>EGLenum</ptype> *<name>event</name></param>
+             <param><ptype>EGLAttrib</ptype> *<name>aux</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglStreamAcquireImageNV</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
+             <param><ptype>EGLImage</ptype> *<name>pImage</name></param>
+             <param><ptype>EGLSync</ptype> <name>sync</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglStreamReleaseImageNV</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
+             <param><ptype>EGLStreamKHR</ptype> <name>stream</name></param>
+             <param><ptype>EGLImage</ptype> <name>image</name></param>
+             <param><ptype>EGLSync</ptype> <name>sync</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglQueryDeviceBinaryEXT</name></proto>
+             <param><ptype>EGLDeviceEXT</ptype> <name>device</name></param>
+             <param><ptype>EGLint</ptype> <name>name</name></param>
+             <param><ptype>EGLint</ptype> <name>max_size</name></param>
+             <param>void *<name>value</name></param>
+             <param>EGLint *<name>size</name></param>
+        </command>
+        <command>
+             <proto><ptype>EGLBoolean</ptype> <name>eglDestroyDisplayEXT</name></proto>
+             <param><ptype>EGLDisplay</ptype> <name>dpy</name></param>
         </command>
     </commands>
 
@@ -2245,6 +2417,11 @@
             </require>
         </extension>
         <extension name="EGL_ANDROID_GLES_layers" supported="egl"/>
+        <extension name="EGL_ANDROID_telemetry_hint" supported="egl">
+            <require>
+                <enum name="EGL_TELEMETRY_HINT_ANDROID"/>
+            </require>
+        </extension>
         <extension name="EGL_ANGLE_d3d_share_handle_client_buffer" supported="egl">
             <require>
                 <enum name="EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE"/>
@@ -2264,6 +2441,11 @@
         <extension name="EGL_ANGLE_surface_d3d_texture_2d_share_handle" supported="egl">
             <require>
                 <enum name="EGL_D3D_TEXTURE_2D_SHARE_HANDLE_ANGLE"/>
+            </require>
+        </extension>
+        <extension name="EGL_ANGLE_sync_control_rate" supported="egl">
+            <require>
+                <command name="eglGetMscRateANGLE"/>
             </require>
         </extension>
         <extension name="EGL_ANGLE_window_fixed_size" supported="egl">
@@ -2293,6 +2475,11 @@
                 <enum name="EGL_SYNC_CLIENT_SIGNAL_EXT"/>
                 <command name="eglClientSignalSyncEXT"/>
             </require>
+        </extension>
+        <extension name="EGL_EXT_config_select_group" supported="egl">
+          <require>
+                <enum name="EGL_CONFIG_SELECT_GROUP_EXT"/>
+          </require>
         </extension>
         <extension name="EGL_EXT_create_context_robustness" supported="egl">
             <require>
@@ -2327,6 +2514,7 @@
         <extension name="EGL_EXT_device_openwf" supported="egl">
             <require>
                 <enum name="EGL_OPENWF_DEVICE_ID_EXT"/>
+                <enum name="EGL_OPENWF_DEVICE_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_device_query" supported="egl">
@@ -2337,6 +2525,11 @@
                 <command name="eglQueryDeviceAttribEXT"/>
                 <command name="eglQueryDeviceStringEXT"/>
                 <command name="eglQueryDisplayAttribEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_gl_colorspace_bt2020_hlg" supported="egl">
+            <require>
+                <enum name="EGL_GL_COLORSPACE_BT2020_HLG_EXT"/>
             </require>
         </extension>
         <extension name="EGL_EXT_gl_colorspace_bt2020_linear" supported="egl">
@@ -2490,6 +2683,17 @@
                 <enum name="EGL_PLATFORM_X11_SCREEN_EXT"/>
             </require>
         </extension>
+        <extension name="EGL_EXT_platform_xcb" supported="egl">
+            <require>
+                <enum name="EGL_PLATFORM_XCB_EXT"/>
+                <enum name="EGL_PLATFORM_XCB_SCREEN_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_present_opaque" supported="egl">
+            <require>
+                <enum name="EGL_PRESENT_OPAQUE_EXT"/>
+            </require>
+        </extension>
         <extension name="EGL_EXT_protected_content" supported="egl">
             <require>
                 <enum name="EGL_PROTECTED_CONTENT_EXT"/>
@@ -2500,6 +2704,7 @@
                 <enum name="EGL_PROTECTED_CONTENT_EXT"/>
             </require>
         </extension>
+        <extension name="EGL_EXT_query_reset_notification_strategy" supported="egl"/>
         <extension name="EGL_EXT_stream_consumer_egloutput" supported="egl">
             <require>
                 <command name="eglStreamConsumerOutputEXT"/>
@@ -3097,6 +3302,18 @@
                 <enum name="EGL_STREAM_DMA_SERVER_NV"/>
             </require>
         </extension>
+         <extension name="EGL_NV_stream_consumer_eglimage" supported="egl">
+            <require>
+                <enum name="EGL_STREAM_CONSUMER_IMAGE_NV"/>
+                <enum name="EGL_STREAM_IMAGE_ADD_NV"/>
+                <enum name="EGL_STREAM_IMAGE_REMOVE_NV"/>
+                <enum name="EGL_STREAM_IMAGE_AVAILABLE_NV"/>
+                <command name="eglStreamImageConsumerConnectNV"/>
+                <command name="eglQueryStreamConsumerEventNV"/>
+                <command name="eglStreamAcquireImageNV"/>
+                <command name="eglStreamReleaseImageNV"/>
+            </require>
+        </extension>
         <extension name="EGL_NV_stream_fifo_next" supported="egl">
             <require>
                 <enum name="EGL_PENDING_FRAME_NV"/>
@@ -3251,6 +3468,28 @@
                 <enum name="EGL_CTA861_3_MAX_FRAME_AVERAGE_LEVEL_EXT"/>
             </require>
         </extension>
+        <extension name="EGL_EXT_surface_compression" supported="egl">
+            <require>
+                <enum name="EGL_SURFACE_COMPRESSION_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_PLANE1_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_PLANE2_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_NONE_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_DEFAULT_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_1BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_2BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_3BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_4BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_5BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_6BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_7BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_8BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_9BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_10BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_11BPC_EXT"/>
+                <enum name="EGL_SURFACE_COMPRESSION_FIXED_RATE_12BPC_EXT"/>
+                <command name="eglQuerySupportedCompressionRatesEXT"/>
+            </require>
+        </extension>
         <extension name="EGL_EXT_image_implicit_sync_control" supported="egl">
             <require>
                 <enum name="EGL_IMPORT_SYNC_TYPE_EXT"/>
@@ -3276,6 +3515,80 @@
                 <enum name="EGL_BOTTOM_NV"/>
                 <enum name="EGL_X_AXIS_NV"/>
                 <enum name="EGL_Y_AXIS_NV"/>
+            </require>
+        </extension>
+        <extension name="EGL_WL_bind_wayland_display" supported="egl">
+            <require>
+                <enum name="EGL_WAYLAND_BUFFER_WL"/>
+                <enum name="EGL_WAYLAND_PLANE_WL"/>
+                <enum name="EGL_TEXTURE_Y_U_V_WL"/>
+                <enum name="EGL_TEXTURE_Y_UV_WL"/>
+                <enum name="EGL_TEXTURE_Y_XUXV_WL"/>
+                <enum name="EGL_TEXTURE_EXTERNAL_WL"/>
+                <enum name="EGL_WAYLAND_Y_INVERTED_WL"/>
+
+                <command name="eglBindWaylandDisplayWL"/>
+                <command name="eglUnbindWaylandDisplayWL"/>
+                <command name="eglQueryWaylandBufferWL"/>
+                <type name="PFNEGLBINDWAYLANDDISPLAYWL"/>
+                <type name="PFNEGLUNBINDWAYLANDDISPLAYWL"/>
+                <type name="PFNEGLQUERYWAYLANDBUFFERWL"/>
+            </require>
+        </extension>
+        <extension name="EGL_WL_create_wayland_buffer_from_image" supported="egl">
+            <require>
+                <command name="eglCreateWaylandBufferFromImageWL"/>
+                <type name="PFNEGLCREATEWAYLANDBUFFERFROMIMAGEWL"/>
+            </require>
+        </extension>
+        <extension name="EGL_ARM_image_format" supported="egl">
+            <require>
+                <enum name="EGL_COLOR_COMPONENT_TYPE_UNSIGNED_INTEGER_ARM"/>
+                <enum name="EGL_COLOR_COMPONENT_TYPE_INTEGER_ARM"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_device_query_name" supported="egl">
+            <require>
+                <enum name="EGL_RENDERER_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_device_persistent_id" supported="egl">
+            <require>
+                <enum name="EGL_DEVICE_UUID_EXT"/>
+                <enum name="EGL_DRIVER_UUID_EXT"/>
+                <enum name="EGL_DRIVER_NAME_EXT"/>
+                <command name="eglQueryDeviceBinaryEXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_device_drm_render_node" supported="egl">
+            <require>
+                <enum name="EGL_DRM_RENDER_NODE_FILE_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_explicit_device" supported="egl">
+            <require>
+                <enum name="EGL_DEVICE_EXT"/>
+            </require>
+        </extension>
+        <extension name="EGL_NV_stream_consumer_eglimage_use_scanout_attrib" supported="egl">
+            <require>
+                <enum name="EGL_STREAM_CONSUMER_IMAGE_USE_SCANOUT_NV"/>
+            </require>
+        </extension>
+        <extension name="EGL_QNX_platform_screen" supported="egl">
+            <require>
+                <enum name="EGL_PLATFORM_SCREEN_QNX"/>
+            </require>
+        </extension>
+        <extension name="EGL_QNX_image_native_buffer" supported="egl">
+            <require>
+                <enum name="EGL_NATIVE_BUFFER_QNX"/>
+            </require>
+        </extension>
+        <extension name="EGL_EXT_display_alloc" supported="egl">
+            <require>
+                <enum name="EGL_ALLOC_NEW_DISPLAY_EXT"/>
+                <command name="eglDestroyDisplayEXT"/>
             </require>
         </extension>
     </extensions>


### PR DESCRIPTION
This brings with it new defines, so libepoxy users don't need to define them themselves.