### PR TITLE
Fix EGL support on macOS

### DIFF
--- a/src/dispatch_common.c
+++ b/src/dispatch_common.c
@@ -175,9 +175,10 @@
 
 #if defined(__APPLE__)
 #define GLX_LIB "/opt/X11/lib/libGL.1.dylib"
+#define EGL_LIB "libEGL.dylib"
+#define GLES1_LIB "libGLESv1_CM.dylib"
+#define GLES2_LIB "libGLESv2.dylib"
 #define OPENGL_LIB "/System/Library/Frameworks/OpenGL.framework/Versions/Current/OpenGL"
-#define GLES1_LIB "libGLESv1_CM.so"
-#define GLES2_LIB "libGLESv2.so"
 #elif defined(__ANDROID__)
 #define GLX_LIB "libGLESv2.so"
 #define EGL_LIB "libEGL.so"

--- a/src/dispatch_common.h
+++ b/src/dispatch_common.h
@@ -28,7 +28,7 @@
 #define PLATFORM_HAS_GLX ENABLE_GLX
 #define PLATFORM_HAS_WGL 1
 #elif defined(__APPLE__)
-#define PLATFORM_HAS_EGL 0 
+#define PLATFORM_HAS_EGL ENABLE_EGL
 #define PLATFORM_HAS_GLX ENABLE_GLX
 #define PLATFORM_HAS_WGL 0
 #elif defined(ANDROID)


### PR DESCRIPTION
This is a simpler version of #239 and is the patch we're using in MacPorts.